### PR TITLE
.bst changes needed for #605

### DIFF
--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -1446,6 +1446,7 @@ FUNCTION {output:specials} {
       if$
       output:write:field
       "extrayear"   extrayear       output:write:field
+      "labeldatesource" "year"      output:write:field
     }
     'skip$
   if$
@@ -1888,7 +1889,7 @@ FUNCTION {input:control:options} {
 % This version corresponds to the .bbl version, *not* the biblatex version!
 FUNCTION {input:control:version} {
   input:control:parse
-  "$Revision: 2.8 $"
+  "$Revision: 2.9 $"
   #12 entry.max$ substring$
   #-3 entry.max$ substring$
   'tempstrga :=

--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -1430,21 +1430,19 @@ FUNCTION {output:specials} {
   ctrl:labeldate
   dateyear empty$ not
   and
-    { "labelyear"
-      dateyear
+    { "labelyear" dateyear output:write:field
       dateendyear empty$
         'skip$
         { dateyear dateendyear =
             'skip$
             { dateendyear open.ended =
                 'skip$
-                { "\bibdatedash " * dateendyear * }
+                { "labelendyear" dateendyear output:write:field }
               if$
             }
           if$
         }
       if$
-      output:write:field
       "extrayear"   extrayear       output:write:field
       "labeldatesource" "year"      output:write:field
     }


### PR DESCRIPTION
Collect the necessary commits for `biblatex.bst` so that #605 does the right thing for BibTeX as well.

We set `labeldatesource` to `year` if appropriate and make sure that `labelyear` only contains a year, the end of a year range now lives in `labelendyear`.