### PR TITLE
Guard against undefined localnumber (#568)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -7126,16 +7126,18 @@
           % regenerates localnumber requiring another run but then
           % the pagebreaks change back again ... etc.
           \ifcsundef{blx@defer@\the\c@refsection @\blx@refcontext@context @\abx@field@entrykey}
-            {\listxadd\blx@localnumaux{%
-               \string\abx@aux@number%
-                 {\the\c@instcount}%
-                 {\abx@field@entrykey}%
-                 {\the\c@refsection}%
-                 {\blx@refcontext@context}%
-                 {\abx@field@localnumber}}%
-               % record that we have already generated and output localnum
-               % for this key in this refsection/refcontext
-               \csgdef{blx@defer@\the\c@refsection @\blx@refcontext@context @\abx@field@entrykey}{}}
+            {\ifundef\abx@field@localnumber
+               {}
+                {\listxadd\blx@localnumaux{%
+                   \string\abx@aux@number%
+                     {\the\c@instcount}%
+                     {\abx@field@entrykey}%
+                     {\the\c@refsection}%
+                     {\blx@refcontext@context}%
+                     {\abx@field@localnumber}}%
+                   % record that we have already generated and output localnum
+                   % for this key in this refsection/refcontext
+                   \csgdef{blx@defer@\the\c@refsection @\blx@refcontext@context @\abx@field@entrykey}{}}}
            {}}
          {}}%
        {}}


### PR DESCRIPTION
Only write `\abx@field@localnumber` to `.aux` if it is not undefined.

Fixes the error for the MWE in #568. But since this involves `.aux` internals testing is probably needed before things can be merged.