### PR TITLE
new translatortype wrapper (#572)

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -886,6 +886,7 @@
 
 \DeclareFieldFormat{authortype}{#1}
 \DeclareFieldFormat{editortype}{#1}
+\DeclareFieldFormat{translatortype}{#1}
 
 % Auxiliary macros for name formatting directives
 % ------------------------------------------------------------------
@@ -2377,13 +2378,14 @@
     {\usebibmacro{editorstrg}}}
 
 \newbibmacro*{translatorstrg}{%
-  \ifboolexpr{
-    test {\ifnumgreater{\value{translator}}{1}}
-    or
-    test {\ifandothers{translator}}
-  }
-    {\bibstring{translators}}
-    {\bibstring{translator}}}
+  \printtext[translatortype]{%
+    \ifboolexpr{
+      test {\ifnumgreater{\value{translator}}{1}}
+      or
+      test {\ifandothers{translator}}
+    }
+      {\bibstring{translators}}
+      {\bibstring{translator}}}}
 
 \newbibmacro*{translator+othersstrg}{%
   \ifboolexpr{
@@ -2410,7 +2412,7 @@
           {\appto\abx@tempa{af}%
            \clearname{afterword}}
           {}}}%
-  \bibstring{\abx@tempa}}
+  \printtext[translatortype]{\bibstring{\abx@tempa}}}
 
 \newbibmacro*{byauthor}{%
   \ifboolexpr{


### PR DESCRIPTION
Cf. #572.
This introduces a format called `translatortype` analogous to `editortype` for `translator...` macros.