### PR TITLE
Demote delim overwrite message to info

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -1079,8 +1079,8 @@
 \def\blx@inf@refsec{%
   \blx@info{Reference section=\the\c@refsection}}%
 
-\def\blx@warn@delimdeclare#1#2{%
-  \blx@warning{Delimiter '#1' in context '#2' already defined, overwriting}}
+\def\blx@inf@delimdeclare#1#2{%
+  \blx@info{Delimiter '#1' in context '#2' already defined, overwriting}}
 
 \def\blx@warn@delimuse#1#2{%
   \blx@warning{Delimiter '#1' in context '#2' undefined}}
@@ -3149,7 +3149,7 @@
   \begingroup
   \def\do##1{%
     \ifcsdef{#1##1}
-      {\blx@warn@delimdeclare{##1}{#2}}
+      {\blx@inf@delimdeclare{##1}{#2}}
       {}%
     \csgdef{#1##1}{#4}}%
   \docsvlist{#3}%
@@ -3178,7 +3178,7 @@
 
 \def\blx@declaredelimalias@i#1#2#3{%
   \ifcsdef{#1#2}
-    {\blx@warn@delimdeclare{#2}{#1}}
+    {\blx@inf@delimdeclare{#2}{#1}}
     {}%
   \global\csletcs{#1#2}{#1#3}}
 


### PR DESCRIPTION
Demote the `Delimiter '#1' in context '#2' already defined, overwriting` message from warning to info. Since the assignment is actually just a `\gdef` I don't think we really need to issue a warning.

Some people try to obtain document logs without warnings, and I have seen people preferring the old way because it avoids warnings. 