### PR TITLE
Tweak memoir headings (#627)

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1927,44 +1927,60 @@
   \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase{\memUChead}}%
   \defbibheading{bibliography}[\refname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
-      {}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+      {}}
   \defbibheading{biblist}[\biblistname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
-      {}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+      {}}
   \defbibheading{bibintoc}[\refname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \phantomsection
-    \addcontentsline{toc}{chapter}{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addcontentsline{toc}{chapter}{#1}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \phantomsection
-    \addcontentsline{toc}{chapter}{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addcontentsline{toc}{chapter}{#1}}
   \defbibheading{bibnumbered}[\refname]{%
     \chapter{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
     \chapter{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{section}{#1}}
-      {}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+      {}}
   \defbibheading{subbibintoc}[\refname]{%
     \section*{#1}%
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi
     \phantomsection
-    \addcontentsline{toc}{section}{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \addcontentsline{toc}{section}{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 
@@ -1972,46 +1988,60 @@
   \ifcsundef{memUChead}{}{\def\abx@MakeMarkcase{\memUChead}}%
   \defbibheading{bibliography}[\bibname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
-      {}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+      {}}
   \defbibheading{biblist}[\biblistname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{chapter}{#1}}
-      {}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+      {}}
   \defbibheading{bibintoc}[\bibname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \phantomsection
-    \addcontentsline{toc}{chapter}{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addcontentsline{toc}{chapter}{#1}}
   \defbibheading{biblistintoc}[\biblistname]{%
     \chapter*{#1}%
+    \if@twoside
+      \markboth{\abx@MakeMarkcase{#1}}{\abx@MakeMarkcase{#1}}%
+    \else
+      \markright{\abx@MakeMarkcase{#1}}%
+    \fi
     \phantomsection
-    \addcontentsline{toc}{chapter}{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addcontentsline{toc}{chapter}{#1}}
   \defbibheading{bibnumbered}[\bibname]{%
-    \chapter{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \chapter{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
-    \chapter{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \chapter{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi
     \ifmemoirbibintoc
       {\phantomsection
        \addcontentsline{toc}{section}{#1}}
-      {}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+      {}}
   \defbibheading{subbibintoc}[\refname]{%
     \section*{#1}%
+    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi
     \phantomsection
-    \addcontentsline{toc}{section}{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \addcontentsline{toc}{section}{#1}}
   \defbibheading{subbibnumbered}[\refname]{%
     \section{#1}}
 


### PR DESCRIPTION
These definitions mirror what `memoir` does with `\bibmark` better than before.

In particular, `memoir` explicitly has `\markboth` and `\markright`, not `\@mkboth`. This is contrary to the advice in #627 and https://github.com/plk/biblatex/commit/f294293855ebf496adf01c93e26762638fe21677  / https://github.com/plk/biblatex/commit/482c684b62e7fece64c76eedf701e7c3d6671d58.

https://tex.stackexchange.com/q/405461/35864