### PR TITLE
Typo `coverts` -> `converts`

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -9543,7 +9543,7 @@ Similar to the \cmd{forcsvlist} command from the \sty{etoolbox} package, except 
 
 \cmditem{MakeCapital}{text}
 
-Similar to \cmd{MakeUppercase} but only coverts the first printable character in \prm{text} to uppercase. Note that the restrictions that apply to \cmd{MakeUppercase} also apply to this command. Namely, all commands in \prm{text} must either be robust or prefixed with \cmd{protect} since the \prm{text} is expanded during capitalization. Apart from Ascii characters and the standard accent commands, this command also handles the active characters of the \sty{inputenc} package as well as the shorthands of the \sty{babel} package. If the \prm{text} starts with a control sequence, nothing is capitalized. This command is robust.
+Similar to \cmd{MakeUppercase} but only converts the first printable character in \prm{text} to uppercase. Note that the restrictions that apply to \cmd{MakeUppercase} also apply to this command. Namely, all commands in \prm{text} must either be robust or prefixed with \cmd{protect} since the \prm{text} is expanded during capitalization. Apart from Ascii characters and the standard accent commands, this command also handles the active characters of the \sty{inputenc} package as well as the shorthands of the \sty{babel} package. If the \prm{text} starts with a control sequence, nothing is capitalized. This command is robust.
 
 \cmditem{MakeSentenceCase}{text}
 \cmditem*{MakeSentenceCase*}{text}


### PR DESCRIPTION
Just a small typo in the documentation.