### PR TITLE
Option to disable etextools incompatibility error

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -335,6 +335,10 @@ The \sty{ucs} package provides support for \utf encoded input. Either use \sty{i
 The \sty{etextools} package provides enhancements to list macros defined by \sty{etoolbox} and a few other tools for command definitions.
 The package redefines list handling macros in a way incompatible with \biblatex.
 
+If you must load the \sty{etextools} package at all costs, use the load-time option \opt{noerroretextools}.
+With \kvopt{noerroretextools}{true} no error will be issued if \sty{etextools} is loaded, that message is degraded to a warning instead.
+In that case you need to make sure that \cmd{forlistloop} has its original \sty{etoolbox} definition when \biblatex\ is loaded.
+
 \end{marglist}
 
 \subsubsection{Compatibility Matrix for \biber}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6082,9 +6082,9 @@
   \do{options}%
   \do{sortinit}%
   \do{sortinithash}%
-  \forlistloop{\do}\blx@datemetafields
-  \forlistloop{\do}\blx@namepartmetafields
-  \forlistloop{\do}\blx@labeldatepartfields}
+  \dolistloop\blx@datemetafields
+  \dolistloop\blx@namepartmetafields
+  \dolistloop\blx@labeldatepartfields}
 
 \def\abx@dobooleans{%
   \do{crossrefsource}%
@@ -6094,7 +6094,7 @@
   \do{uniquebaretitle}%
   \do{uniquework}%
   \do{uniqueprimaryauthor}%
-  \forlistloop{\do}\blx@datemetabooleans}
+  \dolistloop\blx@datemetabooleans}
 
 % Date datatype fields
 \def\do#1{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -49,7 +49,7 @@
      {Outdated 'etoolbox' package}
      {Upgrade to etoolbox v2.1 (2010/11/29) or later.\MessageBreak
       I found: '\csuse{ver@etoolbox.sty}'.\MessageBreak
-      This is a fatal error. I'm aborting now.}%
+      This is a fatal error. I'm aborting now}%
    \endinput}
 
 \@ifpackagelater{xstring}{2013/10/13}
@@ -58,7 +58,7 @@
      {Outdated 'xstring' package}
      {Upgrade to xstring v1.7c (2013/10/13) or later.\MessageBreak
       I found: '\csuse{xstringversion}'.\MessageBreak
-      This is a fatal error. I'm aborting now.}%
+      This is a fatal error. I'm aborting now}%
    \endinput}
 
 % polyglossia pretends to be babel, so we need to make sure
@@ -73,7 +73,7 @@
              {Outdated 'babel' package}
              {Upgrade to babel 3.9r (2016/04/23) or later.\MessageBreak
               I found: '\csuse{ver@babel.sty}'.\MessageBreak
-              This is a fatal error. I'm aborting now.}%
+              This is a fatal error. I'm aborting now}%
             \endinput}}
        {}}}
 
@@ -130,7 +130,26 @@
   \docsvlist{%
     amsrefs,apacite,babelbib,backref,bibtopic,bibunits,chapterbib,
     cite,citeref,drftcite,footbib,inlinebib,jurabib,mcite,mciteplus,
-    mlbib,multibbl,multibib,natbib,opcit,overcite,splitbib,ucs,etextools}%
+    mlbib,multibbl,multibib,natbib,opcit,overcite,splitbib,ucs}%
+  \iftoggle{blx@noerroretextools}
+    {\@ifpackageloaded{etextools}
+       {\blx@warning@noline{%
+          Incompatible package 'etextools' loaded,\MessageBreak
+          no error is thrown because you set\MessageBreak
+          'noerroretextools=true'.\MessageBreak
+          'etextools' redefines '\string\forlistloop', you will\MessageBreak
+          need to restore the definition from 'etoolbox'}}
+       {\blx@warning@noline{%
+          You set 'noerroretextools=true',\MessageBreak
+          but 'etextools' is not loaded.\MessageBreak
+          Please do not set 'noerroretextools' to 'true'\MessageBreak
+          unless you really need it}}}
+    {\@ifpackageloaded{etextools}
+       {\blx@error
+          {Incompatible package 'etextools'}
+          {The 'etextools' package and biblatex are incompatible.\MessageBreak
+           If you must load 'etextools' at all costs, set 'noerroretextools=true'}}
+       {}}%
   \def\blx@langstrings{}%
   % Set up sortlocale defaults and default language if babel/polyglossia is not loaded
   \ifdefstring\blx@sortlocale{auto}
@@ -12172,6 +12191,10 @@
 
 \define@key{blx@opt@ldt}{mcite}[true]{%
   \settoggle{blx@mcite}{#1}}
+
+\newtoggle{blx@noerroretextools}
+\define@key{blx@opt@ldt}{noerroretextools}[true]{%
+  \settoggle{blx@noerroretextools}{#1}}
 
 % load-time and preamble
 


### PR DESCRIPTION
See #669 

This introduces the option `noerroretextools` to demote the incompatibility error message to warning. Users will have to restore `\forlistloop`.