### PR TITLE
add \DeclareDelimAlias

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4689,7 +4689,7 @@ Declares the delimiter macros in the comma"=separated list \prm{names} with the 
 
 \cmditem{DeclareDelimAlias}{alias}{delim}
 
-Declares \prm{alias} to be an alias for the delimiter \prm{delimiter}. The assigment is valid for all existing contexts of \prm{alias}.
+Declares \prm{alias} to be an alias for the delimiter \prm{delim}. The assigment is valid for all existing contexts of \prm{alias}.
 
 \cmditem{printdelim}[context]{name}
 

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4687,6 +4687,10 @@ The delimiters described in \secref{use:fmt:fmt} are globally defined. That is, 
 
 Declares the delimiter macros in the comma"=separated list \prm{names} with the replacement test \prm{code}. If the optional comma"=separated list of \prm{contexts} is given, declare the \prm{names} only for those contexts. \prm{names} defined without any \prm{contexts} behave just like the global delimiter definitions which \cmd{newcommand} gives---just a plain macro with a replacement which can be used as \cmd{name}. However, you can also call delimiter macros defined in this way by using \cmd{printdelim}, which is context-aware. The starred version clears all \prm{context} specific declarations for all \prm{names} first.
 
+\cmditem{DeclareDelimAlias}{alias}{delim}
+
+Declares \prm{alias} to be an alias for the delimiter \prm{delimiter}. The assigment is valid for all existing contexts of \prm{alias}.
+
 \cmditem{printdelim}[context]{name}
 
 Prints a delimiter with name \prm{name}, locally establishing a optional \prm{context} first. Without the optional \prm{context}, \cmd{printdelim} uses the currently active delimiter context.
@@ -12916,6 +12920,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \cmd{DeclareLanguageMappingSuffix}\see{aut:lng:cmd}
 \item Changed default for \cmd{DeclarePrefChars}\see{aut:pct:cfg}
 \item Added \cmd{authortypedelim}, \cmd{editortypedelim} and \cmd{translatortypedelim}\see{use:fmt:fmt}
+\item Added \cmd{DeclareDelimAlias}\see{use:fmt:csd}
 \end{release}
 
 \begin{release}{3.7}{2016-12-08}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3129,6 +3129,23 @@
   \docsvlist{#3}
   \endgroup}
 
+% {<alias>}{<delim>}
+\newrobustcmd*{\DeclareDelimAlias}{\blx@declaredelimalias}
+
+\newrobustcmd*{\blx@declaredelimalias}[2]{%
+  \blx@declaredelimalias@i{}{#1}{#2}%
+  \ifcsvoid{blx@declaredelimcontexts@#2}
+    {}
+    {\def\do##1{%
+       \blx@declaredelimalias@i{blx@printdelim@##1@}{#1}{#2}}%
+     \dolistcsloop{blx@declaredelimcontexts@#2}}}
+
+\def\blx@declaredelimalias@i#1#2#3{%
+  \ifcsdef{#1#2}
+    {\blx@warn@delimdeclare{#2}{#1}}
+    {}%
+  \global\csletcs{#1#2}{#1#3}}
+
 \def\blx@delimcontext{none}
 \newcommand*{\printdelim}[2][]{%
   \ifblank{#1}


### PR DESCRIPTION
Add a way to alias delimiters to other delimiters declared with `\DeclareDelimFormat`.
This copies over all existing contexts.

Use as `\DeclareDelimAlias{finalnamedelim}{multinamedelim}` to make all instances of the `finalnamedelim` behave like `multinamedelim`.