### PR TITLE
Fix https://github.com/plk/biblatex/issues/659

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -1413,7 +1413,9 @@
     {\blx@defprefchars}
     {\let\blx@prefchars\@empty
      \blx@defprefchars}}
-\DeclarePrefChars{'’-}
+% Default for all engines; should be ascii-character only
+% For XeTeX/LuaTeX, the default is overwritten at the end of this file
+\DeclarePrefChars{'-}
 
 \protected\def\blx@imc@ifprefchar{%
   \ifhmode
@@ -13535,5 +13537,13 @@
     \let\do\undef
     \blx@dopreamblecmds
     \let\do\noexpand}}
+
+\ifx\Umathcode\undefined
+  \expandafter\endinput
+\fi
+
+% The rest of this file is effective only on UTF-8-aware engines
+% (XeTeX/LuaTeX)
+\DeclarePrefChars{'’-}% U+2019 added here
 
 \endinput


### PR DESCRIPTION
All engines default to \DeclarePrefChars{'-} first, and XeTeX/LuaTeX are handled at the end of biblatex.sty. This should be safe for all known engines, including pTeX/upTeX/pdfTeX.