### PR TITLE
Fix labelyear format

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -403,17 +403,10 @@
   \ifbibstring{#1}{\bibstring{#1}}{\mkyearzeros{#1}}}
 \DeclareFieldFormat{labelendyear}{% = the '1995' part in 'Jones 1995a'
   \ifbibstring{#1}{\bibstring{#1}}{\mkyearzeros{#1}}}
-% If labeldatesource is a defined field, they 
-% Don't check labelyear directly as it is already processed into a range with markers
-% and so is never nums due to unexpandable parts of labelyear determination
 \DeclareFieldFormat{extrayear}{%
-  \iffieldundef{\thefield{labeldatesource}}
-    {\iffieldnums{\thefield{labeldatesource}year}
-      {\mknumalph{#1}}
-      {\mkbibparens{\mknumalph{#1}}}}
-    {\iffieldnums{\thefield{labeldatesource}}
-      {\mknumalph{#1}}
-      {\mkbibparens{\mknumalph{#1}}}}}%
+  \iffieldnums{labelyear}
+    {\mknumalph{#1}}
+    {\mkbibparens{\mknumalph{#1}}}}
 \DeclareFieldFormat{labelalpha}{#1}%
 \DeclareFieldFormat{extraalpha}{\mknumalph{#1}}%
 \DeclareFieldFormat{shorthand}{#1\isdot}


### PR DESCRIPTION
Addresses #603.

There was an explicit comment not to check `labelyear`, but the contents of that field has changed over time. First tests went OK.