### PR TITLE
Fixes some issues in the documentation related to external hyperlinks

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -128,6 +128,13 @@
 \newrobustcmd*{\LFMark}{%
   \leavevmode\marginpar{\LF}}
 
+% following snippet is based on code by Michael Ummels (TeX Stack Exchange)
+% <http://tex.stackexchange.com/a/13073/8305>
+\makeatletter
+  \newcommand\fnurl@[1]{\footnote{\url@{#1}}}
+  \DeclareRobustCommand{\fnurl}{\hyper@normalise\fnurl@}
+\makeatother
+
 \hyphenation{%
   star-red
   bib-lio-gra-phy
@@ -143,7 +150,7 @@
 \section{Introduction}
 \label{int}
 
-This document is a systematic reference manual for the \biblatex package. Look at the sample documents which ship with \biblatex to get a first impression.\fnurl{\biblatexctan/doc/examples}
+This document is a systematic reference manual for the \biblatex package. Look at the sample documents which ship with \biblatex to get a first impression.\fnurl{\biblatexctan doc/examples}
 For a quick start guide, browse \secref{int:abt, bib:typ, bib:fld, bib:use, use:opt, use:xbx, use:bib, use:cit, use:use}.
 
 \subsection[About]{About \biblatex}


### PR DESCRIPTION
- Fixes bugs in the definition of `\fnurl`:
  - URLs containing special characters (e.g. `#`) were not correctly protected what led to compiling errors.
  - The argument of `\fnurl`, e.g. `\fnurl{\biblatexctan doc/examples}`, got not expanded for the label of the link.
- Fixes double slash error in link to Biblatex examples folder on CTAN.
