### PR TITLE
Use \textit instead of \emph for \mkbibemph

### DIFF
--- a/tex/latex/biblatex/biblatex1.sty
+++ b/tex/latex/biblatex/biblatex1.sty
@@ -8896,9 +8896,9 @@
 
 \def\blx@usqcheck@iii#1#2{#2#1}
 
-\newrobustcmd*{\mkbibemph}{\emph}
+\newrobustcmd*{\mkbibemph}{\textit}
 \protected\long\def\blx@imc@mkbibemph#1{%
-  \emph{#1}\blx@imc@setpunctfont\emph}
+  \textit{#1}\blx@imc@setpunctfont\textit}
 
 \newrobustcmd*{\mkbibbold}{\textbf}
 \protected\long\def\blx@imc@mkbibbold#1{%


### PR DESCRIPTION
Citation styles expect \mkbibemph to result in italics (cf. \mkbibbold, but no \mkbibitalic), but authors may redefine \emph to use smallcaps, letterspacing, boldface or something else.
