### PR TITLE
Make more *namedelims context sensitive

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4500,7 +4500,7 @@ This command should be used with \cmd{bibnamedelimd} as a reversed-name separato
 The dash to be used as a replacement for recurrent authors or editors in the bibliography. The default is an <em> or an <en> dash, depending on the indentation of the list of references.
 
 \csitem{labelnamepunct}
-The separator printed after the name used for alphabetizing in the bibliography (\bibfield{author} or \bibfield{editor}, if the \bibfield{author} field is undefined). With the default styles, this separator replaces \cmd{newunitpunct} at this location. The default definition is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation.
+The separator printed after the name used for alphabetizing in the bibliography (\bibfield{author} or \bibfield{editor}, if the \bibfield{author} field is undefined). With the default styles, this separator replaces \cmd{newunitpunct} at this location. The default definition is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation. See also \cmd{nametitledelim} \see{use:fmt:csd}.
 
 \csitem{subtitlepunct}
 The separator printed between the fields \bibfield{title} and \bibfield{subtitle}, \bibfield{booktitle} and \bibfield{booksubtitle}, as well as \bibfield{maintitle} and \bibfield{mainsubtitle}. With the default styles, this separator replaces \cmd{newunitpunct} at this location. The default definition is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation.
@@ -4514,10 +4514,10 @@ The separator printed before the \bibfield{pages} field. The default is a comma 
 \csitem{bibpagerefpunct}
 The separator printed before the \bibfield{pageref} field. The default is an interword space.
 
-\csitem{multinamedelim}
+\csitem{multinamedelim}\CSdelimMark
 The delimiter printed between multiple items in a name list like \bibfield{author} or \bibfield{editor} if there are more than two names in the list. The default is a comma plus an interword space. See \cmd{finalnamedelim} for an example.\footnote{Note that \cmd{multinamedelim} is not used at all if there are only two names in the list. In this case, the default styles use the \cmd{finalnamedelim}.}
 
-\csitem{finalnamedelim}
+\csitem{finalnamedelim}\CSdelimMark
 The delimiter printed instead of \cmd{multinamedelim} before the final name in a name list. The default is the localised term <and>, separated by interword spaces. Here is an example:
 
 \begin{ltxexample}
@@ -4527,7 +4527,7 @@ Edward Jones <<and>> Joe Williams
 %
 The comma in the first example is the \cmd{multinamedelim} whereas the string <and> in both examples is the \cmd{finalnamedelim}. See also \cmd{finalandcomma} in \secref{use:fmt:lng}.
 
-\csitem{revsdnamedelim}
+\csitem{revsdnamedelim}\CSdelimMark
 An extra delimiter printed after the first name in a name list if the first name is reversed (only in lists with two names). The default is an empty string, \ie no extra delimiter will be printed. Here is an example showing a name list with a comma as \cmd{revsdnamedelim}:
 
 \begin{ltxexample}
@@ -4536,16 +4536,16 @@ Jones, Edward<<, and>> Joe Williams
 %
 In this example, the comma after <Edward> is the \cmd{revsdnamedelim} whereas the string <and> is the \cmd{finalnamedelim}, printed in addition to the former.
 
-\csitem{andothersdelim}
+\csitem{andothersdelim}\CSdelimMark
 The delimiter printed before the localisation string <\texttt{andothers}> if a name list like \bibfield{author} or \bibfield{editor} is truncated. The default is an interword space.
 
-\csitem{multilistdelim}
+\csitem{multilistdelim}\CSdelimMark
 The delimiter printed between multiple items in a literal list like \bibfield{publisher} or \bibfield{location} if there are more than two items in the list. The default is a comma plus an interword space. See \cmd{multinamedelim} for further explanation.
 
-\csitem{finallistdelim}
+\csitem{finallistdelim}\CSdelimMark
 The delimiter printed instead of \cmd{multilistdelim} before the final item in a literal list. The default is the localised term <and>, separated by interword spaces. See \cmd{finalnamedelim} for further explanation.
 
-\csitem{andmoredelim}
+\csitem{andmoredelim}\CSdelimMark
 The delimiter printed before the localisation string <\texttt{andmore}> if a literal list like \bibfield{publisher} or \bibfield{location} is truncated. The default is an interword space.
 
 \csitem{multicitedelim}
@@ -10928,7 +10928,7 @@ The punctuation to be printed between the first and last name parts when a name 
 The dash to be used as a replacement for recurrent authors or editors in the bibliography. The default is an <em> or an <en> dash, depending on the indentation of the list of references.
 
 \csitem{labelnamepunct}
-The separator to be printed after the name used for alphabetizing in the bibliography (\bibfield{author} or \bibfield{editor}, if the \bibfield{author} field is undefined). Use this separator instead of \cmd{newunitpunct} at this location. The default is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation but permits convenient reconfiguration.
+The separator to be printed after the name used for alphabetizing in the bibliography (\bibfield{author} or \bibfield{editor}, if the \bibfield{author} field is undefined). Use this separator instead of \cmd{newunitpunct} at this location. The default is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation but permits convenient reconfiguration. See also \cmd{nametitledelim} \see{use:fmt:csd}.
 
 \csitem{subtitlepunct}
 The separator to be printed between the fields \bibfield{title} and \bibfield{subtitle}, \bibfield{booktitle} and \bibfield{booksubtitle}, as well as \bibfield{maintitle} and \bibfield{mainsubtitle}. Use this separator instead of \cmd{newunitpunct} at this location. The default is \cmd{newunitpunct}, \ie it is not handled differently from regular unit punctuation but permits convenient reconfiguration.

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -77,18 +77,18 @@
 \newcommand*{\bibellipsis}{[\textellipsis\unkern]\midsentence}
 
 % Delimiters used in citations, bibliography and bibliography lists
