### PR TITLE
Protect all words (in titles) that should not undergo case changes

### DIFF
--- a/bibtex/bib/biblatex/biblatex-examples.bib
+++ b/bibtex/bib/biblatex/biblatex-examples.bib
@@ -10,7 +10,7 @@
 @incollection{westfahl:space,
   author       = {Westfahl, Gary},
   title        = {The True Frontier},
-  subtitle     = {Confronting and Avoiding the Realities of Space in American
+  subtitle     = {Confronting and Avoiding the Realities of Space in {American}
                   Science Fiction Films},
   pages        = {55-65},
   crossref     = {westfahl:frontier},
@@ -45,7 +45,7 @@
                   and {\c{C}}etinkaya, Bekir and Ni, Chaoying and
                   B{\"u}y{\"u}kg{\"u}ng{\"o}r, Orhan and {\"O}zkal, Erhan},
   title        = {Effect of immobilization on catalytic characteristics of
-                  saturated Pd-N-heterocyclic carbenes in Mizoroki-Heck
+                  saturated {Pd-N}-heterocyclic carbenes in {Mizoroki-Heck}
                   reactions},
   journaltitle = jomch,
   date         = 2006,
@@ -73,7 +73,7 @@
 
 @article{baez/article,
   author       = {Baez, John C. and Lauda, Aaron D.},
-  title        = {Higher-Dimensional Algebra V: 2-Groups},
+  title        = {Higher-Dimensional Algebra {V}: 2-Groups},
   journaltitle = {Theory and Applications of Categories},
   date         = 2004,
   volume       = 12,
@@ -92,7 +92,7 @@
 
 @article{bertram,
   author       = {Bertram, Aaron and Wentworth, Richard},
-  title        = {Gromov invariants for holomorphic maps on Riemann surfaces},
+  title        = {Gromov invariants for holomorphic maps on {Riemann} surfaces},
   journaltitle = jams,
   date         = 1996,
   volume       = 9,
@@ -107,7 +107,7 @@
 
 @article{doody,
   author       = {Doody, Terrence},
-  title        = {Hemingway's Style and Jake's Narration},
+  title        = {Hemingway's Style and {Jake's} Narration},
   year         = 1974,
   volume       = 4,
   number       = 3,
@@ -139,7 +139,7 @@
 
 @article{gillies,
   author       = {Gillies, Alexander},
-  title        = {Herder and the Preparation of Goethe's Idea of World
+  title        = {Herder and the Preparation of {Goethe's} Idea of World
                   Literature},
   journaltitle = {Publications of the English Goethe Society},
   date         = 1933,
@@ -165,7 +165,7 @@
 @article{herrmann,
   author       = {Herrmann, Wolfgang A. and {\"O}fele, Karl and Schneider,
                   Sabine K.  and Herdtweck, Eberhardt and Hoffmann, Stephan D.},
-  title        = {A carbocyclic carbene as an efficient catalyst ligand for C--C
+  title        = {A carbocyclic carbene as an efficient catalyst ligand for {C--C}
                   coupling reactions},
   journaltitle = anch-ie,
   date         = 2006,
@@ -181,7 +181,7 @@
                   free energies from molecular simulations},
   journaltitle = jchph,
   date         = 2006,
-  subtitle     = {I. The electrostatic potential in molecular liquids},
+  subtitle     = {{I}. {The} electrostatic potential in molecular liquids},
   volume       = 124,
   eid          = 124106,
   doi          = {10.1063/1.2172593},
@@ -224,7 +224,7 @@
                   Gary L. and Porter, Marc D.  and Evans, Neal D. and Murray,
                   Royce W.},
   title        = {Alkanethiolate gold cluster molecules with core diameters from
-                  1.5 to 5.2~nm},
+                  1.5 to 5.2~{nm}},
   journaltitle = {Langmuir},
   date         = 1998,
   subtitle     = {Core and monolayer properties as a function of core size},
@@ -242,7 +242,7 @@
 
 @article{reese,
   author       = {Reese, Trevor R.},
-  title        = {Georgia in Anglo-Spanish Diplomacy, 1736-1739},
+  title        = {Georgia in {Anglo-Spanish} Diplomacy, 1736--1739},
   journaltitle = {William and Mary Quarterly},
   date         = 1958,
   series       = 3,
@@ -340,7 +340,7 @@
 
 @article{springer,
   author       = {Springer, Otto},
-  title        = {Mediaeval Pilgrim Routes from Scandinavia to Rome},
+  title        = {Mediaeval Pilgrim Routes from {Scandinavia} to {Rome}},
   journaltitle = {Mediaeval Studies},
   date         = 1950,
   volume       = 12,
@@ -364,7 +364,7 @@
   author       = {Yoon, Myeong S. and Ryu, Dowook and Kim, Jeongryul and Ahn,
                   Kyo Han},
   title        = {Palladium pincer complexes with reduced bond angle strain:
-                  efficient catalysts for the Heck reaction},
+                  efficient catalysts for the {Heck} reaction},
   journaltitle = {Organometallics},
   date         = 2006,
   volume       = 25,
@@ -406,7 +406,7 @@
   title        = {Poetics},
   date         = 1968,
   editor       = {Lucas, D. W.},
-  series       = {Clarendon Aristotle},
+  series       = {Clarendon {Aristotle}},
   publisher    = {Clarendon Press},
   location     = {Oxford},
   keywords     = {primary},
@@ -419,8 +419,8 @@
 
 @book{aristotle:rhetoric,
   author       = {Aristotle},
-  title        = {The Rhetoric of Aristotle with a commentary by the late Edward
-                  Meredith Cope},
+  title        = {The Rhetoric of {Aristotle} with a commentary by the late {Edward
+                  Meredith Cope}},
   date         = 1877,
   editor       = {Cope, Edward Meredith},
   commentator  = {Cope, Edward Meredith},
@@ -430,7 +430,7 @@
   langid       = {english},
   langidopts   = {variant=british},
   sorttitle    = {Rhetoric of Aristotle},
-  indextitle   = {Rhetoric of Aristotle, The},
+  indextitle   = {Rhetoric of {Aristotle}, The},
   shorttitle   = {Rhetoric},
   annotation   = {A commented edition. Note the concatenation of the
                   \texttt{editor} and \texttt{commentator} fields as well as the
@@ -453,11 +453,11 @@
 @book{averroes/bland,
   author       = {Averroes},
   title        = {The Epistle on the Possibility of Conjunction with the Active
-                  Intellect by Ibn Rushd with the Commentary of Moses Narboni},
+                  Intellect by {Ibn Rushd} with the Commentary of {Moses Narboni}},
   date         = 1982,
   editor       = {Bland, Kalman P.},
   translator   = {Bland, Kalman P.},
-  series       = {Moreshet: Studies in Jewish History, Literature and Thought},
+  series       = {Moreshet: Studies in {Jewish} History, Literature and Thought},
   number       = 7,
   publisher    = {Jewish Theological Seminary of America},
   location     = {New York},
@@ -539,11 +539,11 @@
 
 @book{coleridge,
   author       = {Coleridge, Samuel Taylor},
-  title        = {Biographia literaria, or Biographical sketches of my literary
+  title        = {Biographia literaria, or {Biographical} sketches of my literary
                   life and opinions},
   date         = 1983,
   editor       = {Coburn, Kathleen and Engell, James and Bate, W. Jackson},
-  maintitle    = {The collected works of Samuel Taylor Coleridge},
+  maintitle    = {The collected works of {Samuel Taylor Coleridge}},
   volume       = 7,
   part         = 2,
   series       = {Bollingen Series},
@@ -563,7 +563,7 @@
 
 @book{companion,
   author       = {Goossens, Michel and Mittelbach, Frank and Samarin, Alexander},
-  title        = {The LaTeX Companion},
+  title        = {The {LaTeX} Companion},
   date         = 1994,
   edition      = 1,
   publisher    = {Addison-Wesley},
@@ -614,7 +614,7 @@
 
 @book{gonzalez,
   author       = {Gonzalez, Ray},
-  title        = {The Ghost of John Wayne and Other Stories},
+  title        = {The Ghost of {John Wayne} and Other Stories},
   date         = 2001,
   publisher    = {The University of Arizona Press},
   location     = {Tucson},
@@ -623,7 +623,7 @@
   langidopts   = {variant=american},
   sorttitle    = {Ghost of John Wayne and Other Stories},
   indextitle   = {Ghost of John Wayne and Other Stories, The},
-  shorttitle   = {Ghost of John Wayne},
+  shorttitle   = {Ghost of {John Wayne}},
   annotation   = {A collection of short stories. This is a \texttt{book} entry.
                   Note the \texttt{sorttitle} and \texttt{indextitle} fields in
                   the database file. There's also an \texttt{isbn} field},
@@ -837,7 +837,7 @@
 
 @book{malinowski,
   author       = {Malinowski, Bronis{\l}aw},
-  title        = {Argonauts of the Western Pacific},
+  title        = {Argonauts of the {Western Pacific}},
   date         = 1972,
   edition      = 8,
   publisher    = {Routledge {and} Kegan Paul},
@@ -845,7 +845,7 @@
   langid       = {english},
   langidopts   = {variant=british},
   subtitle     = {An account of native enterprise and adventure in the
-                  Archipelagoes of Melanesian New Guinea},
+                  Archipelagoes of {Melanesian New Guinea}},
   shorttitle   = {Argonauts},
   annotation   = {This is a \texttt{book} entry. Note the format of the
                   \texttt{publisher} and \texttt{edition} fields as well as the
@@ -984,7 +984,7 @@
   location     = {Durham and London},
   langid       = {english},
   langidopts   = {variant=american},
-  subtitle     = {Crime in Mexico City, 1900--1931},
+  subtitle     = {Crime in {Mexico City}, 1900--1931},
   shorttitle   = {City of Suspects},
   annotation   = {This is a \texttt{book} entry. Note the format of the
                   \texttt{location} field in the database file},
@@ -1084,7 +1084,7 @@
   title        = {The Importance of Being Earnest: A Trivial Comedy for Serious
                   People},
   year         = 1899,
-  series       = {English and American drama of the Nineteenth Century},
+  series       = {English and {American} drama of the Nineteenth Century},
   publisher    = {Leonard Smithers {and} Company},
   eprint       = {4HIWAAAAYAAJ},
   eprinttype   = {googlebooks},
@@ -1102,7 +1102,7 @@
   langidopts   = {variant=american},
   sorttitle    = {Cast of Character},
   indextitle   = {Cast of Character, The},
-  subtitle     = {Style in Greek Literature},
+  subtitle     = {Style in {Greek} Literature},
   shorttitle   = {Cast of Character},
   annotation   = {A \texttt{book} entry. Note the \texttt{sorttitle} and
                   \texttt{indextitle} fields},
@@ -1110,7 +1110,7 @@
 
 @collection{britannica,
   editor       = {Preece, Warren E.},
-  title        = {The New Encyclop{\ae}dia Britannica},
+  title        = {The {New Encyclop{\ae}dia Britannica}},
   date         = 2003,
   edition      = 15,
   volumes      = 32,
@@ -1121,8 +1121,8 @@
   langid       = {english},
   langidopts   = {variant=british},
   sorttitle    = {Encyclop{\ae}dia Britannica},
-  indextitle   = {Encyclop{\ae}dia Britannica, The New},
-  shorttitle   = {Encyclop{\ae}dia Britannica},
+  indextitle   = {{Encyclop{\ae}dia Britannica}, The {New}},
+  shorttitle   = {{Encyclop{\ae}dia Britannica}},
   annotation   = {This is a \texttt{collection} entry for an encyclopedia. Note
                   the \texttt{useeditor} option in the \texttt{options} field as
                   well as the \texttt{sorttitle} field. We want this entry to be
@@ -1169,6 +1169,7 @@
   edition      = 2,
   volumes      = 2,
   location     = {Leipzig},
+  langid       = {latin},
   editoratype  = {redactor},
   indextitle   = {Regesta Pontificum Romanorum},
   shorttitle   = {Regesta Pontificum Romanorum},
@@ -1295,9 +1296,9 @@
   author       = {Arthur Hyman},
   editor       = {O'Meara, Dominic J.},
   title        = {Aristotle's Theory of the Intellect and its Interpretation by
-                  Averroes},
+                  {Averroes}},
   date         = 1981,
-  booktitle    = {Studies in Aristotle},
+  booktitle    = {Studies in {Aristotle}},
   series       = {Studies in Philosophy and the History of Philosophy},
   number       = 9,
   publisher    = {The Catholic University of America Press},
@@ -1315,18 +1316,18 @@
 @incollection{pines,
   author       = {Pines, Shlomo},
   editor       = {Twersky, Isadore},
-  title        = {The Limitations of Human Knowledge According to Al-Farabi, ibn
-                  Bajja, and Maimonides},
+  title        = {The Limitations of Human Knowledge According to {Al-Farabi}, {ibn
+                  Bajja}, and {Maimonides}},
   date         = 1979,
-  booktitle    = {Studies in Medieval Jewish History and Literature},
+  booktitle    = {Studies in Medieval {Jewish} History and Literature},
   publisher    = hup,
   location     = {Cambridge, Mass.},
   pages        = {82-109},
   keywords     = {secondary},
   langid       = {english},
   langidopts   = {variant=american},
-  indextitle   = {Limitations of Human Knowledge According to Al-Farabi, ibn
-                  Bajja, and Maimonides, The},
+  indextitle   = {Limitations of Human Knowledge According to {Al-Farabi}, {ibn
+                  Bajja}, and {Maimonides}, The},
   shorttitle   = {Limitations of Human Knowledge},
   annotation   = {A typical \texttt{incollection} entry. Note the
                   \texttt{indextitle} field},
@@ -1363,7 +1364,7 @@
   date         = 1968,
   booktitle    = {Elementary particle theory},
   booksubtitle = {Relativistic groups and analyticity},
-  booktitleaddon= {Proceedings of the Eighth Nobel Symposium},
+  booktitleaddon= {Proceedings of the {Eighth Nobel Symposium}},
   eventdate    = {1968-05-19/1968-05-25},
   venue        = {Aspen{\"a}sgarden, Lerum},
   publisher    = {Almquist \& Wiksell},
@@ -1397,7 +1398,7 @@
 
 @online{baez/online,
   author       = {Baez, John C. and Lauda, Aaron D.},
-  title        = {Higher-Dimensional Algebra V: 2-Groups},
+  title        = {Higher-Dimensional Algebra {V}: 2-Groups},
   date         = {2004-10-27},
   version      = 3,
   langid       = {english},
@@ -1414,7 +1415,7 @@
   title        = {CTAN},
   date         = 2006,
   url          = {http://www.ctan.org},
-  subtitle     = {The Comprehensive TeX Archive Network},
+  subtitle     = {The {Comprehensive TeX Archive Network}},
   urldate      = {2006-10-01},
   label        = {CTAN},
   langid       = {english},
@@ -1431,7 +1432,7 @@
 
 @online{itzhaki,
   author       = {Itzhaki, Nissan},
-  title        = {Some remarks on 't Hooft's S-matrix for black holes},
+  title        = {Some remarks on {'t Hooft's} {S}-matrix for black holes},
   date         = {1996-03-11},
   version      = 1,
   langid       = {english},
@@ -1452,10 +1453,10 @@
 
 @online{markey,
   author       = {Markey, Nicolas},
-  title        = {Tame the BeaST},
+  title        = {Tame the {BeaST}},
   date         = {2005-10-16},
   url          = {http://tug.ctan.org/tex-archive/info/bibtex/tamethebeast/ttb_en.pdf},
-  subtitle     = {The B to X of BibTeX},
+  subtitle     = {The {B} to {X} of {BibTeX}},
   version      = {1.3},
   urldate      = {2006-10-01},
   langid       = {english},
@@ -1551,7 +1552,7 @@
 @patent{sorace,
   author       = {Sorace, Ronald E. and Reinhardt, Victor S. and Vaughn, Steven
                   A.},
-  title        = {High-Speed Digital-to-RF Converter},
+  title        = {High-Speed Digital-to-{RF} Converter},
   number       = 5668842,
   date         = {1997-09-16},
   holder       = {{Hughes Aircraft Company}},
@@ -1577,8 +1578,8 @@
 
 @report{chiu,
   author       = {Chiu, Willy W. and Chow, We Min},
-  title        = {A Hybrid Hierarchical Model of a Multiple Virtual Storage
-                  (MVS) Operating System},
+  title        = {A Hybrid Hierarchical Model of a {Multiple Virtual Storage}
+                  ({MVS}) Operating System},
   type         = {resreport},
   institution  = {IBM},
   date         = 1978,
@@ -1597,7 +1598,7 @@
 
 @report{padhye,
   author       = {Padhye, Jitendra and Firoiu, Victor and Towsley, Don},
-  title        = {A Stochastic Model of TCP Reno Congestion Avoidance and
+  title        = {A Stochastic Model of {TCP Reno} Congestion Avoidance and
                   Control},
   type         = {techreport},
   institution  = {University of Massachusetts},
@@ -1608,7 +1609,7 @@
   langidopts   = {variant=american},
   sorttitle    = {A Stochastic Model of TCP Reno Congestion Avoidance and
                   Control},
-  indextitle   = {Stochastic Model of TCP Reno Congestion Avoidance and Control,
+  indextitle   = {Stochastic Model of {TCP Reno} Congestion Avoidance and Control,
                   A},
   annotation   = {This is a \texttt{report} entry for a technical report. Note
                   the format of the \texttt{type} field in the database file
@@ -1645,7 +1646,7 @@
   type         = {phdthesis},
   institution  = {Uppsala Universitet},
   date         = 1985,
-  subtitle     = {The Orkney Earldom of the Twelfth Century. A Musicological
+  subtitle     = {The {Orkney Earldom} of the Twelfth Century. {A} Musicological
                   Study},
   location     = {Uppsala},
   options      = {useprefix=false},


### PR DESCRIPTION
Protect all words (in titles) that should not undergo case changes when used with "sentence-case" styles such as biblatex-apa.