### PR TITLE
Tweak EDTF to ISO transition

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -1,4 +1,4 @@
-# RELEASE NOTES FOR VERSION 4.0
+# RELEASE NOTES FOR VERSION ??
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes
   the draft EDTF (Extended Date Time Format) extensions. Biblatex therefore
   now supports the ISO8601-2 Clause 4, Level 1 Extended Format which is

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -13208,6 +13208,10 @@ use$<$name$>$	&\+&\+&\_&\+&\+&\_&\_\\
 This revision history is a list of changes relevant to users of this package. Changes of a more technical nature which do not affect the user interface or the behavior of the package are not included in the list. More technical details are to be found in the \file{CHANGES.org} file. The numbers on the right indicate the relevant section of this manual.
 
 \begin{changelog}
+\begin{release}{??}{201?-??-??}
+\item Changed \opt{edtf} to \opt{iso}\see{use:opt:pre:gen}
+\end{release}
+
 \begin{release}{3.9}{2017-11-21}
 \item Added \cmd{iffieldplusstringbibstring}\see{aut:aux:tst}
 \item Fixed \cmd{mkpagetotal}\see{aut:aux:msc}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5396,10 +5396,6 @@
       \printtext[#1time]{\csuse{mkbibtime\csuse{blx@timeformat@#1time}}{#1#2hour}{#1#2minute}{#1#2second}{#1#2timezone}}}
     {}}
 
-\def\mkdaterangeedtf{%LEGACY(<3.9)
-  \blx@warning@noline{'\string\mkdaterangeedtf' is deprecated, please use '\string\mkdaterangeiso'}%
-  \mkdaterangeiso}
-
 \newrobustcmd*{\mkdaterangeiso}[1]{%
   \blx@metadateinfo{#1}%
   \def\bibdatetimesep{T}%
@@ -5429,10 +5425,6 @@
             {}%
          \enddateuncertainprint
          \enddatecircaprintiso}}}}
