### PR TITLE
Use nametitledelim in standard.bbx

### DIFF
--- a/tex/latex/biblatex/bbx/standard.bbx
+++ b/tex/latex/biblatex/bbx/standard.bbx
@@ -27,7 +27,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -65,7 +65,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/editor+others/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{maintitle+title}%
   \newunit
   \printlist{language}%
@@ -113,7 +113,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/editor+others/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -150,7 +150,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{editor+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{maintitle+title}%
   \newunit
   \printlist{language}%
@@ -196,7 +196,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -247,7 +247,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -296,7 +296,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -347,7 +347,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/editor}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -394,7 +394,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/editor+others/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -429,7 +429,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author/editor+others/translator+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -466,7 +466,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -504,7 +504,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{editor}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title+issuetitle}%
   \newunit
   \printlist{language}%
@@ -533,7 +533,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{editor+others}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{maintitle+title}%
   \newunit
   \printlist{language}%
@@ -581,7 +581,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -622,7 +622,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%
@@ -659,7 +659,7 @@
   \usebibmacro{bibindex}%
   \usebibmacro{begentry}%
   \usebibmacro{author}%
-  \setunit{\labelnamepunct}\newblock
+  \setunit{\printdelim{nametitledelim}}\newblock
   \usebibmacro{title}%
   \newunit
   \printlist{language}%

--- a/tex/latex/biblatex/biblatex_.def
+++ b/tex/latex/biblatex/biblatex_.def
@@ -107,8 +107,10 @@
   \space}
 
 % context-sensitive delimiters
+% retain compatibility with \labelnamepunct
 \DeclareDelimFormat{namelabeldelim}{\addspace}
 \DeclareDelimFormat{nametitledelim}{\addcomma\space}
+\DeclareDelimFormat[bib]{nametitledelim}{\labelnamepunct}
 \DeclareDelimFormat[textcite]{nametitledelim}{\addspace}
 \DeclareDelimFormat{nameyeardelim}{\addspace}
 \DeclareDelimFormat{nonameyeardelim}{\addspace}

--- a/tex/latex/biblatex/biblatex_legacy.def
+++ b/tex/latex/biblatex/biblatex_legacy.def
@@ -51,8 +51,10 @@
   \space}
 
 % context-sensitive delimiters
+% retain compatibility with \labelnamepunct
 \DeclareDelimFormat{namelabeldelim}{\addspace}
 \DeclareDelimFormat{nametitledelim}{\addcomma\space}
+\DeclareDelimFormat[bib]{nametitledelim}{\labelnamepunct}
 \DeclareDelimFormat[textcite]{nametitledelim}{\addspace}
 \DeclareDelimFormat{nameyeardelim}{\addspace}
 \DeclareDelimFormat{nonameyeardelim}{\addspace}


### PR DESCRIPTION
This replaces the use of `\labelnamepunct` by `\printdelim{nametitledelim}` in the bibliography styles. The code added to the two `.def`s should enable full backwards compatibility.