### PR TITLE
Improve French translations

### DIFF
--- a/tex/latex/biblatex/lbx/french.lbx
+++ b/tex/latex/biblatex/lbx/french.lbx
@@ -6,8 +6,7 @@
 \DeclareRedundantLanguages{french}{french}
 
 \DeclareBibliographyExtras{%
-  \protected\def\bibrangedash{%
-    \textendash\penalty\hyphenpenalty}% breakable dash
+  \protected\def\bibrangedash{-}
   \let\finalandcomma=\empty
   \let\finalandsemicolon=\empty
   \def\mkbibordinal{\mkbibmascord}%
@@ -113,7 +112,7 @@
   references       = {{R\'ef\'erences}{R\'ef\'erences}},
   shorthands       = {{Liste des sigles}{Sigles}},
   editor           = {{\'editeur}{\'ed\adddot}},
-  editors          = {{\'editeurs}{\'eds\adddot}},
+  editors          = {{\'editeurs}{\'ed\adddot}},
   compiler         = {{compilateur}{comp\adddot}},
   compilers        = {{compilateurs}{comp\adddot}},
   redactor         = {{r\'edacteur}{r\'ed\adddot}},
@@ -142,111 +141,111 @@
   editorco         = {{\'editeur et commentateur}%
                       {\'ed\adddotspace et comm\adddot}},
   editorsco        = {{\'editeurs et commentateurs}%
-                      {\'eds\adddotspace et comm\adddot}},
+                      {\'ed\adddotspace et comm\adddot}},
   editoran         = {{\'editeur et annotateur}%
                       {\'ed\adddotspace et annot\adddot}},
   editorsan        = {{\'editeurs et annotateurs}%
-                      {\'eds\adddotspace et annot\adddot}},
+                      {\'ed\adddotspace et annot\adddot}},
   editorin         = {{\'editeur et introduction}%
                       {\'ed\adddotspace et introd\adddot}},
   editorsin        = {{\'editeurs et introduction}%
-                      {\'eds\adddotspace et introd\adddot}},
+                      {\'ed\adddotspace et introd\adddot}},
   editorfo         = {{\'editeur et pr\'eface}%
                       {\'ed\adddotspace et pr\'ef\adddot}},
   editorsfo        = {{\'editeurs et pr\'eface}%
-                      {\'eds\adddotspace et pr\'ef\adddot}},
+                      {\'ed\adddotspace et pr\'ef\adddot}},
   editoraf         = {{\'editeur et postface}%
                       {\'ed\adddotspace et postf\adddot}},
   editorsaf        = {{\'editeurs et postface}%
-                      {\'eds\adddotspace et postf\adddot}},
+                      {\'ed\adddotspace et postf\adddot}},
   editortrco       = {{\'editeur, traducteur et commentateur}%
-                      {\'ed.,\addabbrvspace trans\adddotspace et comm\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et comm\adddot}},
   editorstrco      = {{\'editeurs, traducteurs et commentateurs}%
-                      {\'eds.,\addabbrvspace trans\adddotspace et comm\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et comm\adddot}},
   editortran       = {{\'editeur, traducteur et annotateur}%
-                      {\'ed.,\addabbrvspace trans\adddotspace et annot\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et annot\adddot}},
   editorstran      = {{\'editeurs, traducteurs et annotateurs}%
-                      {\'eds.,\addabbrvspace trans\adddotspace et annot\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et annot\adddot}},
   editortrin       = {{\'editeur, traducteur et introduction}%
-                      {\'ed.,\addabbrvspace trans\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et introd\adddot}},
   editorstrin      = {{\'editeurs, traducteurs et introduction}%
-                      {\'eds.,\addabbrvspace trans\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et introd\adddot}},
   editortrfo       = {{\'editeur, traducteur et pr\'eface}%
-                      {\'ed.,\addabbrvspace trans\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et pr\'ef\adddot}},
   editorstrfo      = {{\'editeurs, traducteurs et pr\'eface}%
-                      {\'eds.,\addabbrvspace trans\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et pr\'ef\adddot}},
   editortraf       = {{\'editeur, traducteur et postface}%
-                      {\'ed.,\addabbrvspace trans\adddotspace et postf\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddotspace et postf\adddot}},
   editorstraf      = {{\'editeurs, traducteurs et postface}%
-                      {\'eds.,\addabbrvspace trans\adddot et postf\adddot}},
+                      {\'ed.,\addabbrvspace trad\adddot et postf\adddot}},
   editorcoin       = {{\'editeur, commentateur et introduction}%
                       {\'ed.,\addabbrvspace comm\adddotspace et introd\adddot}},
   editorscoin      = {{\'editeurs, commentateurs et introduction}%
-                      {\'eds.,\addabbrvspace comm\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace comm\adddotspace et introd\adddot}},
   editorcofo       = {{\'editeur, commentateur et pr\'eface}%
                       {\'ed.,\addabbrvspace comm\adddotspace et pr\'ef\adddot}},
   editorscofo      = {{\'editeurs, commentateurs et pr\'eface}%
-                      {\'eds.,\addabbrvspace comm\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace comm\adddotspace et pr\'ef\adddot}},
   editorcoaf       = {{\'editeur, commentateur et postface}%
                       {\'ed.,\addabbrvspace comm\adddotspace et postf\adddot}},
   editorscoaf      = {{\'editeurs, commentateurs et postface}%
-                      {\'eds.,\addabbrvspace comm\adddotspace et postf\adddot}},
+                      {\'ed.,\addabbrvspace comm\adddotspace et postf\adddot}},
   editoranin       = {{\'editeur, annotateur et introduction}%
                       {\'ed.,\addabbrvspace annot\adddotspace et introd\adddot}},
   editorsanin      = {{\'editeurs, annotateurs et introduction}%
-                      {\'eds.,\addabbrvspace annot\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace annot\adddotspace et introd\adddot}},
   editoranfo       = {{\'editeur, annotateur et pr\'eface}%
                       {\'ed.,\addabbrvspace annot\adddotspace et pr\'ef\adddot}},
   editorsanfo      = {{\'editeurs, annotateurs et pr\'eface}%
-                      {\'eds.,\addabbrvspace annot\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace annot\adddotspace et pr\'ef\adddot}},
   editoranaf       = {{\'editeur, annotateur et postface}%
                       {\'ed.,\addabbrvspace annot\adddotspace et postf\adddot}},
   editorsanaf      = {{\'editeurs, annotateurs et postface}%
-                      {\'eds.,\addabbrvspace annot\adddotspace et postf\adddot}},
+                      {\'ed.,\addabbrvspace annot\adddotspace et postf\adddot}},
   editortrcoin     = {{\'editeur, traducteur, commentateur et introduction}%
                       {\'ed.,\addabbrvspace trad., comm\adddotspace et introd\adddot}},
   editorstrcoin    = {{\'editeurs, traducteurs, commentateurs et introduction}%
-                      {\'eds.,\addabbrvspace trad., comm\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace trad., comm\adddotspace et introd\adddot}},
   editortrcofo     = {{\'editeur, traducteur, commentateur et pr\'eface}%
                       {\'ed.,\addabbrvspace trad., comm\adddotspace et pr\'ef\adddot}},
   editorstrcofo    = {{\'editeurs, traducteurs, commentateurs et pr\'eface}%
-                      {\'eds.,\addabbrvspace trad., comm\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace trad., comm\adddotspace et pr\'ef\adddot}},
   editortrcoaf     = {{\'editeur, traducteur, commentateur et postface}%
                       {\'ed.,\addabbrvspace trad., comm\adddotspace et postf\adddot}},
   editorstrcoaf    = {{\'editeurs, traducteurs, commentateurs et postface}%
-                      {\'eds.,\addabbrvspace trad., comm\adddotspace et postf\adddot}},
+                      {\'ed.,\addabbrvspace trad., comm\adddotspace et postf\adddot}},
   editortranin     = {{\'editeur, traducteur, annotateur et introduction}%
                       {\'ed.,\addabbrvspace trad., annot\adddotspace et introd\adddot}},
   editorstranin    = {{\'editeurs, traducteurs, annotateurs et introduction}%
-                      {\'eds.,\addabbrvspace trad., annot\adddotspace et introd\adddot}},
+                      {\'ed.,\addabbrvspace trad., annot\adddotspace et introd\adddot}},
   editortranfo     = {{\'editeur, traducteur, annotateur et pr\'eface}%
                       {\'ed.,\addabbrvspace trad., annot\adddotspace et pr\'ef\adddot}},
   editorstranfo    = {{\'editeurs, traducteurs, annotateurs et pr\'eface}%
-                      {\'eds.,\addabbrvspace trad., annot\adddotspace et pr\'ef\adddot}},
+                      {\'ed.,\addabbrvspace trad., annot\adddotspace et pr\'ef\adddot}},
   editortranaf     = {{\'editeur, traducteur, annotateur et postface}%
                       {\'ed.,\addabbrvspace trad., annot\adddotspace et postf\adddot}},
   editorstranaf    = {{\'editeurs, traducteurs, annotateurs et postface}%
-                      {\'eds.,\addabbrvspace trad., annot\adddotspace et postf\adddot}},
+                      {\'ed.,\addabbrvspace trad., annot\adddotspace et postf\adddot}},
   translatorco     = {{traducteur et commentateur}%
-                      {trans\adddotspace et comm\adddot}},
+                      {trad\adddotspace et comm\adddot}},
   translatorsco    = {{traducteurs et commentateurs}%
-                      {trans\adddotspace et comm\adddot}},
+                      {trad\adddotspace et comm\adddot}},
   translatoran     = {{traducteur et annotateur}%
-                      {trans\adddotspace et annot\adddot}},
+                      {trad\adddotspace et annot\adddot}},
   translatorsan    = {{traducteurs et annotateurs}%
-                      {trans\adddotspace et annot\adddot}},
+                      {trad\adddotspace et annot\adddot}},
   translatorin     = {{traduction et introduction}%
-                      {trans\adddotspace et introd\adddot}},
+                      {trad\adddotspace et introd\adddot}},
   translatorsin    = {{traduction et introduction}%
-                      {trans\adddotspace et introd\adddot}},
+                      {trad\adddotspace et introd\adddot}},
   translatorfo     = {{traduction et pr\'eface}%
-                      {trans\adddotspace et pr\'ef\adddot}},
+                      {trad\adddotspace et pr\'ef\adddot}},
   translatorsfo    = {{traduction et pr\'eface}%
-                      {trans\adddotspace et pr\'ef\adddot}},
+                      {trad\adddotspace et pr\'ef\adddot}},
   translatoraf     = {{traduction et postface}%
-                      {trans\adddotspace et postf\adddot}},
+                      {trad\adddotspace et postf\adddot}},
   translatorsaf    = {{traduction et postface}%
-                      {trans\adddotspace et postf\adddot}},
+                      {trad\adddotspace et postf\adddot}},
   translatorcoin   = {{traduction, commentaire et introduction}%
                       {trad., comm\adddotspace et introd\adddot}},
   translatorscoin  = {{traduction, commentaire et introduction}%
@@ -396,7 +395,7 @@
   verse            = {{vers}{v\adddot}},
   verses           = {{vers}{v\adddot}},
   section          = {{section}{\S}},
-  sections         = {{sections}{\S\S}},
+  sections         = {{sections}{\S}},
   paragraph        = {{paragraphe}{par\adddot}},
   paragraphs       = {{paragraphes}{par\adddot}},
   pagetotal        = {{page}{p\adddot}},
@@ -408,7 +407,7 @@
   versetotal       = {{vers}{v\adddot}},
   versetotals      = {{vers}{v\adddot}},
   sectiontotal     = {{section}{\S}},
-  sectiontotals    = {{sections}{\S\S}},
+  sectiontotals    = {{sections}{\S}},
   paragraphtotal   = {{paragraphe}{par\adddot}},
   paragraphtotals  = {{paragraphes}{par\adddot}},
   in               = {{in}{in}},
@@ -470,14 +469,14 @@
   december         = {{d\'ecembre}{d\'ec\adddot}},
   langamerican     = {{am\'ericain}{am\'ericain}},
   langbrazilian    = {{br\'esilien}{br\'esilien}},
-% langbulgarian    = {{}{}},% FIXME: missing
+  langbulgarian    = {{bulgare}{bulgare}},
   langcatalan      = {{catalan}{catalan}},
   langcroatian     = {{croate}{croate}},
   langczech        = {{tch\`eque}{tch\`eque}},
   langdanish       = {{danois}{danois}},
   langdutch        = {{n\'eerlandais}{n\'eerlandais}},
   langenglish      = {{anglais}{anglais}},
-%  langestonian     = {{}{}},% FIXME: missing
+  langestonian     = {{estonien}{estonien}},
   langfinnish      = {{finnois}{finnois}},
   langfrench       = {{fran\c{c}ais}{fran\c{c}ais}},
   langgalician     = {{galicien}{galicien}},
@@ -494,14 +493,14 @@
   langswedish      = {{su\'edois}{su\'edois}},
   fromamerican     = {{de l'am\'ericain}{de l'am\'ericain}},
   frombrazilian    = {{du br\'esilien}{du br\'esilien}},
-% frombulgarian    = {{}{}},% FIXME: missing
+  frombulgarian    = {{du bulgare}{du bulgare}},
   fromcatalan      = {{du catalan}{du catalan}},
   fromcroatian     = {{du croate}{du croate}},
   fromczech        = {{du tch\`eque}{du tch\`eque}},
   fromdanish       = {{du danois}{du danois}},
   fromdutch        = {{du n\'eerlandais}{du n\'eerlandais}},
   fromenglish      = {{de l'anglais}{de l'anglais}},
-%  fromestonian     = {{}{}},% FIXME: missing
+  fromestonian     = {{de l'estonien}{de l'estonien}},
   fromfinnish      = {{du finnois}{du finnois}},
   fromfrench       = {{du fran\c{c}ais}{du fran\c{c}ais}},
   fromgalician     = {{du galicien}{du galicien}},
@@ -540,13 +539,13 @@
   annotation       = {{annotations}{annotations}},
   commonera        = {{de l’\`ere commune}{EC}},
   beforecommonera  = {{avant l’\`ere commune}{AEC}},
-  annodomini       = {{apr\`es J\'esus-Christ}{ap\adddotspace J\adddot-C\adddot}},
+  annodomini       = {{apr\`es J\'esus-Christ}{apr\adddotspace J\adddot-C\adddot}},
   beforechrist     = {{avant J\'esus-Christ}{av\adddotspace J\adddot-C\adddot}},
-% circa            = {{}{}},% FIXME: missing
-% spring           = {{}{}},% FIXME: missing
-% summer           = {{}{}},% FIXME: missing
-% autumn           = {{}{}},% FIXME: missing
-% winter           = {{}{}},% FIXME: missing
+  circa            = {{vers}{vers}},
+  spring           = {{printemps}{printemps}},
+  summer           = {{été}{été}},
+  autumn           = {{automne}{automne}},
+  winter           = {{hiver}{hiver}},
   am               = {{AM}{AM}},
   pm               = {{PM}{PM}},
 }


### PR DESCRIPTION
Changes:

- `\bibrangedash` defined as a hyphen instead of an en dash

  Rationale:

  - “L’abréviation de « pages » est « p. » (en anglais « pp. ») et on sépare les numéros par un tiret court « p. 12-34 » (en anglais par un moyen « pp. 12–34 »).” (https://jacques-andre.fr/faqtypo/lessons.pdf, page 43)

- `andothers`, `andmore` translated to “et coll.” instead of “et al.”

  Rationale:

  - “On peut aussi recourir à des formules telles que : *sous la direction de*, ou : *et collab*…” (http://www.orthotypographie.fr/volume-I/bandeau-bureau.html#Bibliographie)
  - “On tend à privilégier les formes françaises *et autres*, *et coll.*, etc., plutôt que la locution latine *et alii* ainsi que son abréviation *et al.*” (http://gdt.oqlf.gouv.qc.ca/ficheOqlf.aspx?Id_Fiche=8362481)
  - “S’il y a plus de trois auteurs, on indique le nom et le prénom du premier en les faisant suivre d’une virgule et de la mention *et autres* ou *et collab.* (pour *et collaborateurs*) de préférence à l’abréviation latine *et al.* (pour *et alii* « et les autres »).” (http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?t1=1&id=3245)

- `sections` and `sectiontotals` translated to “\S” instead of “\S\S”

  Rationale:

  - “On proscrira la répétition des signes ou des lettres pour indiquer la pluralité : § 5 et 6 et non §§ 5 et 6” (*Lexique des règles typographiques en usage à l’Imprimerie nationale* (1990), page 6)

- `annodomini` translated to “apr. J.-C.” instead of “ap. J.-C.”

  Rationale:

  - http://www.orthotypographie.fr/volume-I/abreviations-01.html
  - http://www.btb.termiumplus.gc.ca/redac-chap?lang=fra&lettr=chapsect1&info0=1.4#a
  - *Lexique des règles typographiques en usage à l’Imprimerie nationale* (1990), page 7.

- `opcit` translated to “ouvr. cité” instead of “op. cit.” and `loccit` translated to “pass. cité” instead of “loc. cit.”

  Rationale: http://www.orthotypographie.fr/volume-I/abreviations-01.html

- `sequens` and `sequentes` translated to “et suiv.” instead of “sq.” and “sqq.”

  Rationale: http://www.orthotypographie.fr/volume-I/abreviations-01.html

- `langestonian` translated to “estonien” and `fromestonian` translated to “de
  l’estonien”

- `langbulgarian` translated to “bulgare” and `frombulgarian` translated to “du
  bulgare”