### PR TITLE
New (author|editor|translator)typedelims

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4602,6 +4602,15 @@ The delimiter printed between the name\slash title and the label by alphabetic a
 \csitem{nonameyeardelim}\CSdelimMark
 The delimiter printed between the substitute for the labelname when it does not exist (usually the label or title in standard styles) and the year in author-year citation styles. This is only used when there is no labelname since when the labelname exists, \cmd{nameyeardelim} is used. The default definition is an interword space.
 
+\csitem{authortypedelim}\CSdelimMark
+The delimiter printed between the author and the \field{authortype}.
+
+\csitem{editortypedelim}\CSdelimMark
+The delimiter printed between the editor and the \field{editortype} bibstring.
+
+\csitem{translatortypedelim}\CSdelimMark
+The delimiter printed between the translator and the translatortype bibstring.
+
 \csitem{labelalphaothers}
 A string to be appended to the non"=numeric portion of the \bibfield{labelalpha} field (\ie the field holding the citation label used by alphabetic citation styles) if the number of authors\slash editors exceeds the \opt{maxalphanames} threshold or the \bibfield{author}\slash \bibfield{editor} list was truncated in the \file{bib} file with the keyword <\texttt{and others}>. This will typically be a single character such as a plus sign or an asterisk. The default is a plus sign. This command may also be redefined to an empty string to disable this feature. In any case, it must be redefined in the preamble.
 
@@ -10976,6 +10985,15 @@ The delimiter printed between the name\slash title and the label. This command s
 \csitem{nonameyeardelim}
 The delimiter printed between the substitute for the labelname when it does not exist (usually the label or title in standard styles) and the year in author-year citation styles. This is only used when there is no labelname since when the labelname exists, \cmd{nameyeardelim} is used.
 
+\csitem{authortypedelim}
+The delimiter printed between the author and the \field{authortype}.
+
+\csitem{editortypedelim}
+The delimiter printed between the editor and the \field{editortype} bibstring.
+
+\csitem{translatortypedelim}
+The delimiter printed between the translator and the translatortype bibstring.
+
 \csitem{volcitedelim}
 The delimiter to be printed between the volume portion and the page/text portion of \cmd{volcite} and related commands (\secref{use:cit:spc}).
 
@@ -12896,6 +12914,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item \bibfield{sortyear} is now a literal, not an integer\see{bib:fld:spc}
 \item Added \cmd{DeclareLanguageMappingSuffix}\see{aut:lng:cmd}
 \item Changed default for \cmd{DeclarePrefChars}\see{aut:pct:cfg}
+\item Added \cmd{authortypedelim}, \cmd{editortypedelim} and \cmd{translatortypedelim}\see{use:fmt:fmt}
 \end{release}
 
 \begin{release}{3.7}{2016-12-08}

--- a/tex/latex/biblatex/bbx/authortitle.bbx
+++ b/tex/latex/biblatex/bbx/authortitle.bbx
@@ -69,7 +69,7 @@
     {\usebibmacro{bbx:dashcheck}
        {\bibnamedash}
        {\printnames{author}%
-        \setunit{\addcomma\space}%
+        \setunit{\printdelim{authortypedelim}}%
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{authorstrg}}
     {\global\undef\bbx@lasthash}}
@@ -87,7 +87,7 @@
     {\usebibmacro{bbx:dashcheck}
        {\bibnamedash}
        {\printnames{editor}%
-        \setunit{\addcomma\space}%
+        \setunit{\printdelim{editortypedelim}}%
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{#1}%
      \clearname{editor}}
@@ -106,7 +106,7 @@
     {\usebibmacro{bbx:dashcheck}
        {\bibnamedash}
        {\printnames{translator}%
-        \setunit{\addcomma\space}%
+        \setunit{\printdelim{translatortypedelim}}%
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{#1}%
      \clearname{translator}}

--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -189,7 +189,7 @@
         \printnames{author}%
         \iffieldundef{authortype}
           {\setunit{\printdelim{nameyeardelim}}}
-          {\setunit{\addcomma\space}}}%
+          {\setunit{\printdelim{authortypedelim}}}}%
      \iffieldundef{authortype}
        {}
        {\usebibmacro{authorstrg}%
@@ -212,7 +212,7 @@
     {\usebibmacro{bbx:dashcheck}
        {\bibnamedash}
        {\printnames{editor}%
-        \setunit{\addcomma\space}%
+        \setunit{\printdelim{editortypedelim}}%
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{#1}%
      \clearname{editor}%
@@ -235,7 +235,7 @@
     {\usebibmacro{bbx:dashcheck}
        {\bibnamedash}
        {\printnames{translator}%
-        \setunit{\addcomma\space}%
+        \setunit{\printdelim{translatortypedelim}}%
         \usebibmacro{bbx:savehash}}%
      \usebibmacro{#1}%
      \clearname{translator}%

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -105,8 +105,12 @@
     {\iftextcitepunct{\addsemicolon}{\addcomma}}%
   \space}
 
+
 % context-sensitive delimiters
 % retain compatibility with \labelnamepunct
+\DeclareDelimFormat{authortypedelim}{\addcomma\space}
+\DeclareDelimFormat{editortypedelim}{\addcomma\space}
+\DeclareDelimFormat{translatortypedelim}{\addcomma\space}
 \DeclareDelimFormat{namelabeldelim}{\addspace}
 \DeclareDelimFormat{nametitledelim}{\addcomma\space}
 \DeclareDelimFormat[bib]{nametitledelim}{\labelnamepunct}
@@ -2249,7 +2253,7 @@
     {\printnames{author}%
      \iffieldundef{authortype}
        {}
-       {\setunit{\addcomma\space}%
+       {\setunit{\printdelim{authortypedelim}}%
         \usebibmacro{authorstrg}}}
     {}}
 
@@ -2260,7 +2264,7 @@
     not test {\ifnameundef{editor}}
   }
     {\printnames{editor}%
-     \setunit{\addcomma\space}%
+     \setunit{\printdelim{editortypedelim}}%
      \usebibmacro{editorstrg}%
      \clearname{editor}}
     {}}
@@ -2272,7 +2276,7 @@
     not test {\ifnameundef{editor}}
   }
     {\printnames{editor}%
-     \setunit{\addcomma\space}%
+     \setunit{\printdelim{editortypedelim}}%
      \usebibmacro{editor+othersstrg}%
      \clearname{editor}}
     {}}
@@ -2284,7 +2288,7 @@
     not test {\ifnameundef{translator}}
   }
     {\printnames{translator}%
-     \setunit{\addcomma\space}%
+     \setunit{\printdelim{translatortypedelim}}%
      \usebibmacro{translatorstrg}%
      \clearname{translator}}
     {}}
@@ -2296,7 +2300,7 @@
     not test {\ifnameundef{translator}}
   }
     {\printnames{translator}%
-     \setunit{\addcomma\space}%
+     \setunit{\printdelim{translatortypedelim}}%
      \usebibmacro{translator+othersstrg}%
      \clearname{translator}}
     {}}


### PR DESCRIPTION
Cf. #572. This introduces user-definable delimiters between name fields and their <name> bibstring.

Currently named `<role>typedelim` could be renamed to `<role>strgdelim`, if that seems more appropriate.