-
-\def\mkdaterangeedtfextra{%LEGACY(<3.9)
-  \blx@warning@noline{'\string\mkdaterangeedtfextra' is deprecated, please use '\string\mkdaterangeisoextra'}%
-  \mkdaterangeisoextra}
 
 \newrobustcmd*{\mkdaterangeisoextra}[1]{%
   \blx@metadateinfo{#1}%
@@ -12864,10 +12856,17 @@
       \settoggle{blx@labeldateparts}{#1}}
      {\ifstrequal{#1}{iso8601}
        {\blx@warning@noline{%
-        'edtf' date format specifier is deprecated, use 'iso' instead}%
+          'iso8601' date format specifier is deprecated.\MessageBreak
+          Use 'iso' instead}%
         \def\blx@dateformat@labeldate{iso}%
         \renewrobustcmd*{\bibdateeraendprefix}{\bibdateeraprefix}}
-       {\def\blx@dateformat@labeldate{#1}}%
+       {\ifstrequal{#1}{edtf}
+          {\blx@warning@noline{%
+             'edtf' date format specifier is deprecated.\MessageBreak
+             Use 'iso' instead}%
+           \def\blx@dateformat@labeldate{iso}%
+           \renewrobustcmd*{\bibdateeraendprefix}{\bibdateeraprefix}}
+          {\def\blx@dateformat@labeldate{#1}}}%
       \ifstrequal{#1}{ymd}
          {\renewrobustcmd*{\bibdaterangesep}{\slash}%
           \renewrobustcmd*{\bibtimerangesep}{\slash}%
@@ -12924,11 +12923,15 @@
      \protected\def\enddatecircaprint{%
        \ifenddatecirca{\bibstring{circa}\printdelim{datecircadelim}}{}}%
      \protected\def\datecircaprintedtf{%LEGACY(<3.9)
-       \blx@warning@noline{'\string\datecircaprintedtf' is deprecated, please use '\string\datecircaprintiso'}%
-       \ifdatecirca{\textasciitilde}{}}%
+       \blx@warning@noline{%
+         '\string\datecircaprintedtf' is deprecated.
+         Please use '\string\datecircaprintiso'}%
+       \datecircaprintiso}%
      \protected\def\enddatecircaprintedtf{%LEGACY(<3.9)
-       \blx@warning@noline{'\string\enddatecircaprintedtf' is deprecated, please use '\string\enddatecircaprintiso'}%
-       \ifenddatecirca{\textasciitilde}{}}%
+       \blx@warning@noline{%
+         '\string\enddatecircaprintedtf' is deprecated.
+         Please use '\string\enddatecircaprintiso'}%
+       \enddatecircaprintiso}%
      \protected\def\datecircaprintiso{%
        \ifdatecirca{\textasciitilde}{}}%
      \protected\def\enddatecircaprintiso{%
@@ -12951,10 +12954,15 @@
 % Date metadata toggles are defined in one of the \abx@dobooleans calls
 \def\do#1{%
   \DeclareBibliographyOption[string]{#1date}{%
-    \ifstrequal{##1}{edtf}
-      {\blx@warning@noline{'edtf' date format specifier is deprecated, use 'iso' instead}%
+    \ifstrequal{##1}{iso8601}
+      {\blx@warning@noline{'iso8601' date format specifier is deprecated.\MessageBreak
+         Use 'iso' instead}%
        \csdef{blx@dateformat@#1date}{iso}}
-      {\csdef{blx@dateformat@#1date}{##1}}%
+      {\ifstrequal{##1}{edtf}
+         {\blx@warning@noline{'edtf' date format specifier is deprecated.\MessageBreak
+            Use 'iso' instead}%
+          \csdef{blx@dateformat@#1date}{iso}}
+         {\csdef{blx@dateformat@#1date}{##1}}}%
     \ifstrequal{##1}{ymd}
       {\renewrobustcmd*{\bibdaterangesep}{\slash}%
        \renewrobustcmd*{\bibtimerangesep}{\slash}%

--- a/tex/latex/biblatex/blx-compat.def
+++ b/tex/latex/biblatex/blx-compat.def
@@ -294,8 +294,17 @@
     'DeclareLabelyear' is deprecated.\MessageBreak
     Please use 'DeclareLabeldate'}}
 
-\cslet{mkdaterangeiso8601}\mkdaterangeedtf% Legacy option support
-\cslet{mkdaterangeiso8601extra}\mkdaterangeedtfextra% Legacy option support
+\csdef{mkdaterangeiso8601}{%
+  \blx@warning@noline{%
+    '\string\mkdaterangeiso8601' is deprecated.\MessageBreak
+    Please use '\string\mkdaterangeiso'}%
+  \mkdaterangeiso}
+
+\csdef{mkdaterangeiso8601extra}{%
+  \blx@warning@noline{%
+    '\string\mkdaterangeiso8601extra' is deprecated.\MessageBreak
+    Please use '\string\mkdaterangeisoextra'}%
+  \mkdaterangeisoextra}
 
 \newrobustcmd*{\bibdatedash}{\bibrangedash}%LEGACY(<3.5)
 
@@ -330,5 +339,18 @@
 
 \DeprecateFieldWithReplacement{extrayear}{extradate}
 \DeclareFieldAlias{extrayear}{extradate}
+
+% EDTF -> ISO
+\def\mkdaterangeedtf{%
+  \blx@warning@noline{%
+    '\string\mkdaterangeedtf' is deprecated.\MessageBreak
+    Please use '\string\mkdaterangeiso'}%
+  \mkdaterangeiso}
+
+\def\mkdaterangeedtfextra{%
+  \blx@warning@noline{%
+    '\string\mkdaterangeedtfextra' is deprecated.\MessageBreak
+    Please use '\string\mkdaterangeisoextra'}%
+  \mkdaterangeisoextra}
 
 \endinput


### PR DESCRIPTION
- `iso8601` option is still deprecated
- Move deprecated commands to `blx-compat.def`