### PR TITLE
Typos in the documentation about newrefcontext

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3821,14 +3821,14 @@ At the beginning of the document, there is always a global context containing gl
 %   labelprefix=A
 \end{refcontext}
 
-\newfcontext}[labelprefix=B]
+\newrefcontext[labelprefix=B]
 % reference context:
 %   sorting=nty
 %   sortingnamekeyscheme=global
 %   labelprefix=B
 \endrefcontext
 
-\newfcontext}[sorting=ynt,labelprefix=C]{testrc}
+\newrefcontext[sorting=ynt,labelprefix=C]{testrc}
 % reference context:
 %   sorting=ynt
 %   sortingnamekeyscheme=global


### PR DESCRIPTION
I haven't tried to compile any version of the code, but those typos seem to be obviously wrong.