### PR TITLE
Use Unicode chars only with Unicode engines (#659)

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -9993,6 +9993,11 @@ This command configures the \cmd{ifnumerals} and \cmd{ifpages} tests from \secre
 \begin{ltxexample}
 \DeclareRangeChars{~,;-+/}
 \end{ltxexample}
+
+On engines that fully support Unicode the default is
+\begin{ltxexample}
+\DeclareRangeChars{~,;-–—+/}
+\end{ltxexample}
 %
 This means that strings like <3--5>, <35+>, <8/9> and so on will be considered as a range by \cmd{ifnumerals} and \cmd{ifpages}. Non-range characters in such strings are recognized as numbers. So strings like <3a--5a> and <35b+> are not deemed to be ranges by default. See also \secref{bib:use:pag, use:cav:pag} for further details.
 
@@ -10234,8 +10239,15 @@ The following commands configure various features related to punctuation and aut
 \begin{ltxsyntax}
 
 \cmditem{DeclarePrefChars}{characters}
+\cmditem*{DeclarePrefChars*}{characters}
 
-This command declares characters that are to be treated specially when testing to see if \cmd{bibnamedelimc} is to be inserted between a name prefix and a family name. If a character is in the list of \prm{characters}, \cmd{bibnamedelimc} is not inserted. It is used to allow abbreviated name prefices like <d'Argent> where no space should be inserted after the apostrophe. The default setting is:
+This command declares characters that are to be treated specially when testing to see if \cmd{bibnamedelimc} is to be inserted between a name prefix and a family name. If a character is in the list of \prm{characters}, \cmd{bibnamedelimc} is not inserted. It is used to allow abbreviated name prefices like <d'Argent> where no space should be inserted after the apostrophe. The starred version appends its argument to the list of prefix characters, the unstarred version replaces current setting. The default setting is:
+
+\begin{ltxexample}
+\DeclarePrefChars{'-}
+\end{ltxexample}
+
+On engines that fully support Unicode the default is
 
 \begin{ltxexample}
 \DeclarePrefChars{'’-}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -1411,9 +1411,9 @@
 \newrobustcmd*{\DeclarePrefChars}{%
   \@ifstar
     {\blx@defprefchars}
-    {\let\blx@prefchars\@empty
+    {\global\let\blx@prefchars\@empty
      \blx@defprefchars}}
-\DeclarePrefChars{'’-}
+\DeclarePrefChars{'-}
 
 \protected\def\blx@imc@ifprefchar{%
   \ifhmode
@@ -1462,32 +1462,6 @@
   \blx@tempcnta"C0
   \blx@tempcntb"DF
   \blx@tempa
-\fi
-\ifx\Umathcode\undefined
-\else
-  \openin\blx@bcfin=UnicodeData.txt %
-  \ifeof\blx@bcfin
-  \else
-    \let\blx@setazcodes\@empty
-    \def\Lu{Lu}
-    \def\storedpar{\par}
-    \def\blx@tempa#1;#2;#3;#4\relax{%
-      \def\temp{#3}%
-      \ifx\temp\Lu
-        \xdef\blx@setazcodes{%
-          \blx@setazcodes
-          \sfcode"#1=\@m
-        }
-      \fi
-    }
-    \loop\unless\ifeof\blx@bcfin
-      \read\blx@bcfin to \blx@tempb
-      \unless\ifx\blx@tempb\storedpar
-        \expandafter\blx@tempa\blx@tempb\relax
-      \fi
-    \repeat
-  \fi
-  \closein\blx@bcfin
 \fi
 \endgroup
 
@@ -4402,7 +4376,7 @@
                 \csname abx@field@#1\endcsname}}
        {\@secondoftwo}
        {\@firstoftwo}}}
-       
+
 % {<field>}{<string>}{<true>}{<false>}
 \def\blx@imc@iffieldplusstringbibstring#1#2{%
   \blx@imc@iffieldundef{#1}
@@ -13336,6 +13310,14 @@
   parentracker,maxparens=3,bibencoding=auto,bibwarn,timezones=false,
   seconds=false,julian=false,labeltime=24h}
 
+% Load Unicode enhancements (only for LuaTeX and XeTeX)
+\ifboolexpr{
+    not test {\ifundef\XeTeXrevision}
+    or
+    not test {\ifundef\luatexversion}}
+  {\blx@inputonce{blx-unicode.def}{enhanced support for Unicode engines}{}{}{}{}}
+  {}
+
 % Load compatibility code
 \blx@inputonce{blx-compat.def}{compatibility code}{}{}{}{}
 
@@ -13346,7 +13328,7 @@
 % Process load-time options
 \ProcessOptions*
 
-% Switch to BibTeX support if requests
+% Switch to BibTeX support if requested
 \iftoggle{blx@bibtex}
   {\blx@inputonce{blx-bibtex.def}{BibTeX backend compatibility}{}{}{}{}}
   {}

--- a/tex/latex/biblatex/blx-unicode.def
+++ b/tex/latex/biblatex/blx-unicode.def
@@ -1,0 +1,38 @@
+% This test should not be needed since biblatex.sty already checks
+% if LuaTeX or XeTeX is used.
+% Currently Unicode-aware engines are only XeTeX and LuaTeX,
+% both of which define \Umathcode.
+\ifx\Umathcode\undefined
+  \expandafter\endinput
+\fi
+
+\begingroup
+\openin\blx@bcfin=UnicodeData.txt %
+\ifeof\blx@bcfin
+\else
+  \let\blx@setazcodes\@empty
+  \def\Lu{Lu}
+  \def\storedpar{\par}
+  \def\blx@tempa#1;#2;#3;#4\relax{%
+    \def\temp{#3}%
+    \ifx\temp\Lu
+      \xdef\blx@setazcodes{%
+        \blx@setazcodes
+        \sfcode"#1=\@m
+      }
+    \fi
+  }
+  \loop\unless\ifeof\blx@bcfin
+    \read\blx@bcfin to \blx@tempb
+    \unless\ifx\blx@tempb\storedpar
+      \expandafter\blx@tempa\blx@tempb\relax
+    \fi
+  \repeat
+\fi
+\closein\blx@bcfin
+\endgroup
+
+\DeclarePrefChars{'’-}
+\DeclareRangeChars{~,;-–—+/}
+
+\endinput


### PR DESCRIPTION
See #659, #664. Big thanks to @aminophen

Introduces a dedicated Unicode file that is only read by the Unicode-aware engines.
`biblatex.sty` is ASCII-only again.
`\DeclarePrefChars{'’-}` did not work as intended with pdfLaTeX anyway and did not throw an error only because the list loop could not handle UTF-8 characters properly.
