### PR TITLE
Remove manual headers for unstarred sectioning (#627)

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1795,11 +1795,9 @@
     \addcontentsline{toc}{section}{#1}%
     \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\refname]{%
-    \section{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \section{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
-    \section{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \section{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \subsection*{#1}}
   \defbibheading{subbibintoc}[\refname]{%
@@ -1824,11 +1822,9 @@
     \addcontentsline{toc}{chapter}{#1}%
     \@mkdouble{\abx@MakeMarkcase{#1}}}
   \defbibheading{bibnumbered}[\bibname]{%
-    \chapter{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \chapter{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
-    \chapter{#1}%
-    \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
+    \chapter{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
     \if@twoside\markright{\abx@MakeMarkcase{#1}}\fi}
@@ -1843,35 +1839,29 @@
   \defbibheading{bibliography}[\refname]{%
     \ifcsundef{bibliography@heading}
       {\ifkomabibtotocnumbered
-         {\section{#1}%
-          \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+         {\section{#1}}
          {\ifkomabibtotoc
             {\addsec{#1}}
-            {\section*{#1}}%
-          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+            {\section*{#1}%
+             \@mkdouble{\abx@MakeMarkcase{#1}}}}}
       {\bibliography@heading{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifcsundef{bibliography@heading}
       {\ifkomabibtotocnumbered
-         {\section{#1}%
-          \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+         {\section{#1}}
          {\ifkomabibtotoc
             {\addsec{#1}}
-            {\section*{#1}}%
-          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+            {\section*{#1}%
+             \@mkdouble{\abx@MakeMarkcase{#1}}}}}
       {\bibliography@heading{#1}}}
   \defbibheading{bibintoc}[\refname]{%
-    \addsec{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addsec{#1}}
   \defbibheading{biblistintoc}[\biblistname]{%
-    \addsec{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addsec{#1}}
   \defbibheading{bibnumbered}[\refname]{%
-    \section{#1}%
-    \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+    \section{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
-    \section{#1}%
-    \@mkdouble{\abx@MakeMarkcase{\sectionmarkformat#1}}}
+    \section{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \subsection*{#1}%
     \@mkright{\abx@MakeMarkcase{#1}}}
@@ -1886,35 +1876,29 @@
   \defbibheading{bibliography}[\bibname]{%
     \ifcsundef{bibliography@heading}
       {\ifkomabibtotocnumbered
-         {\chapter{#1}%
-          \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+         {\chapter{#1}}
          {\ifkomabibtotoc
             {\addchap{#1}}
-            {\chapter*{#1}}%
-          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+            {\chapter*{#1}
+             \@mkdouble{\abx@MakeMarkcase{#1}}}}}
       {\bibliography@heading{#1}}}
   \defbibheading{biblist}[\biblistname]{%
     \ifcsundef{bibliography@heading}
       {\ifkomabibtotocnumbered
-         {\chapter{#1}%
-          \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+         {\chapter{#1}}
          {\ifkomabibtotoc
             {\addchap{#1}}
-            {\chapter*{#1}}%
-          \@mkdouble{\abx@MakeMarkcase{#1}}}}
+            {\chapter*{#1}
+             \@mkdouble{\abx@MakeMarkcase{#1}}}}}
       {\bibliography@heading{#1}}}
   \defbibheading{bibintoc}[\bibname]{%
-    \addchap{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addchap{#1}}
   \defbibheading{biblistintoc}[\biblistname]{%
-    \addchap{#1}%
-    \@mkdouble{\abx@MakeMarkcase{#1}}}
+    \addchap{#1}}
   \defbibheading{bibnumbered}[\bibname]{%
-    \chapter{#1}%
-    \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+    \chapter{#1}}
   \defbibheading{biblistnumbered}[\biblistname]{%
-    \chapter{#1}%
-    \@mkdouble{\abx@MakeMarkcase{\chaptermarkformat#1}}}
+    \chapter{#1}}
   \defbibheading{subbibliography}[\refname]{%
     \section*{#1}%
     \@mkright{\abx@MakeMarkcase{#1}}}


### PR DESCRIPTION
Use manual marks `\@mkboth`, `\@mkright` only with starred sectioning commands. The unstarred sectionng commands should set marks automatically.