### PR TITLE
Add driver and biblistfilter to \printbiblist

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -1,3 +1,7 @@
+# RELEASE NOTES FOR VERSION ??
+- `\printbiblist` now supports `driver` and `biblistfilter` options
+  to change the defaults set by the biblistname.
+
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes
   the draft EDTF (Extended Date Time Format) extensions. Biblatex therefore

--- a/doc/latex/biblatex/README
+++ b/doc/latex/biblatex/README
@@ -162,4 +162,4 @@ Refer to biblatex.pdf for a systematic reference manual and to the
 CHANGES
 
 A list of changes relevant to users of this package is included at
-the end of 'biblatex.pdf'. See also the release notes in 'CHANGES.org'.
+the end of 'biblatex.pdf'. See also the release notes in 'CHANGES.md'.

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -13235,9 +13235,13 @@ use$<$name$>$	&\+&\+&\_&\+&\+&\_&\_\\
 \section{Revision History}
 \label{apx:log}
 
-This revision history is a list of changes relevant to users of this package. Changes of a more technical nature which do not affect the user interface or the behavior of the package are not included in the list. More technical details are to be found in the \file{CHANGES.org} file. The numbers on the right indicate the relevant section of this manual.
+This revision history is a list of changes relevant to users of this package. Changes of a more technical nature which do not affect the user interface or the behavior of the package are not included in the list. More technical details are to be found in the \file{CHANGES.md} file. The numbers on the right indicate the relevant section of this manual.
 
 \begin{changelog}
+\begin{release}{??}{20??-??-??}
+\item Added \opt{driver} and \opt{biblistfilter} options to \cmd{printbiblist}\see{use:bib:biblist}
+\end{release}
+
 \begin{release}{3.10}{2017-12-19}
 \item Changed \opt{edtf} to \opt{iso}\see{use:opt:pre:gen}
 \item Added \opt{noerroretextools} option\see{int:pre:inc}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3393,16 +3393,29 @@ A bibliography list differs from a normal bibliography in that the same bibliogr
 
 \cmditem{printbiblist}[key=value, \dots]{$<$biblistname$>$}
 
-This command prints a bibliography list. It takes an optional argument, which is a list of options given in \keyval notation. Valid options are all options supported by \cmd{printbibliography} (\secref{use:bib:bib}) except \opt{resetnumbers} and \opt{omitnumbers}. If there are any \env{refsection} environments in the document, the bibliography list will be local to these environments; see \secref{use:bib:sec} for details. By default, this command uses the heading \texttt{biblist}. See \secref{use:bib:hdg} for details.
+This command prints a bibliography list. It takes an optional argument, which is a list of options given in \keyval notation. Valid options are all options supported by \cmd{printbibliography} (\secref{use:bib:bib}) except \opt{resetnumbers} and \opt{omitnumbers}, two additional options are available. If there are any \env{refsection} environments in the document, the bibliography list will be local to these environments; see \secref{use:bib:sec} for details. By default, this command uses the heading \texttt{biblist}. See \secref{use:bib:hdg} for details.
+
 
 The \prm{biblistname} is a mandatory argument which names the bibliography list. This name is used to identify:
 \begin{itemize}
 \item The default bibliography driver used to print the list entries
-\item A default filter declared with \cmd{DeclareBiblistFilter} (see \secref{aut:ctm:bibfilt}) used to filter the entries returned from \biber
+\item A default bibliography list filter declared with \cmd{DeclareBiblistFilter} (see \secref{aut:ctm:bibfilt}) used to filter the entries returned from \biber
 \item A default check declared with \cmd{defbibcheck} (see \secref{use:bib:flt}) used to post-process the list entries
 \item The default bib environment to use
 \item The default sorting template to use
 \end{itemize}
