### PR TITLE
Patch footnotes when bidi is loaded (fixes #412)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -195,6 +195,17 @@
        {\togglefalse{blx@tempa}}
        {}}
     {}%
+  \@ifpackageloaded{bidi}{%   bidi
+    \def\do#1{
+      \pretocmd#1
+        {\toggletrue{blx@footnote}}
+        {\togglefalse{blx@tempa}}
+        {}}%
+    \docsvlist{%
+      \@footnotetext,
+      \@LTRfootnotetext,
+      \@RTLfootnotetext}}%
+    {}%
   \@ifclassloaded{memoir}
     {\def\do#1{%
        \patchcmd#1%


### PR DESCRIPTION
This commit patches footnotes when `bidi` is loaded. Without this any feature that relies on footnote tracking does not work as soon as a RTL language is loaded under `xelatex`.