### PR TITLE
Fixed a typo in finnish.lbx breaking the package

### DIFF
--- a/tex/latex/biblatex/lbx/finnish.lbx
+++ b/tex/latex/biblatex/lbx/finnish.lbx
@@ -103,7 +103,7 @@
                       {toimittaneet ja kommentaarin kirjoittaneet}},
   editoran         = {{toimittanut ja selityksin varustanut}% FIXME: unsure
                       {toimittanut ja selityksin varustanut}},
-  editorsan        = {{toimittaneet ja selityksin varustaneet,% FIXME: unsure
+  editorsan        = {{toimittaneet ja selityksin varustaneet}% FIXME: unsure
                       {toimittaneet ja selityksin varustaneet}},
   editorin         = {{toimittanut ja johdannon kirjoittanut}%
                       {toimittanut ja johdannon kirjoittanut}},


### PR DESCRIPTION
A comma instead of closing curly bracket caused:
Runaway argument?
{bibliography = {{Kirjallisuusluettelo}{Kirjallisuus}}, references = \ETC.
! Paragraph ended before \DeclareBibliographyStrings was complete.
