### PR TITLE
Augment bibheading definitions to include subsubbibliographies

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1800,6 +1800,13 @@
     \addcontentsline{toc}{subsection}{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \subsection{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsubsection*{#1}}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsubsection*{#1}%
+    \addcontentsline{toc}{subsubsection}{#1}}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsubsection{#1}}
 
 \or % book/report
   \defbibheading{bibliography}[\bibname]{%
@@ -1831,6 +1838,13 @@
     \if@twoside\markright{\MakeUppercase{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsection*{#1}}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsection*{#1}%
+    \addcontentsline{toc}{subsection}{#1}}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsection{#1}}
 
 \or % scrartcl
   \defbibheading{bibliography}[\refname]{%
@@ -1866,6 +1880,13 @@
     \addcontentsline{toc}{subsection}{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \subsection{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsubsection*{#1}}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsubsection*{#1}%
+    \addcontentsline{toc}{subsubsection}{#1}}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsubsection{#1}}
 
 \or % scrbook/scrreprt
   \defbibheading{bibliography}[\bibname]{%
@@ -1902,6 +1923,13 @@
     \markboth{#1}{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsection*{#1}}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsection*{#1}%
+    \addcontentsline{toc}{subsection}{#1}}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsection{#1}}
 
 \or % memoir (article)
   \ifdef\memUChead{}{\let\memUChead\MakeUppercase}
@@ -1947,6 +1975,20 @@
     \if@twoside\markright{\memUChead{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsection*{#1}%
+    \ifmemoirbibintoc
+      {\phantomsection
+       \addcontentsline{toc}{subsection}{#1}}
+      {}%
+    \if@twoside\markright{\memUChead{#1}}\fi}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsection*{#1}%
+    \phantomsection
+    \addcontentsline{toc}{subsection}{#1}%
+    \if@twoside\markright{\memUChead{#1}}\fi}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsection{#1}}
 
 \or % memoir (book)
   \ifdef\memUChead{}{\let\memUChead\MakeUppercase}
@@ -1994,6 +2036,20 @@
     \if@twoside\markright{\memUChead{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
+  \defbibheading{subsubbibliography}[\refname]{%
+    \subsection*{#1}%
+    \ifmemoirbibintoc
+      {\phantomsection
+       \addcontentsline{toc}{subsection}{#1}}
+      {}%
+    \if@twoside\markright{\memUChead{#1}}\fi}
+  \defbibheading{subsubbibintoc}[\refname]{%
+    \subsection*{#1}%
+    \phantomsection
+    \addcontentsline{toc}{subsection}{#1}%
+    \if@twoside\markright{\memUChead{#1}}\fi}
+  \defbibheading{subsubbibnumbered}[\refname]{%
+    \subsection{#1}}
 
 \fi
 


### PR DESCRIPTION
Hi, would you consider the addition of bibheadings one level deeper than currently supported?  It would allow one to call:

    \printbibliography[heading=subsubbibliography]
    \printbibliography[heading=subsubbibnumbered]
    \printbibliography[heading=subsubbibintoc]

Besides the commit in the pull request, I've written a set of tests for each document class already supported in biblatex.def.  I've uploaded these tests to [gist](https://gist.github.com/jeffreywildman/580d536acbb663b7c06e).