### PR TITLE
Use (no)nameyeardelim in authoryear.bbx

### DIFF
--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -188,15 +188,15 @@
        {\usebibmacro{bbx:savehash}%
         \printnames{author}%
         \iffieldundef{authortype}
-          {\setunit{\addspace}}
+          {\setunit{\printdelim{nameyeardelim}}}
           {\setunit{\addcomma\space}}}%
      \iffieldundef{authortype}
        {}
        {\usebibmacro{authorstrg}%
-        \setunit{\addspace}}}%
+        \setunit{\printdelim{nameyeardelim}}}}%
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
-     \setunit*{\addspace}}%
+     \setunit*{\printdelim{nonameyeardelim}}}%
   \usebibmacro{date+extrayear}}
 
 \renewbibmacro*{editor}{%
@@ -216,10 +216,10 @@
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{#1}%
      \clearname{editor}%
-     \setunit{\addspace}}%
+     \setunit{\printdelim{nameyeardelim}}}%
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
-     \setunit*{\addspace}}%
+     \setunit*{\printdelim{nonameyeardelim}}}%
   \usebibmacro{date+extrayear}}
 
 \renewbibmacro*{translator}{%
@@ -239,10 +239,10 @@
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{translator+othersstrg}%
      \clearname{translator}%
-     \setunit{\addspace}}%
+     \setunit{\printdelim{nameyeardelim}}}%
     {\global\undef\bbx@lasthash
      \usebibmacro{labeltitle}%
-     \setunit*{\addspace}}%
+     \setunit*{\printdelim{nonameyeardelim}}}%
   \usebibmacro{date+extrayear}}
 
 \newbibmacro*{bbx:dashcheck}[2]{%

--- a/tex/latex/biblatex/biblatex_.def
+++ b/tex/latex/biblatex/biblatex_.def
@@ -111,7 +111,9 @@
 \DeclareDelimFormat{nametitledelim}{\addcomma\space}
 \DeclareDelimFormat[textcite]{nametitledelim}{\addspace}
 \DeclareDelimFormat{nameyeardelim}{\addspace}
+\DeclareDelimFormat[bib]{nameyeardelim}{\addspace}
 \DeclareDelimFormat{nonameyeardelim}{\addspace}
+\DeclareDelimFormat[bib]{nonameyeardelim}{\addspace}
 
 % This is a provisional definition for \iffinalcitedelim{<true>}{<false>}, a
 % test that should expand <true> if the next non-compact citation delimiter

--- a/tex/latex/biblatex/biblatex_legacy.def
+++ b/tex/latex/biblatex/biblatex_legacy.def
@@ -55,7 +55,9 @@
 \DeclareDelimFormat{nametitledelim}{\addcomma\space}
 \DeclareDelimFormat[textcite]{nametitledelim}{\addspace}
 \DeclareDelimFormat{nameyeardelim}{\addspace}
+\DeclareDelimFormat[bib]{nameyeardelim}{\addspace}
 \DeclareDelimFormat{nonameyeardelim}{\addspace}
+\DeclareDelimFormat[bib]{nonameyeardelim}{\addspace}
 
 % This is a provisional definition for \iffinalcitedelim{<true>}{<false>}, a
 % test that should expand <true> if the next non-compact citation delimiter


### PR DESCRIPTION
Make use of (no)nameyeardelim in authoryear.bbx as well. The defaults should be backwards compatible.