+
+The two additional options can be used to change some of the defaults set by the mandatory argument.
+
+\valitem{driver}{driver}
+
+Change the bibliography driver used to print the list entries.
+% \prm{driver} must be a valid driver declared with \cmd{DeclareBibliographyDriver} (see \secref{aut:bbx:bbx}).
+
+\valitem{biblistfilter}{biblistfilter}
+
+Change the bibliography list filter used to filter the entries. \prm{biblistfilter} must be a valid bibliography list filter defined with \cmd{DeclareBiblistFilter} (see \secref{aut:ctm:bibfilt}).
+
 
 In terms of sorting the list, the default is to sort use the sorting template named after the bibliography list (if it exists) and only then to fall back to the current context sorting template is this is not defined (see \secref{use:bib:context}).
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -8201,6 +8201,12 @@
 
 \appto\blx@mknohyperref{\let\blx@anchor\relax}
 
+\define@key{blx@biblist2}{driver}{\blx@key@driver{#1}}
+\define@key{blx@biblist1}{driver}{}
+
+\def\blx@key@driver#1{%
+  \def\blx@thebiblistdriver{#1}}
+
 % Custom bibliography list
 % [<otions>]{biblistname}
 \newrobustcmd*{\printbiblist}[2][]{%
@@ -8212,6 +8218,8 @@
   \def\blx@theheading{biblist}% default to biblist heading
   \def\blx@theenv{#2}% default to list name
   \def\blx@thebiblist{#2}%
+  \def\blx@thebiblistdriver{#2}%
+  \def\blx@thebiblistfilter{#2}%
   \let\blx@theprenote\@empty
   \let\blx@thepostnote\@empty
   \let\blx@thetitle\@empty
@@ -8257,7 +8265,7 @@
     {}
     {\listxadd\blx@dlistnames{\blx@refcontext@context @\blx@tempe @list}%
      \csxappto{blx@dlists}{%
-       \blx@xml@dlist{\blx@refcontext@context}{list}{\blx@tempe}{\blx@xml@dlist@refcontext{\blx@tempc}{\blx@refcontext@sortingnamekeytemplatename}{\blx@refcontext@labelprefix}{\blx@refcontext@uniquenametemplatename}{\blx@refcontext@labelalphanametemplatename}}{\csuse{blx@biblistfilters@#2}}}}%
+       \blx@xml@dlist{\blx@refcontext@context}{list}{\blx@tempe}{\blx@xml@dlist@refcontext{\blx@tempc}{\blx@refcontext@sortingnamekeytemplatename}{\blx@refcontext@labelprefix}{\blx@refcontext@uniquenametemplatename}{\blx@refcontext@labelalphanametemplatename}}{\csuse{blx@biblistfilters@\blx@thebiblistfilter}}}}%
   \ifdefvoid\blx@tempa
     {\blx@warn@biblistempty{#2}\endgroup}
     {\blx@biblist\blx@tempa}}
@@ -8323,7 +8331,7 @@
        \blx@beglangbib
        \bibsentence
        \blx@pagetracker
-       \blx@driver{\blx@thebiblist}%
+       \blx@driver{\blx@thebiblistdriver}%
        \blx@postpunct
        \blx@endlangbib}%
      \endgroup}
@@ -11736,6 +11744,17 @@
 % Predefine filters for label fields
 \def\do#1{\DeclareBiblistFilter{#1}{\filter[type=field,filter=#1]}}
 \abx@dolabelfields
+
+\define@key{blx@biblist2}{biblistfilter}{\blx@key@biblistfilter{#1}}
+\define@key{blx@biblist1}{biblistfilter}{}
+
+\def\blx@key@biblistfilter#1{%
+  \ifcsundef{blx@biblistfilters@#1}
+    {\blx@error
+        {BiblistFilter '#1' not found}
+        {The BiblistFilter '#1' could not be found.\MessageBreak
+         Use '\string\DeclareBiblistFilter' to define it}}
+    {\def\blx@thebiblistfilter{#1}}}
 
 % [<entrytype>]
 \newrobustcmd*{\DeclareSortTranslit}[2][]{%


### PR DESCRIPTION
The `driver` and `biblistfilter` options would come in handy in https://tex.stackexchange.com/a/407352/35864.

Ideally, `\printbiblist` would also support a `sorting` option again, but that was not as straightforward as the other two options here.