### PR TITLE
Fix cite:extrayear backwards code

### DIFF
--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -18,7 +18,11 @@
         'true' (=compact), and 'false'.}}}
 
 \providebibmacro*{date+extradate}{}
-\providebibmacro*{date+extrayear}{\usebibmacro{date+extradate}}
+\providebibmacro*{date+extrayear}{%
+  \blx@warning{bibmacro 'date+extrayear' is deprecated.\MessageBreak
+    Please use 'date+extradate'.\MessageBreak
+    Using 'date+extradate' instead}%
+  \usebibmacro{date+extradate}}
 
 \def\bbx@opt@mergedate@true{\bbx@opt@mergedate@compact}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -662,7 +662,7 @@
         \ifcsundef{abx@field@legacy@warning@#1}
           {\blx@warning@noline{Field '#1' is deprecated.\MessageBreak
              Please use '#2' instead.\MessageBreak
-             Using '#2' now.}}
+             Using '#2' now}}
           {}%
         \global\csdef{abx@field@legacy@warning@#1}{}}}}}
 
@@ -675,7 +675,7 @@
         \ifcsundef{abx@list@legacy@warning@#1}
           {\blx@warning@noline{List '#1' is deprecated.\MessageBreak
              Please use '#2' instead.\MessageBreak
-             Using '#2' now.}}
+             Using '#2' now}}
           {}%
         \global\csdef{abx@list@legacy@warning@#1}{}}}}}
 
@@ -688,7 +688,7 @@
         \ifcsundef{abx@name@legacy@warning@#1}
           {\blx@warning@noline{Name '#1' is deprecated.\MessageBreak
              Please use '#2' instead.\MessageBreak
-             Using '#2' now.}}
+             Using '#2' now}}
           {}%
         \global\csdef{abx@name@legacy@warning@#1}{}}}}}
 

--- a/tex/latex/biblatex/cbx/authoryear-comp.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-comp.cbx
@@ -138,8 +138,8 @@
 
 \newbibmacro{cite:extrayear}{%
   \def\blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
-    Using 'cite:extrayear' instead.}%
-  \usebibmacro{cite:extrayear}}
+    Using 'cite:extradate' instead.}%
+  \usebibmacro{cite:extradate}}
 
 \newbibmacro*{textcite:postnote}{%
   \usebibmacro{postnote}%

--- a/tex/latex/biblatex/cbx/authoryear-comp.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-comp.cbx
@@ -127,8 +127,9 @@
     {\printtext[bibhyperref]{\printlabeldateextra}}}
 
 \newbibmacro{cite:labelyear+extrayear}{%
-  \def\blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
-    Using 'cite:labeldate+extradate' instead.}%
+  \blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
+    Please use 'cite:labeldate+extradate'.\MessageBreak
+    Using 'cite:labeldate+extradate' instead}%
   \usebibmacro{cite:labeldate+extradate}}
 
 \newbibmacro*{cite:extradate}{%
@@ -137,8 +138,9 @@
     {\printtext[bibhyperref]{\printfield{extradate}}}}
 
 \newbibmacro{cite:extrayear}{%
-  \def\blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
-    Using 'cite:extradate' instead.}%
+  \blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
+    Please use 'cite:extradate'.\MessageBreak
+    Using 'cite:extradate' instead}%
   \usebibmacro{cite:extradate}}
 
 \newbibmacro*{textcite:postnote}{%

--- a/tex/latex/biblatex/cbx/authoryear-ibid.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-ibid.cbx
@@ -86,8 +86,9 @@
     {\printtext[bibhyperref]{\printlabeldateextra}}}
 
 \newbibmacro{cite:labelyear+extrayear}{%
-  \def\blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
-    Using 'cite:labeldate+extradate' instead.}%
+  \blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
+    Please use 'cite:labeldate+extradate'.\MessageBreak
+    Using 'cite:labeldate+extradate' instead}%
   \usebibmacro{cite:labeldate+extradate}}
 
 \newbibmacro*{cite:postnote}{%

--- a/tex/latex/biblatex/cbx/authoryear-icomp.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-icomp.cbx
@@ -143,8 +143,9 @@
     {\printtext[bibhyperref]{\printlabeldateextra}}}
 
 \newbibmacro{cite:labelyear+extrayear}{%
-  \def\blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
-    Using 'cite:labeldate+extradate' instead.}%
+  \blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
+    Please use 'cite:labeldate+extradate'.\MessageBreak
+    Using 'cite:labeldate+extradate' instead}%
   \usebibmacro{cite:labeldate+extradate}}
 
 \newbibmacro*{cite:extradate}{%
@@ -153,8 +154,9 @@
     {\printtext[bibhyperref]{\printfield{extradate}}}}
 
 \newbibmacro{cite:extrayear}{%
-  \def\blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
-    Using 'cite:extradate' instead.}%
+  \blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
+    Please use 'cite:extradate'.\MessageBreak
+    Using 'cite:extradate' instead}%
   \usebibmacro{cite:extradate}}
 
 \newbibmacro*{cite:ibid}{%

--- a/tex/latex/biblatex/cbx/authoryear-icomp.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-icomp.cbx
@@ -154,8 +154,8 @@
 
 \newbibmacro{cite:extrayear}{%
   \def\blx@warning{bibmacro 'cite:extrayear' is deprecated.\MessageBreak
-    Using 'cite:extrayear' instead.}%
-  \usebibmacro{cite:extrayear}}
+    Using 'cite:extradate' instead.}%
+  \usebibmacro{cite:extradate}}
 
 \newbibmacro*{cite:ibid}{%
   \printtext[bibhyperref]{\bibstring[\mkibid]{ibidem}}%

--- a/tex/latex/biblatex/cbx/authoryear.cbx
+++ b/tex/latex/biblatex/cbx/authoryear.cbx
@@ -59,8 +59,9 @@
     {\printtext[bibhyperref]{\printlabeldateextra}}}
 
 \newbibmacro{cite:labelyear+extrayear}{%
-  \def\blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
-    Using 'cite:labeldate+extradate' instead.}%
+  \blx@warning{bibmacro 'cite:labelyear+extrayear' is deprecated.\MessageBreak
+    Please use 'cite:labeldate+extradate'.\MessageBreak
+    Using 'cite:labeldate+extradate' instead}%
   \usebibmacro{cite:labeldate+extradate}}
 
 \newbibmacro*{textcite:postnote}{%


### PR DESCRIPTION
Unfortunately, I messed up in https://github.com/plk/biblatex/commit/320f114d493ca7fa310c559c3a48b5912282fa22. A call to the outdated `cite:extryear` would cause an infinite loop.
I also had incorrect `\def`s bewore the warning message.

As far as I can tell, of the CTAN styles this would affect `biblatex-philosophy`.