### PR TITLE
Fix and simplify headings

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1739,8 +1739,9 @@
 
 \defbibheading{none}{}
 
-\def\abx@MakeMarkcase\MakeUppercase
-\ifcsundef{MakeMarkcase}{}{\def\abx@MakeMarkcase\MakeMarkcase}%
+\def\abx@MakeMarkcase{\MakeUppercase}
+\AtEndPreamble{%
+  \ifcsundef{MakeMarkcase}{}{\def\abx@MakeMarkcase{\MakeMarkcase}}}
 
 \ifcase\abx@classtype\relax % article
   \defbibheading{bibliography}[\refname]{%
@@ -1879,7 +1880,7 @@
     \section{#1}}
 
 \or % memoir (article)
-  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase\memUChead}%
+  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase{\memUChead}}%
   \defbibheading{bibliography}[\refname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
@@ -1924,7 +1925,7 @@
     \section{#1}}
 
 \or % memoir (book)
-  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase\memUChead}%
+  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase{\memUChead}}%
   \defbibheading{bibliography}[\bibname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1805,21 +1805,25 @@
 
 \or % scrartcl
   \defbibheading{bibliography}[\refname]{%
-    \ifkomabibtotocnumbered
-      {\section{#1}%
-       \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
-      {\ifkomabibtotoc
-         {\addsec{#1}}
-         {\section*{#1}}%
-       \@mkdouble{\abx@MakeMarkcase{#1}}}}
+    \ifcsundef{bibliography@heading}
+      {\ifkomabibtotocnumbered
+         {\section{#1}%
+          \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+         {\ifkomabibtotoc
+            {\addsec{#1}}
+            {\section*{#1}}%
+          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+      {\bibliography@heading{#1}}}
   \defbibheading{biblist}[\biblistname]{%
-    \ifkomabibtotocnumbered
-      {\section{#1}%
-       \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
-      {\ifkomabibtotoc
-         {\addsec{#1}}
-         {\section*{#1}}%
-       \@mkdouble{\abx@MakeMarkcase{#1}}}}
+    \ifcsundef{bibliography@heading}
+      {\ifkomabibtotocnumbered
+         {\section{#1}%
+          \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+         {\ifkomabibtotoc
+            {\addsec{#1}}
+            {\section*{#1}}%
+          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+      {\bibliography@heading{#1}}}
   \defbibheading{bibintoc}[\refname]{%
     \addsec{#1}%
     \@mkdouble{\abx@MakeMarkcase{#1}}}
@@ -1844,21 +1848,25 @@
 
 \or % scrbook/scrreprt
   \defbibheading{bibliography}[\bibname]{%
-    \ifkomabibtotocnumbered
-      {\chapter{#1}%
-       \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
-      {\ifkomabibtotoc
-         {\addchap{#1}}
-         {\chapter*{#1}}%
-       \@mkdouble{\abx@MakeMarkcase{#1}}}}
+    \ifcsundef{bibliography@heading}
+      {\ifkomabibtotocnumbered
+         {\chapter{#1}%
+          \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+         {\ifkomabibtotoc
+            {\addchap{#1}}
+            {\chapter*{#1}}%
+          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+      {\bibliography@heading{#1}}}
   \defbibheading{biblist}[\biblistname]{%
-    \ifkomabibtotocnumbered
-      {\chapter{#1}%
-       \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
-      {\ifkomabibtotoc
-         {\addchap{#1}}
-         {\chapter*{#1}}%
-       \@mkdouble{\abx@MakeMarkcase{#1}}}}
+    \ifcsundef{bibliography@heading}
+      {\ifkomabibtotocnumbered
+         {\chapter{#1}%
+          \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+         {\ifkomabibtotoc
+            {\addchap{#1}}
+            {\chapter*{#1}}%
+          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+      {\bibliography@heading{#1}}}
   \defbibheading{bibintoc}[\bibname]{%
     \addchap{#1}%
     \@mkdouble{\abx@MakeMarkcase{#1}}}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1802,71 +1802,84 @@
 \or % scrartcl
   \defbibheading{bibliography}[\refname]{%
     \ifkomabibtotocnumbered
-      {\section{#1}}
+      {\section{#1}%
+       \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}%
+               {\MakeMarkcase{\sectionmarkformat#1}}}
       {\ifkomabibtotoc
          {\addsec{#1}}
          {\section*{#1}}%
-       \@mkboth{#1}{#1}}}
+       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifkomabibtotocnumbered
-      {\section{#1}}
+      {\section{#1}%
+       \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}%
+               {\MakeMarkcase{\sectionmarkformat#1}}}
       {\ifkomabibtotoc
          {\addsec{#1}}
          {\section*{#1}}%
-       \@mkboth{#1}{#1}}}
+       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
   \defbibheading{bibintoc}[\refname]{%
     \addsec{#1}%
-    \@mkboth{#1}{#1}}
+    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \addsec{#1}%
-    \@mkboth{#1}{#1}}
+    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\refname]{%
     \section{#1}%
-    \@mkboth{\sectionmarkformat#1}{\sectionmarkformat#1}}
+    \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}
+            {\MakeMarkcase{\sectionmarkformat#1}}}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \section{#1}%
-    \@mkboth{\sectionmarkformat#1}{\sectionmarkformat#1}}
+    \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}
+            {\MakeMarkcase{\sectionmarkformat#1}}}
   \defbibheading{subbibliography}[\refname]{%
-    \subsection*{#1}}
+    \subsection*{#1}%
+    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
   \defbibheading{subbibintoc}[\refname]{%
     \subsection*{#1}%
-    \addcontentsline{toc}{subsection}{#1}}
+    \addcontentsline{toc}{subsection}{#1}%
+    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \subsection{#1}}
 
 \or % scrbook/scrreprt
   \defbibheading{bibliography}[\bibname]{%
     \ifkomabibtotocnumbered
-      {\chapter{#1}}
+      {\chapter{#1}%
+       \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
+               {\MakeMarkcase{\chaptermarkformat#1}}}
       {\ifkomabibtotoc
          {\addchap{#1}}
          {\chapter*{#1}}%
-       \@mkboth{#1}{#1}}}
+       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifkomabibtotocnumbered
-      {\chapter{#1}}
+      {\chapter{#1}%
+       \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
+               {\MakeMarkcase{\chaptermarkformat#1}}}
       {\ifkomabibtotoc
          {\addchap{#1}}
          {\chapter*{#1}}%
-       \@mkboth{#1}{#1}}}
+       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
   \defbibheading{bibintoc}[\bibname]{%
     \addchap{#1}%
-    \@mkboth{#1}{#1}}
+    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \addchap{#1}%
-    \@mkboth{#1}{#1}}
+    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\bibname]{%
     \chapter{#1}%
-    \@mkboth{\chaptermarkformat#1}{\chaptermarkformat#1}}
+    \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
+            {\MakeMarkcase{\chaptermarkformat#1}}}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \chapter{#1}%
-    \@mkboth{\chaptermarkformat#1}{\chaptermarkformat#1}}
+    \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
+            {\MakeMarkcase{\chaptermarkformat#1}}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
-    \if@twoside\markright{#1}\fi}
+    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
   \defbibheading{subbibintoc}[\refname]{%
-    \addsec{#1}%
-    \@mkboth{#1}{#1}}
+    \addsec{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1739,27 +1739,30 @@
 
 \defbibheading{none}{}
 
+\let\abx@MakeMarkcase\MakeUppercase
+\ifcsundef{MakeMarkcase}{}{\let\abx@MakeMarkcase\MakeMarkcase}%
+
 \ifcase\abx@classtype\relax % article
   \defbibheading{bibliography}[\refname]{%
     \section*{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \section*{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibintoc}[\refname]{%
     \section*{#1}%
     \addcontentsline{toc}{section}{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \section*{#1}%
     \addcontentsline{toc}{section}{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\refname]{%
     \section{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \section{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibliography}[\refname]{%
     \subsection*{#1}}
   \defbibheading{subbibintoc}[\refname]{%
@@ -1771,31 +1774,31 @@
 \or % book/report
   \defbibheading{bibliography}[\bibname]{%
     \chapter*{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \chapter*{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibintoc}[\bibname]{%
     \chapter*{#1}%
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \chapter*{#1}%
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\MakeUppercase{#1}}{\MakeUppercase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\bibname]{%
     \chapter{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \chapter{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibintoc}[\refname]{%
     \section*{#1}%
     \addcontentsline{toc}{section}{#1}%
-    \if@twoside\markright{\MakeUppercase{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 
@@ -1803,42 +1806,38 @@
   \defbibheading{bibliography}[\refname]{%
     \ifkomabibtotocnumbered
       {\section{#1}%
-       \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}%
-               {\MakeMarkcase{\sectionmarkformat#1}}}
+       \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
       {\ifkomabibtotoc
          {\addsec{#1}}
          {\section*{#1}}%
-       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
+       \@mkdouble{\abx@MakeMarkcase{#1}}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifkomabibtotocnumbered
       {\section{#1}%
-       \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}%
-               {\MakeMarkcase{\sectionmarkformat#1}}}
+       \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
       {\ifkomabibtotoc
          {\addsec{#1}}
          {\section*{#1}}%
-       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
+       \@mkdouble{\abx@MakeMarkcase{#1}}}}
   \defbibheading{bibintoc}[\refname]{%
     \addsec{#1}%
-    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \addsec{#1}%
-    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\refname]{%
     \section{#1}%
-    \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}
-            {\MakeMarkcase{\sectionmarkformat#1}}}
+    \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \section{#1}%
-    \@mkboth{\MakeMarkcase{\sectionmarkformat#1}}
-            {\MakeMarkcase{\sectionmarkformat#1}}}
+    \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
   \defbibheading{subbibliography}[\refname]{%
     \subsection*{#1}%
-    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
+    \@mkright{\abx@MakeMarkcase{#1}}}
   \defbibheading{subbibintoc}[\refname]{%
     \subsection*{#1}%
     \addcontentsline{toc}{subsection}{#1}%
-    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
+    \@mkright{\abx@MakeMarkcase{#1}}}
   \defbibheading{subbibnumbered}[\refname]{%
     \subsection{#1}}
 
@@ -1846,69 +1845,65 @@
   \defbibheading{bibliography}[\bibname]{%
     \ifkomabibtotocnumbered
       {\chapter{#1}%
-       \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
-               {\MakeMarkcase{\chaptermarkformat#1}}}
+       \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
       {\ifkomabibtotoc
          {\addchap{#1}}
          {\chapter*{#1}}%
-       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
+       \@mkdouble{\abx@MakeMarkcase{#1}}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifkomabibtotocnumbered
       {\chapter{#1}%
-       \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
-               {\MakeMarkcase{\chaptermarkformat#1}}}
+       \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
       {\ifkomabibtotoc
          {\addchap{#1}}
          {\chapter*{#1}}%
-       \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}}
+       \@mkdouble{\abx@MakeMarkcase{#1}}}}
   \defbibheading{bibintoc}[\bibname]{%
     \addchap{#1}%
-    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \addchap{#1}%
-    \@mkboth{\MakeMarkcase{#1}}{\MakeMarkcase{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\bibname]{%
     \chapter{#1}%
-    \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
-            {\MakeMarkcase{\chaptermarkformat#1}}}
+    \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \chapter{#1}%
-    \@mkboth{\MakeMarkcase{\chaptermarkformat#1}}%
-            {\MakeMarkcase{\chaptermarkformat#1}}}
+    \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
-    \ifx\@mkboth\@gobbletwo\else\markright{\MakeMarkcase{#1}}\fi}
+    \@mkright{\abx@MakeMarkcase{#1}}}
   \defbibheading{subbibintoc}[\refname]{%
     \addsec{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 
 \or % memoir (article)
-  \ifdef\memUChead{}{\let\memUChead\MakeUppercase}
+  \ifcsundef{memUChead}{}{\let\abx@MakeMarkcase\memUChead}%
   \defbibheading{bibliography}[\refname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
       {}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
       {}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibintoc}[\refname]{%
     \chapter*{#1}%
     \phantomsection
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \chapter*{#1}%
     \phantomsection
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\refname]{%
     \chapter{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
@@ -1919,59 +1914,59 @@
       {\phantomsection
        \addcontentsline{toc}{section}{#1}}
       {}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibintoc}[\refname]{%
     \section*{#1}%
     \phantomsection
     \addcontentsline{toc}{section}{#1}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 
 \or % memoir (book)
-  \ifdef\memUChead{}{\let\memUChead\MakeUppercase}
+  \ifcsundef{memUChead}{}{\let\abx@MakeMarkcase\memUChead}%
   \defbibheading{bibliography}[\bibname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
       {}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
       {}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibintoc}[\bibname]{%
     \chapter*{#1}%
     \phantomsection
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \chapter*{#1}%
     \phantomsection
     \addcontentsline{toc}{chapter}{#1}%
-    \@mkboth{\memUChead{#1}}{\memUChead{#1}}}
+    \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\bibname]{%
     \chapter{#1}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \chapter{#1}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{section}{#1}}
       {}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibintoc}[\refname]{%
     \section*{#1}%
     \phantomsection
     \addcontentsline{toc}{section}{#1}%
-    \if@twoside\markright{\memUChead{#1}}\fi}
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1739,8 +1739,8 @@
 
 \defbibheading{none}{}
 
-\let\abx@MakeMarkcase\MakeUppercase
-\ifcsundef{MakeMarkcase}{}{\let\abx@MakeMarkcase\MakeMarkcase}%
+\def\abx@MakeMarkcase\MakeUppercase
+\ifcsundef{MakeMarkcase}{}{\def\abx@MakeMarkcase\MakeMarkcase}%
 
 \ifcase\abx@classtype\relax % article
   \defbibheading{bibliography}[\refname]{%
@@ -1879,7 +1879,7 @@
     \section{#1}}
 
 \or % memoir (article)
-  \ifcsundef{memUChead}{}{\let\abx@MakeMarkcase\memUChead}%
+  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase\memUChead}%
   \defbibheading{bibliography}[\refname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc
@@ -1924,7 +1924,7 @@
     \section{#1}}
 
 \or % memoir (book)
-  \ifcsundef{memUChead}{}{\let\abx@MakeMarkcase\memUChead}%
+  \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase\memUChead}%
   \defbibheading{bibliography}[\bibname]{%
     \chapter*{#1}%
     \ifmemoirbibintoc

--- a/tex/latex/biblatex/blx-compat.def
+++ b/tex/latex/biblatex/blx-compat.def
@@ -77,17 +77,41 @@
      {}%
    \DeclareOption{bibtotoc}{%
      \let\ifkomabibtotoc=\@firstoftwo
-     \let\ifkomabibtotocnumbered=\@secondoftwo}
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
    \DeclareOption{bibtotocnumbered}{%
      \let\ifkomabibtotoc=\@firstoftwo
      \let\ifkomabibtotocnumbered=\@firstoftwo}%
-   \DeclareOption{bibliography=totoc}{%
-     \let\ifkomabibtotoc=\@firstoftwo
-     \let\ifkomabibtotocnumbered=\@secondoftwo}
+   \DeclareOption{bibliography=notoc}{%
+     \let\ifkomabibtotoc=\@secondoftwo
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
    \DeclareOption{bibliography=nottotoc}{%
      \let\ifkomabibtotoc=\@secondoftwo
-     \let\ifkomabibtotocnumbered=\@secondoftwo}
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
+   \DeclareOption{bibliography=plainheading}{%
+     \let\ifkomabibtotoc=\@secondoftwo
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
+   \DeclareOption{bibliography=totoc}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
+   \DeclareOption{bibliography=toc}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
+   \DeclareOption{bibliography=notnumbered}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@secondoftwo}%
+   \DeclareOption{bibliography=numbered}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@firstoftwo}%
    \DeclareOption{bibliography=totocnumbered}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@firstoftwo}%
+   \DeclareOption{bibliography=tocnumbered}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@firstoftwo}%
+   \DeclareOption{bibliography=numberedtotoc}{%
+     \let\ifkomabibtotoc=\@firstoftwo
+     \let\ifkomabibtotocnumbered=\@firstoftwo}%
+   \DeclareOption{bibliography=numberedtoc}{%
      \let\ifkomabibtotoc=\@firstoftwo
      \let\ifkomabibtotocnumbered=\@firstoftwo}%
    \DeclareOption{bibliography=oldstyle}{%

--- a/tex/latex/biblatex/blx-compat.def
+++ b/tex/latex/biblatex/blx-compat.def
@@ -16,6 +16,8 @@
     {Use the package option 'style' instead.\MessageBreak
      I'm ignoring this command}}
 
+\providecommand*{\@mkdouble}[1]{\@mkboth{#1}{#1}}
+
 % standard classes
 
 \DeclareOption{openbib}{\ExecuteBibliographyOptions{block=par}}
@@ -37,6 +39,31 @@
   {\newcommand{\ifmemoirbibintoc}[2]{#2}}
 
 % KOMA-Script
+
+\providecommand*{\@mkright}{%
+  \begingroup
+    \ifx\@mkboth\markboth \aftergroup\markright
+    \else
+      \ifx\@mkboth\@gobbletwo \aftergroup\@gobble
+      \else \def\@gobbletwo##1##2{}%
+        \ifx \@mkboth\@gobbletwo \aftergroup\@gobble
+        \else
+          \PackageWarning{biblatex}{% changed for biblatex
+            package incompatibility detected!\MessageBreak
+            \string\@mkboth it neither \string\markboth nor any\MessageBreak
+            kind of two arguments gobbling,\MessageBreak
+            e.g., \string\@gobbletwo.\MessageBreak
+            So I don't known, what to do\MessageBreak
+            with \string\@mkright.\MessageBreak
+            Nevertheless, \string\markright\space will be\MessageBreak
+            used%
+          }%
+          \aftergroup\markright
+        \fi
+      \fi
+    \fi
+  \endgroup
+}%
 
 \newcommand{\ifkomabibtotoc}[2]{#2}
 \newcommand{\ifkomabibtotocnumbered}[2]{#2}


### PR DESCRIPTION
See #627 

- Introduces a new `\abx@MakeMarkcase` to control the format of running heads. Defaults to `\MakeUppercase` with standard classes, `\MakeMarkcase` if available (KOMA classes/packages) and `\memUChead` for `memoir`. 
- Use `\@mkdouble`, `\@mkright` for running heads (stolen from KOMA)
- If possible uses new `\bibliography@heading` with KOMA classes.
