### PR TITLE
Remove monospace style from doi and eprint

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -438,8 +438,8 @@
 \DeclareFieldFormat{doi}{%
   \mkbibacro{DOI}\addcolon\space
   \ifhyperref
-    {\href{https://doi.org/#1}{\nolinkurl{#1}}}
-    {\nolinkurl{#1}}}
+    {\href{https://doi.org/#1}{#1}}
+    {#1}}
 \DeclareFieldFormat{edition}{%
   \ifinteger{#1}
     {\mkbibordedition{#1}~\bibstring{edition}}
@@ -451,25 +451,25 @@
   \addcolon\space
   \ifhyperref
     {\url{#1}}
-    {\nolinkurl{#1}}%
+    {#1}%
   \iffieldundef{eprintclass}
     {}
     {\addspace\mkbibparens{\thefield{eprintclass}}}}
 \DeclareFieldFormat{eprint:hdl}{%
   HDL\addcolon\space
   \ifhyperref
-    {\href{http://hdl.handle.net/#1}{\nolinkurl{#1}}}
-    {\nolinkurl{#1}}}
+    {\href{http://hdl.handle.net/#1}{#1}}
+    {#1}}
 \DeclareFieldAlias{eprint:HDL}{eprint:hdl}
 \DeclareFieldFormat{eprint:arxiv}{%
   arXiv\addcolon\space
   \ifhyperref
     {\href{http://arxiv.org/\abx@arxivpath/#1}{%
-       \nolinkurl{#1}%
+       #1%
        \iffieldundef{eprintclass}
          {}
          {\addspace\mkbibbrackets{\thefield{eprintclass}}}}}
-    {\nolinkurl{#1}
+    {#1
      \iffieldundef{eprintclass}
        {}
        {\addspace\mkbibbrackets{\thefield{eprintclass}}}}}
@@ -477,20 +477,20 @@
 \DeclareFieldFormat{eprint:jstor}{%
   JSTOR\addcolon\space
   \ifhyperref
-    {\href{http://www.jstor.org/stable/#1}{\nolinkurl{#1}}}
-    {\nolinkurl{#1}}}
+    {\href{http://www.jstor.org/stable/#1}{#1}}
+    {#1}}
 \DeclareFieldAlias{eprint:JSTOR}{eprint:jstor}
 \DeclareFieldFormat{eprint:pubmed}{%
   PMID\addcolon\space
   \ifhyperref
-    {\href{http://www.ncbi.nlm.nih.gov/pubmed/#1}{\nolinkurl{#1}}}
-    {\nolinkurl{#1}}}
+    {\href{http://www.ncbi.nlm.nih.gov/pubmed/#1}{#1}}
+    {#1}}
 \DeclareFieldAlias{eprint:PubMed}{eprint:pubmed}
 \DeclareFieldFormat{eprint:googlebooks}{%
   Google Books\addcolon\space
   \ifhyperref
-    {\href{http://books.google.com/books?id=#1}{\nolinkurl{#1}}}
-    {\nolinkurl{#1}}}
+    {\href{http://books.google.com/books?id=#1}{#1}}
+    {#1}}
 \DeclareFieldAlias{eprint:Google Books}{eprint:googlebooks}
 \DeclareFieldFormat{file}{\url{#1}}
 \DeclareFieldFormat{isbn}{\mkbibacro{ISBN}\addcolon\space #1}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -468,11 +468,11 @@
        \nolinkurl{#1}%
        \iffieldundef{eprintclass}
          {}
-         {\addspace\texttt{\mkbibbrackets{\thefield{eprintclass}}}}}}
+         {\addspace\mkbibbrackets{\thefield{eprintclass}}}}}
     {\nolinkurl{#1}
      \iffieldundef{eprintclass}
        {}
-       {\addspace\texttt{\mkbibbrackets{\thefield{eprintclass}}}}}}
+       {\addspace\mkbibbrackets{\thefield{eprintclass}}}}}
 \DeclareFieldAlias{eprint:arXiv}{eprint:arxiv}
 \DeclareFieldFormat{eprint:jstor}{%
   JSTOR\addcolon\space


### PR DESCRIPTION
The doi and the eprint identifier were set in monospace font, which often results in an uneven display. Monospace is often used to increase readabilty (for example for passwords), but as most identifiers are as readable as ISBN/ISSN numbers a consistent font should be used for both. 