### PR TITLE
refine \DeclareDelimAlias

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4688,8 +4688,10 @@ The delimiters described in \secref{use:fmt:fmt} are globally defined. That is, 
 Declares the delimiter macros in the comma"=separated list \prm{names} with the replacement test \prm{code}. If the optional comma"=separated list of \prm{contexts} is given, declare the \prm{names} only for those contexts. \prm{names} defined without any \prm{contexts} behave just like the global delimiter definitions which \cmd{newcommand} gives---just a plain macro with a replacement which can be used as \cmd{name}. However, you can also call delimiter macros defined in this way by using \cmd{printdelim}, which is context-aware. The starred version clears all \prm{context} specific declarations for all \prm{names} first.
 
 \cmditem{DeclareDelimAlias}{alias}{delim}
+\cmditem*{DeclareDelimAlias}*[context, \dots]{alias}{delim}
 
 Declares \prm{alias} to be an alias for the delimiter \prm{delim}. The assigment is valid for all existing contexts of \prm{alias}.
+The starred version assigns the alias for the given \opt{contexts} only---if the optional argument is empty, assigment is for the global/empty context.
 
 \cmditem{printdelim}[context]{name}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3126,13 +3126,23 @@
       {\blx@warn@delimdeclare{##1}{#2}}
       {}%
     \csgdef{#1##1}{#4}}%
-  \docsvlist{#3}
+  \docsvlist{#3}%
   \endgroup}
 
-% {<alias>}{<delim>}
-\newrobustcmd*{\DeclareDelimAlias}{\blx@declaredelimalias}
+% *[<contextname, ...>]{<alias>}{<delim>}
+\newrobustcmd*{\DeclareDelimAlias}{%
+  \@ifstar
+    {\blx@declaredelimalias}
+    {\blx@declaredelimaliasauto}}
 
-\newrobustcmd*{\blx@declaredelimalias}[2]{%
+\newrobustcmd*{\blx@declaredelimalias}[3][]{%
+  \ifblank{#1}
+    {\blx@declaredelimalias@i{}{#2}{#3}}
+    {\def\do##1{%
+      \blx@declaredelimalias@i{blx@printdelim@##1@}{#2}{#3}}
+     \docsvlist{#1}}}
+
+\newrobustcmd*{\blx@declaredelimaliasauto}[2]{%
   \blx@declaredelimalias@i{}{#1}{#2}%
   \ifcsvoid{blx@declaredelimcontexts@#2}
     {}


### PR DESCRIPTION
Refine \DeclareDelimAlias to allow for manual control over assigned contexts if needed. The unstarred variant is still fully automatic. With the starred variant the option context argument is enabled.