### PR TITLE
normalise journal/periodcial/issue macros

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -2640,7 +2640,11 @@
   \printfield{maintitleaddon}}
 
 \newbibmacro*{journal}{%
-  \iffieldundef{journaltitle}
+  \ifboolexpr{
+    test {\iffieldundef{journaltitle}}
+    and
+    test {\iffieldundef{journalsubtitle}}
+  }
     {}
     {\printtext[journaltitle]{%
        \printfield[titlecase]{journaltitle}%
@@ -2648,7 +2652,11 @@
        \printfield[titlecase]{journalsubtitle}}}}
 
 \newbibmacro*{periodical}{%
-  \iffieldundef{title}
+  \ifboolexpr{
+    test {\iffieldundef{title}}
+    and
+    test {\iffieldundef{subtitle}}
+  }
     {}
     {\printtext[title]{%
        \printfield[titlecase]{title}%
@@ -2656,7 +2664,11 @@
        \printfield[titlecase]{subtitle}}}}
 
 \newbibmacro*{issue}{%
-  \iffieldundef{issuetitle}
+  \ifboolexpr{
+    test {\iffieldundef{issuetitle}}
+    and
+    test {\iffieldundef{issuesubtitle}}
+  }
     {}
     {\printtext[issuetitle]{%
        \printfield[titlecase]{issuetitle}%


### PR DESCRIPTION
Cf. #554. Bring printing of `subtitle` (like) fields in `journal`, `periodical` and `issue` macros in line with other macros