-\newcommand*{\multinamedelim}{\addcomma\space}
-\newcommand*{\finalnamedelim}{%
+\DeclareDelimFormat{multinamedelim}{\addcomma\space}
+\DeclareDelimFormat{finalnamedelim}{%
   \ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
   \addspace\bibstring{and}\space}
-\newcommand*{\revsdnamedelim}{}
-\newcommand*{\andothersdelim}{\addspace}
+\DeclareDelimFormat{revsdnamedelim}{}
+\DeclareDelimFormat{andothersdelim}{\addspace}
 
-\newcommand*{\multilistdelim}{\addcomma\space}
-\newcommand*{\finallistdelim}{%
+\DeclareDelimFormat{multilistdelim}{\addcomma\space}
+\DeclareDelimFormat{finallistdelim}{%
   \ifnumgreater{\value{liststop}}{2}{\finalandcomma}{}%
   \addspace\bibstring{and}\space}
-\newcommand*{\andmoredelim}{\addspace}
+\DeclareDelimFormat{andmoredelim}{\addspace}
 
 \newcommand*{\multicitedelim}{\addsemicolon\space}
 \newcommand*{\compcitedelim}{\addcomma\space}
@@ -630,13 +630,13 @@
        or
        test \ifmoreitems
      }
-       {\multilistdelim}
+       {\printdelim{multilistdelim}}
        {\lbx@finallistdelim{#1}}}
     {}}
 
 \newbibmacro*{list:plain}{%
   \ifnumgreater{\value{listcount}}{\value{liststart}}
-    {\multilistdelim}
+    {\printdelim{multilistdelim}}
     {}}
 
 \newbibmacro*{list:andothers}{%
@@ -648,7 +648,7 @@
     {\ifnumgreater{\value{liststop}}{1}
        {\finalandcomma}
        {}%
-     \andmoredelim\bibstring{andmore}}
+     \printdelim{\andmoredelim}\bibstring{andmore}}
     {}}
 
 \newbibmacro*{pageref:init}{%
@@ -681,7 +681,7 @@
         \numdef\abx@range@diff{\abx@range@diff+1}}
        {\usebibmacro{pageref:dump}%
         \ifnumgreater{\abx@range@last}{-1}
-          {\multilistdelim}
+          {\printdelim{multilistdelim}}
           {}%
         \ifhyperref
           {\hyperlink{page.#1}{#1}}
@@ -689,7 +689,7 @@
      \edef\abx@range@prev{\abx@range@num}}
     {\usebibmacro{pageref:dump}%
      \ifnumgreater{\abx@range@last}{-1}
-       {\multilistdelim}
+       {\printdelim{multilistdelim}}
        {}%
      \ifhyperref
        {\hyperlink{page.#1}{#1}}
@@ -706,7 +706,7 @@
          {\abx@range@hold}%
      \or % three
        \ifnumless{\abx@range@diff}{2}
-         {\multilistdelim}
+         {\printdelim{multilistdelim}}
          {\bibrangedash}%
        \ifhyperref
          {\hyperlink{page.\abx@range@hold}{\abx@range@hold}}
@@ -970,7 +970,7 @@
        or
        test \ifmorenames
      }
-       {\multinamedelim}
+       {\printdelim{multinamedelim}}
        {\lbx@finalnamedelim{#1}}}
     {}}
 
@@ -984,7 +984,7 @@
     or
     test {\ifnumequal{\value{liststop}}{2}}
   }
-    {\revsdnamedelim}
+    {\printdelim{revsdnamedelim}}
     {}}
 
 \newbibmacro*{name:andothers}{%
@@ -996,7 +996,7 @@
     {\ifnumgreater{\value{liststop}}{1}
        {\finalandcomma}
        {}%
-     \andothersdelim\bibstring{andothers}}
+     \printdelim{andothersdelim}\bibstring{andothers}}
     {}}
 
 % ------------------------------------------------------------------
@@ -1612,8 +1612,8 @@
 
 \newcommand*{\lbx@initnamehook}[1]{}
 \newcommand*{\lbx@inittitlehook}[1]{}
-\newcommand*{\lbx@finalnamedelim}[1]{\finalnamedelim}
-\newcommand*{\lbx@finallistdelim}[1]{\finallistdelim}
+\newcommand*{\lbx@finalnamedelim}[1]{\printdelim{finalnamedelim}}
+\newcommand*{\lbx@finallistdelim}[1]{\printdelim{finallistdelim}}
 
 \newcommand*{\lbx@lfromlang}{%
   \iffieldundef{origlanguage}


### PR DESCRIPTION
Make more delimiters use the context-sensitive `\printdelim`. 
Cf. #572, #373.

The commands changed are ubiquitous, so this needs testing. First tentative playing around with this revealed no immediately obvious problem.