### PR TITLE
Slovak support

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -4515,6 +4515,7 @@
   \do{langpolish}%
   \do{langportuguese}%
   \do{langrussian}%
+  \do{langslovak}%
   \do{langslovene}%
   \do{langspanish}%
   \do{langswedish}%
@@ -4537,6 +4538,7 @@
   \do{frompolish}%
   \do{fromportuguese}%
   \do{fromrussian}%
+  \do{fromslovak}%
   \do{fromslovene}%
   \do{fromspanish}%
   \do{fromswedish}%


### PR DESCRIPTION
Shouldn't be at least 'langslovak' and 'fromslovak' included in \abx@dostrings to get it working?