### PR TITLE
Save and restore catcode of _ (#629)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5573,6 +5573,7 @@
       {No default polyglossia language defined}
       {You must define a default language for polyglossia}}
     {}%
+  \edef\blx@saved@underscore@catcode{\the\catcode`\_}%
   \catcode`\_=11% polyglossia uses "_" as a letter
   \pretocmd\select@language{\blx@langsetup{#1}}
     {\ifdef\blx@thelangenv
@@ -5633,7 +5634,7 @@
      \blx@langsetup\bbl@main@language}
     {\blx@err@patch{'polyglossia' package}%
      \blx@mknoautolang}%
-  \catcode`\_=8}
+  \catcode`\_=\blx@saved@underscore@catcode\relax}
 \endgroup
 
 \def\blx@mknoautolang{%


### PR DESCRIPTION
Cf. #629.
This saves the original catcode of _ and restores it later instead of going back to 8. The idea is inspired by code from `inputenc.sty`.