### PR TITLE
Add support for Swiss German

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -1171,8 +1171,10 @@ Finnish      & Finland        & \opt{finnish} \\
 French       & France, Canada & \opt{french} \\
 German       & Germany        & \opt{german} \\
              & Austria        & \opt{austrian} \\
+             & Switzerland    & \opt{swissgerman} \\
 German (new) & Germany        & \opt{ngerman} \\
              & Austria        & \opt{naustrian} \\
+             & Switzerland    & \opt{nswissgerman} \\
 Greek        & Greece         & \opt{greek} \\
 Italian      & Italy          & \opt{italian} \\
 Norwegian    & Norway         & \opt{norwegian}, \opt{norsk}, \opt{nynorsk} \\
@@ -10183,7 +10185,8 @@ The \prm{language} is the string given in the \bibfield{language} field (without
 
 \begin{ltxexample}
 \DeclareRedundantLanguages{french}{french}
-\DeclareRedundantLanguages{german}{german,ngerman,austrian,naustrian}
+\DeclareRedundantLanguages{german}{german,ngerman,austrian,naustrian,
+        nswissgerman,swissgerman}
 \DeclareRedundantLanguages{english,american}{english,american,british,
 	canadian,australian,newzealand,USenglish,UKenglish}
 \end{ltxexample}

--- a/tex/latex/biblatex/lbx/german.lbx
+++ b/tex/latex/biblatex/lbx/german.lbx
@@ -1,7 +1,7 @@
 \ProvidesFile{german.lbx}
 [\abx@lbxid]
 
-\DeclareRedundantLanguages{german}{german,ngerman,austrian,naustrian}
+\DeclareRedundantLanguages{german}{german,ngerman,austrian,naustrian,nswissgerman,swissgerman}
 
 \DeclareBibliographyExtras{%
   \DeclareCapitalPunctuation{.:!?}%
@@ -399,7 +399,7 @@
   forthcoming      = {{im Erscheinen}{im Erscheinen}},
   inpress          = {{im Druck}{im Druck}},
   prepublished     = {{Vorver\"offentlichung}{Vorver\"offentlichung}},
-  citedas          = {{im Folgenden zitiert als}{im Folgenden zit\adddotspace als}},
+  citedas          = {{im folgenden zitiert als}{im folgenden zit\adddotspace als}},
   thiscite         = {{hier}{hier}},
   seenote          = {{siehe Anmerkung}{s\adddotspace Anm\adddot}},
   quotedin         = {{zitiert nach}{zit\adddotspace nach}},

--- a/tex/latex/biblatex/lbx/nswissgerman.lbx
+++ b/tex/latex/biblatex/lbx/nswissgerman.lbx
@@ -1,0 +1,28 @@
+\ProvidesFile{nswissgerman.lbx}
+[\abx@lbxid]
+
+\InheritBibliographyExtras{german}
+
+% Swiss time sep is a dot
+\DeclareBibliographyExtras{%
+  \protected\def\bibtimesep{.}
+}
+
+% One point where Swiss German spelling
+% differs from Austrian and German German
+% is the (non-)use of \ss
+\DeclareBibliographyStrings{%
+  inherit          = {german},
+  citedas          = {{im Folgenden zitiert als}{im Folgenden zit\adddotspace als}},
+  countryuk        = {{Grossbritannien}{GB}},
+% alternative spelling, uncomment to enable:
+% section          = {{Paragraf}{\S}},
+% sections         = {{Paragrafen}{\S\S}},
+}
+
+\DeclareHyphenationExceptions{%
+  Pa-tent-an-mel-dung
+  Pa-tent-an-meld
+}
+
+\endinput

--- a/tex/latex/biblatex/lbx/swissgerman.lbx
+++ b/tex/latex/biblatex/lbx/swissgerman.lbx
@@ -1,0 +1,24 @@
+\ProvidesFile{swissgerman.lbx}
+[\abx@lbxid]
+
+\InheritBibliographyExtras{german}
+
+% Swiss time sep is a dot
+\DeclareBibliographyExtras{%
+  \protected\def\bibtimesep{.}
+}
+
+% One point where Swiss German spelling
+% differs from Austrian and German German
+% is the (non-)use of \ss
+\DeclareBibliographyStrings{%
+  inherit          = {german},
+  countryuk        = {{Grossbritannien}{GB}},
+}
+
+\DeclareHyphenationExceptions{%
+  Pa-tent-an-mel-dung
+  Pa-tent-an-meld
+}
+
+\endinput


### PR DESCRIPTION
These are supported by Babel as `swissgerman` and `nswissgerman`, by
polyglossia als `german`, `variant=swiss` (`spelling=old|new`)

This commit includes the correction to a string in german.lbx which has erroneously been changed
to follow new orthography, which meanwhile was corrected by yourself.