### PR TITLE
Norwegian translations for urlfrom and resreport. 

### DIFF
--- a/tex/latex/biblatex/lbx/norwegian.lbx
+++ b/tex/latex/biblatex/lbx/norwegian.lbx
@@ -336,7 +336,7 @@
   audiocd          = {{lyd-cd}{lyd-cd}},
   version          = {{versjon}{versjon}},
   url              = {{side}{side}},
-% urlfrom          = {{}{}},% FIXME: missing
+  urlfrom          = {{tilgjengelig fra}{tilgj\adddotspace fra}},
   urlseen          = {{sjekket}{sjekket}},
   inpreparation    = {{under utarbeidelse}{under utarb\adddot}},
   submitted        = {{innsendt}{innsendt}},

--- a/tex/latex/biblatex/lbx/nynorsk.lbx
+++ b/tex/latex/biblatex/lbx/nynorsk.lbx
@@ -241,7 +241,8 @@
   origpubin        = {{opphavleg utgitt i}{opph\adddot\ utg\adddot\ i}},
   mathesis         = {{masteroppg{\aa}ve}{masteroppg\adddot}},
   candthesis       = {{hovudoppg{\aa}ve}{hovudoppg\adddot}},
-% urlfrom          = {{}{}},% FIXME: missing
+  resreport        = {{forskingsrapport}{forsk.rapp\adddot}},
+  urlfrom          = {{tilgjengeleg fr{\aa}}{tilgj\adddotspace fr{\aa}}},
   urlseen          = {{sjekka}{sjekka}},
   inpreparation    = {{under utarbeiding}{under utarb\adddot}},
   forthcoming      = {{under utgiving}{under utgiv\adddot}},


### PR DESCRIPTION
`urlfrom` translated into both forms of Norwegian.
`resreport` translated into nynorsk. (I overlooked this earlier.)
