### PR TITLE
Replace \ifnameundef with \setunit*

### DIFF
--- a/tex/latex/biblatex/cbx/authortitle-comp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-comp.cbx
@@ -25,10 +25,8 @@
   \iffieldundef{shorthand}
     {\iffieldequals{namehash}{\cbx@lasthash}
        {\setunit{\compcitedelim}}
-       {\ifnameundef{labelname}
-          {}
-          {\printnames{labelname}%
-           \setunit{\printdelim{nametitledelim}}}%
+       {\printnames{labelname}%
+        \setunit*{\printdelim{nametitledelim}}%
         \savefield{namehash}{\cbx@lasthash}}%
      \usebibmacro{cite:title}}
     {\usebibmacro{cite:shorthand}%
@@ -44,12 +42,10 @@
 \newbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
     {\setunit{\compcitedelim}}
-    {\ifnameundef{labelname}
-       {}
-       {\printnames{labelname}%
-        \setunit{%
-          \global\booltrue{cbx:parens}%
-          \printdelim{nametitledelim}\bibopenparen}}%
+    {\printnames{labelname}%
+     \setunit*{%
+       \global\booltrue{cbx:parens}%
+       \printdelim{nametitledelim}\bibopenparen}%
      \stepcounter{textcitecount}%
      \savefield{namehash}{\cbx@lasthash}}%
   \ifnumequal{\value{citecount}}{1}

--- a/tex/latex/biblatex/cbx/authortitle-ibid.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-ibid.cbx
@@ -20,10 +20,8 @@
   \iffieldundef{shorthand}
     {\ifthenelse{\ifciteibid\AND\NOT\iffirstonpage}
        {\usebibmacro{cite:ibid}}
-       {\ifnameundef{labelname}
-          {}
-          {\printnames{labelname}%
-           \setunit{\printdelim{nametitledelim}}}%
+       {\printnames{labelname}%
+        \setunit*{\printdelim{nametitledelim}}%
         \usebibmacro{cite:title}}}%
     {\usebibmacro{cite:shorthand}}}
 
@@ -37,12 +35,10 @@
 
 \newbibmacro*{textcite}{%
   \global\boolfalse{cbx:loccit}%
-  \ifnameundef{labelname}
-    {}
-    {\printnames{labelname}%
-     \setunit{%
-       \global\booltrue{cbx:parens}%
-       \printdelim{nametitledelim}\bibopenparen}}%
+  \printnames{labelname}%
+    \setunit*{%
+      \global\booltrue{cbx:parens}%
+      \printdelim{nametitledelim}\bibopenparen}%
   \ifnumequal{\value{citecount}}{1}
     {\usebibmacro{prenote}}
     {}%

--- a/tex/latex/biblatex/cbx/authortitle-icomp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-icomp.cbx
@@ -36,10 +36,8 @@
        {\usebibmacro{cite:ibid}}
        {\iffieldequals{namehash}{\cbx@lasthash}
           {\setunit{\compcitedelim}}
-          {\ifnameundef{labelname}
-             {}
-             {\printnames{labelname}%
-              \setunit{\printdelim{nametitledelim}}}%
+          {\printnames{labelname}%
+           \setunit*{\printdelim{nametitledelim}}%
            \savefield{namehash}{\cbx@lasthash}}%
         \usebibmacro{cite:title}}}%
     {\usebibmacro{cite:shorthand}%
@@ -57,12 +55,10 @@
 \newbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
     {\setunit{\compcitedelim}}
-    {\ifnameundef{labelname}
-       {}
-       {\printnames{labelname}%
-        \setunit{%
-          \global\booltrue{cbx:parens}%
-          \printdelim{nametitledelim}\bibopenparen}}%
+    {\printnames{labelname}%
+      \setunit*{%
+        \global\booltrue{cbx:parens}%
+        \printdelim{nametitledelim}\bibopenparen}%
      \stepcounter{textcitecount}%
      \savefield{namehash}{\cbx@lasthash}}%
   \ifnumequal{\value{citecount}}{1}

--- a/tex/latex/biblatex/cbx/authortitle.cbx
+++ b/tex/latex/biblatex/cbx/authortitle.cbx
@@ -9,10 +9,8 @@
 
 \newbibmacro*{cite}{%
   \iffieldundef{shorthand}
-    {\ifnameundef{labelname}
-       {}
-       {\printnames{labelname}%
-        \setunit{\printdelim{nametitledelim}}}%
+    {\printnames{labelname}%
+     \setunit*{\printdelim{nametitledelim}}%
      \usebibmacro{cite:title}}%
     {\usebibmacro{cite:shorthand}}}
 
@@ -22,12 +20,10 @@
     {\usebibmacro{cite:shorthand}}}
 
 \newbibmacro*{textcite}{%
-  \ifnameundef{labelname}
-    {}
-    {\printnames{labelname}%
-     \setunit{%
-       \global\booltrue{cbx:parens}%
-       \printdelim{nametitledelim}\bibopenparen}}%
+  \printnames{labelname}%
+  \setunit*{%
+    \global\booltrue{cbx:parens}%
+    \printdelim{nametitledelim}\bibopenparen}%
   \ifnumequal{\value{citecount}}{1}
     {\usebibmacro{prenote}}
     {}%


### PR DESCRIPTION
Replace` \ifnameundef{labelname}` with empty true branch by using starred `\setunit*`, the `\ifnameundef` is implicit now.

This change needs testing. It worked fine in my manual tests so far.