### PR TITLE
Fixed missing period in Norwegian translation of phdthesis key

### DIFF
--- a/tex/latex/biblatex/lbx/norwegian.lbx
+++ b/tex/latex/biblatex/lbx/norwegian.lbx
@@ -328,7 +328,7 @@
   number           = {{nummer}{nr\adddot}},
   chapter          = {{kapittel}{kap\adddot}},
   mathesis         = {{masteroppgave}{masteroppg\adddot}},
-  phdthesis        = {{ph.d-avhandling}{ph.d.-avh\adddot}},
+  phdthesis        = {{ph.d.-avhandling}{ph.d.-avh\adddot}},
   candthesis       = {{hovedoppgave}{hovedoppg\adddot}},
   resreport        = {{forskningsrapport}{forskn.rapp\adddot}},
   techreport       = {{teknisk rapport}{tekn\adddotspace rapp\adddot}},


### PR DESCRIPTION
I found a small error. Sorry I didn't catch this earlier.
