### PR TITLE
Detect hyphenrules in polyglossia

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5484,9 +5484,11 @@
                      {\csname\abx@field@langid\endcsname}}
                   {\csname\blx@thelangenv\expandafter\endcsname\expandafter{\abx@field@langid}}%
                 % These lines are equal to \blx@maplang
-                \blx@resetpunct
-                \csuse{abx@extras@\abx@field@langid}%
-                \csuse{abx@strings@\abx@field@langid}}}
+                \ifcsstring{blx@thelangenv}{hyphenrules}
+                  {}
+                  {\blx@resetpunct
+                   \csuse{abx@extras@\abx@field@langid}%
+                   \csuse{abx@strings@\abx@field@langid}}}}
             {}}}
        {}%
      % polyglossia needs this - it doesn't get the


### PR DESCRIPTION
See #564. This guards against using the language strings/extras initialisation sequence also with hyphenrules.