### PR TITLE
german.lbx: improve some strings.

### DIFF
--- a/tex/latex/biblatex/lbx/german.lbx
+++ b/tex/latex/biblatex/lbx/german.lbx
@@ -60,24 +60,24 @@
   shorthands       = {{Sigelverzeichnis}{Sigel}},
   editor           = {{Herausgeber}{Hrsg\adddot}},
   editors          = {{Herausgeber}{Hrsg\adddot}},
-  compiler         = {{Herausgeber}{Hrsg\adddot}},
-  compilers        = {{Herausgeber}{Hrsg\adddot}},
+  compiler         = {{Kompilator}{Komp\adddot}},
+  compilers        = {{Kompilatoren}{Komp\adddot}},
   redactor         = {{Bearbeiter}{Bearb\adddot}},
   redactors        = {{Bearbeiter}{Bearb\adddot}},
   reviser          = {{\"Uberarbeiter}{\"Uberarb\adddot}},
   revisers         = {{\"Uberarbeiter}{\"Uberarb\adddot}},
   founder          = {{Begr\"under}{Begr\adddot}},
   founders         = {{Begr\"under}{Begr\adddot}},
-  continuator      = {{Fortf\"uhrung}{Fortf\adddot}},
-  continuators     = {{Fortf\"uhrung}{Fortf\adddot}},
-  collaborator     = {{Mitarbeit}{Mitarb\adddot}},
-  collaborators    = {{Mitarbeit}{Mitarb\adddot}},
+  continuator      = {{Fortf\"uhrer}{Fortf\adddot}},
+  continuators     = {{Fortf\"uhrer}{Fortf\adddot}},
+  collaborator     = {{Mitarbeiter}{Mitarb\adddot}},
+  collaborators    = {{Mitarbeiter}{Mitarb\adddot}},
   translator       = {{\"Ubersetzer}{\"Ubers\adddot}},
   translators      = {{\"Ubersetzer}{\"Ubers\adddot}},
-  commentator      = {{Kommentar}{Komm\adddot}},
-  commentators     = {{Kommentar}{Komm\adddot}},
-  annotator        = {{Erl\"auterungen}{Erl\"aut\adddot}},
-  annotators       = {{Erl\"auterungen}{Erl\"aut\adddot}},
+  commentator      = {{Kommentator}{Komm\adddot}},
+  commentators     = {{Kommentatoren}{Komm\adddot}},
+  annotator        = {{Kommentator}{Komm\adddot}},
+  annotators       = {{Kommentatoren}{Komm\adddot}},
   commentary       = {{Kommentar}{Komm\adddot}},
   annotations      = {{Erl\"auterungen}{Erl\"aut\adddot}},
   introduction     = {{Einleitung}{Einl\adddot}},
@@ -87,93 +87,93 @@
                       {Hrsg\adddot\ und \"Ubers\adddot}},
   editorstr        = {{Herausgeber und \"Ubersetzer}%
                       {Hrsg\adddot\ und \"Ubers\adddot}},
-  editorco         = {{Herausgeber und Kommentar}%
+  editorco         = {{Herausgeber und Kommentator}%
                       {Hrsg\adddot\ und Komm\adddot}},
-  editorsco        = {{Herausgeber und Kommentar}%
+  editorsco        = {{Herausgeber und Kommentatoren}%
                       {Hrsg\adddot\ und Komm\adddot}},
-  editoran         = {{Herausgeber und Erl\"auterungen}%
-                      {Hrsg\adddot\ und Erl\"aut\adddot}},
-  editorsan        = {{Herausgeber und Erl\"auterungen}%
-                      {Hrsg\adddot\ und Erl\"aut\adddot}},
-  editorin         = {{Herausgeber und Einleitung}%
+  editoran         = {{Herausgeber und Kommentator}%
+                      {Hrsg\adddot\ und Komm\adddot}},
+  editorsan        = {{Herausgeber und Kommentatoren}%
+                      {Hrsg\adddot\ und Komm\adddot}},
+  editorin         = {{Herausgabe und Einleitung}%
                       {Hrsg\adddot\ und Einl\adddot}},
   editorsin        = {{Herausgeber und Einleitung}%
                       {Hrsg\adddot\ und Einl\adddot}},
   editorfo         = {{Herausgeber und Vorwort}%
                       {Hrsg\adddot\ und Vorw\adddot}},
-  editorsfo        = {{Herausgeber und Vorwort}%
+  editorsfo        = {{Herausgabe und Vorwort}%
                       {Hrsg\adddot\ und Vorw\adddot}},
-  editoraf         = {{Herausgeber und Nachwort}%
+  editoraf         = {{Herausgabe und Nachwort}%
                       {Hrsg\adddot\ und Nachw\adddot}},
-  editorsaf        = {{Herausgeber und Nachwort}%
+  editorsaf        = {{Herausgabe und Nachwort}%
                       {Hrsg\adddot\ und Nachw\adddot}},
-  editortrco       = {{Herausgeber, \"Ubersetzer und Kommentar}%
+  editortrco       = {{Herausgeber, \"Ubersetzer und Kommentator}%
                       {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
-  editorstrco      = {{Herausgeber, \"Ubersetzer und Kommentar}%
+  editorstrco      = {{Herausgeber, \"Ubersetzer und Kommentatoren}%
                       {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
-  editortran       = {{Herausgeber, \"Ubersetzer und Erl\"auterungen}%
-                      {Hrsg., \"Ubers\adddot\ und Erl\"aut\adddot}},
-  editorstran      = {{Herausgeber, \"Ubersetzer und Erl\"auterungen}%
-                      {Hrsg., \"Ubers\adddot\ und Erl\"aut\adddot}},
-  editortrin       = {{Herausgeber, \"Ubersetzer und Einleitung}%
+  editortran       = {{Herausgeber, \"Ubersetzer und Kommentator}%
+                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+  editorstran      = {{Herausgeber, \"Ubersetzer und Kommentatoren}%
+                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+  editortrin       = {{Herausgabe, \"Ubersetzung und Einleitung}%
                       {Hrsg., \"Ubers\adddot\ und Einl\adddot}},
-  editorstrin      = {{Herausgeber, \"Ubersetzer und Einleitung}%
+  editorstrin      = {{Herausgabe, \"Ubersetzung und Einleitung}%
                       {Hrsg., \"Ubers\adddot\ und Einl\adddot}},
-  editortrfo       = {{Herausgeber, \"Ubersetzer und Vorwort}%
+  editortrfo       = {{Herausgabe, \"Ubersetzung und Vorwort}%
                       {Hrsg., \"Ubers\adddot\ und Vorw\adddot}},
-  editorstrfo      = {{Herausgeber, \"Ubersetzer und Vorwort}%
+  editorstrfo      = {{Herausgabe, \"Ubersetzung und Vorwort}%
                       {Hrsg., \"Ubers\adddot\ und Vorw\adddot}},
-  editortraf       = {{Herausgeber, \"Ubersetzer und Nachwort}%
+  editortraf       = {{Herausgabe, \"Ubersetzung und Nachwort}%
                       {Hrsg., \"Ubers\adddot\ und Nachw\adddot}},
-  editorstraf      = {{Herausgeber, \"Ubersetzer und Nachwort}%
+  editorstraf      = {{Herausgabe, \"Ubersetzung und Nachwort}%
                       {Hrsg., \"Ubers\adddot\ und Nachw\adddot}},
-  editorcoin       = {{Herausgeber, Kommentar und Einleitung}%
+  editorcoin       = {{Herausgabe, Kommentar und Einleitung}%
                       {Hrsg., Komm\adddot\ und Einl\adddot}},
-  editorscoin      = {{Herausgeber, Kommentar und Einleitung}%
+  editorscoin      = {{Herausgabe, Kommentar und Einleitung}%
                       {Hrsg., Komm\adddot\ und Einl\adddot}},
-  editorcofo       = {{Herausgeber, Kommentar und Vorwort}%
+  editorcofo       = {{Herausgabe, Kommentar und Vorwort}%
                       {Hrsg., Komm\adddot\ und Vorw\adddot}},
-  editorscofo      = {{Herausgeber, Kommentar und Vorwort}%
+  editorscofo      = {{Herausgabe, Kommentar und Vorwort}%
                       {Hrsg., Komm\adddot\ und Vorw\adddot}},
-  editorcoaf       = {{Herausgeber, Kommentar und Nachwort}%
+  editorcoaf       = {{Herausgabe, Kommentar und Nachwort}%
                       {Hrsg., Komm\adddot\ und Nachw\adddot}},
-  editorscoaf      = {{Herausgeber, Kommentar und Nachwort}%
+  editorscoaf      = {{Herausgabe, Kommentar und Nachwort}%
                       {Hrsg., Komm\adddot\ und Nachw\adddot}},
-  editoranin       = {{Herausgeber, Erl\"auterungen und Einleitung}%
+  editoranin       = {{Herausgabe, Erl\"auterungen und Einleitung}%
                       {Hrsg., Erl\"aut\adddot\ und Einl\adddot}},
-  editorsanin      = {{Herausgeber, Erl\"auterungen und Einleitung}%
+  editorsanin      = {{Herausgabe, Erl\"auterungen und Einleitung}%
                       {Hrsg., Erl\"aut\adddot\ und Einl\adddot}},
-  editoranfo       = {{Herausgeber, Erl\"auterungen und Vorwort}%
+  editoranfo       = {{Herausgabe, Erl\"auterungen und Vorwort}%
                       {Hrsg., Erl\"aut\adddot\ und Vorw\adddot}},
-  editorsanfo      = {{Herausgeber, Erl\"auterungen und Vorwort}%
+  editorsanfo      = {{Herausgabe, Erl\"auterungen und Vorwort}%
                       {Hrsg., Erl\"aut\adddot\ und Vorw\adddot}},
-  editoranaf       = {{Herausgeber, Erl\"auterungen und Nachwort}%
+  editoranaf       = {{Herausgabe, Erl\"auterungen und Nachwort}%
                       {Hrsg., Erl\"aut\adddot\ und Nachw\adddot}},
-  editorsanaf      = {{Herausgeber, Erl\"auterungen und Nachwort}%
+  editorsanaf      = {{Herausgabe, Erl\"auterungen und Nachwort}%
                       {Hrsg., Erl\"aut\adddot\ und Nachw\adddot}},
-  editortrcoin     = {{Herausgeber, \"Ubersetzer, Kommentar und Einleitung}%
+  editortrcoin     = {{Herausgabe, \"Ubersetzung, Kommentar und Einleitung}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Einl\adddot}},
-  editorstrcoin    = {{Herausgeber, \"Ubersetzer, Kommentar und Einleitung}%
+  editorstrcoin    = {{Herausgabe, \"Ubersetzung, Kommentar und Einleitung}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Einl\adddot}},
-  editortrcofo     = {{Herausgeber, \"Ubersetzer, Kommentar und Vorwort}%
+  editortrcofo     = {{Herausgabe, \"Ubersetzung, Kommentar und Vorwort}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Vorw\adddot}},
-  editorstrcofo    = {{Herausgeber, \"Ubersetzer, Kommentar und Vorwort}%
+  editorstrcofo    = {{Herausgabe, \"Ubersetzung, Kommentar und Vorwort}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Vorw\adddot}},
-  editortrcoaf     = {{Herausgeber, \"Ubersetzer, Kommentar und Nachwort}%
+  editortrcoaf     = {{Herausgabe, \"Ubersetzung, Kommentar und Nachwort}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Nachw\adddot}},
-  editorstrcoaf    = {{Herausgeber, \"Ubersetzer, Kommentar und Nachwort}%
+  editorstrcoaf    = {{Herausgabe, \"Ubersetzung, Kommentar und Nachwort}%
                       {Hrsg., \"Ubers., Komm\adddot\ und Nachw\adddot}},
-  editortranin     = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Einleitung}%
+  editortranin     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Einleitung}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
-  editorstranin    = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Einleitung}%
+  editorstranin    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Einleitung}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
-  editortranfo     = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Vorwort}%
+  editortranfo     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Vorwort}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
-  editorstranfo    = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Vorwort}%
+  editorstranfo    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Vorwort}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
-  editortranaf     = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Nachwort}%
+  editortranaf     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Nachwort}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
-  editorstranaf    = {{Herausgeber, \"Ubersetzer, Erl\"auterungen und Nachwort}%
+  editorstranaf    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Nachwort}%
                       {Hrsg., \"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
   translatorco     = {{\"Ubersetzung und Kommentar}%
                       {\"Ubers\adddot\ und Komm\adddot}},
@@ -309,7 +309,7 @@
   andmore          = {{u.\,a\adddot}{u.\,a\adddot}},
   volume           = {{Band}{Bd\adddot}},
   volumes          = {{B\"ande}{Bde\adddot}},
-  involumes        = {{in}{in}},% FIXME: unsure
+  involumes        = {{in}{in}},
   jourvol          = {{Jahrgang}{Jg\adddot}},
   jourser          = {{Serie}{Ser\adddot}},
   book             = {{Buch}{Buch}},


### PR DESCRIPTION
Some translations were (IMHO) not ideal. This patch improves them. Some rationales:

* compiler is usually translated as "Kompilator".
* there is no distinction between "annotator" and "commentator" in German.
* do not mix roles with tasks ("Herausgabe und Einleitung", not "Herausgeber und Einleitung"), because it should either be stated what a person _is_ or what he _does_.