### PR TITLE
\mknormrange for #293

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -1,6 +1,7 @@
 # RELEASE NOTES FOR VERSION ??
 - `\printbiblist` now supports `driver` and `biblistfilter` options
   to change the defaults set by the biblistname.
+- Add `\mknormrange` to normalise page ranges without compressing them.
 
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -2,6 +2,29 @@
 - `\printbiblist` now supports `driver` and `biblistfilter` options
   to change the defaults set by the biblistname.
 - Add `\mknormrange` to normalise page ranges without compressing them.
+- **INCOMPATIBLE CHANGE** The format for `postnote` (`multipostnote`,
+  `volcitepages`) normalises page ranges with `\mknormrange`.
+  Since `\mknormrange` acts only on page ranges as detected by
+  `\ifpages`, this does not affect text other than page ranges.
+  Hyphens and dashes in page ranges will be transformed to
+  `\bibrangedash`, commas and semi-colons to `\bibrangesep`.
+  This is analogous to Biber's treatment of page-like fields.
+  If you always separated page ranges with `--` or `\bibrangedash`
+  anyway, this should not change the output you get.
+  If you used a single hyphen to separate page ranges (e.g., `23-27`)
+  you will now get the arguably more aesthetically pleasing output
+  with `\bibrangedash`.
+  In case you want to restore the old behaviour where page ranges were
+  not normalised add the following three lines to your preamble.
+  ```
+  \DeclareFieldFormat{postnote}{\mkpageprefix[pagination]{#1}}
+  \DeclareFieldFormat{volcitepages}{\mkpageprefix[pagination]{#1}}
+  \DeclareFieldFormat{multipostnote}{\mkpageprefix[pagination]{#1}}
+  ```
+  Style developers may note that the field format for `pages`
+  was not changed to include `\mknormrange` because the contents
+  of that field are prepared by the backend and Biber already does
+  the page range normalisation out of the box.
 
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -9867,11 +9867,10 @@ The problem with this convention is that the braces will suppress the kerning on
 This command is intended for use in field formatting directives which format the page numbers in the \prm{postnote} argument of citation commands and the \bibfield{pages} field of bibliography entries. It will parse its \prm{text} argument and prefix it with <p.> or <pp.> by default. The optional \prm{pagination} argument holds the name of a field indicating the pagination type. This may be either \bibfield{pagination} or \bibfield{bookpagination}, with \bibfield{pagination} being the default. The spacing between the prefix and the \prm{text} may be modified by redefining \cmd{ppspace}. The default is an unbreakable interword space. See \secref{bib:use:pag, use:cav:pag} for further details. See also \cmd{DeclareNumChars}, \cmd{DeclareRangeChars}, \cmd{DeclareRangeCommands}, and \cmd{NumCheckSetup}. The optional \prm{postpro} argument specifies a macro to be used for post-processing the \prm{text}. If only one optional argument is given, it is taken as \prm{pagination}. Here are two typical examples:
 
 \begin{ltxexample}
-\DeclareFieldFormat{postnote}{<<\mkpageprefix[pagination]{#1}>>}
+\DeclareFieldFormat{postnote}{<<\mkpageprefix[pagination][\mknormrange]{#1}>>}
 \DeclareFieldFormat{pages}{<<\mkpageprefix[bookpagination]{#1}>>}
 \end{ltxexample}
 %
-The optional argument \bibfield{pagination} in the first example is omissible.
 
 \cmditem{mkpagetotal}[pagination][postpro]{text}
 

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -9923,7 +9923,7 @@ The pagination strings are taken from \texttt{$<$pagination$>$total} and \texttt
 \cmditem{mkcomprange}[postpro]{text}
 \cmditem*{mkcomprange*}[postpro]{text}
 
-This command, which is intended for use in field formatting directives, will parse its \prm{text} argument for page ranges and compress them. For example, «125--129» may be formatted as «125--9». You may configure the behavior of \cmd{mkcomprange} by adjusting the \latex counters \cnt{mincomprange}, \cnt{maxcomprange}, and \cnt{mincompwidth}, as illustrated in \tabref{aut:aux:tab1}. The default settings are \texttt{10}, \texttt{100000}, and \texttt{1}, respectively. This means that the command tries to compress as much as possible by default. Use \cmd{setcounter} to adjust the parameters. The scanner recognises \cmd{bibrangedash} and hyphens as range dashes. It will normalize the dash by replacing any number of consecutive hyphens with \cmd{bibrangedash}. Lists of ranges delimited with \cmd{bibrangessep} are also supported. The backend will normalise any comma or semi-colons surrounded by optional space by replacing them with \cmd{bibrangessep}. If you want to hide a character from the list/range scanner for some reason, wrap the character or the entire string in curly braces. The optional \prm{postpro} argument specifies a macro to be used for post-processing the \prm{text}. This is important if you want to combine \cmd{mkcomprange} with other formatting macros which also need to parse their \prm{text} argument, such as \cmd{mkpageprefix}. Simply nesting these commands will not work as expected. Use the \prm{postpro} argument to set up the processing chain as follows:
+This command, which is intended for use in field formatting directives, will parse its \prm{text} argument for page ranges and compress them. For example, «125--129» may be formatted as «125--9». You may configure the behavior of \cmd{mkcomprange} by adjusting the \latex counters \cnt{mincomprange}, \cnt{maxcomprange}, and \cnt{mincompwidth}, as illustrated in \tabref{aut:aux:tab1}. The default settings are \texttt{10}, \texttt{100000}, and \texttt{1}, respectively. This means that the command tries to compress as much as possible by default. Use \cmd{setcounter} to adjust the parameters. The scanner recognises \cmd{bibrangedash} and hyphens as range dashes. It will normalize the dash by replacing any number of consecutive hyphens with \cmd{bibrangedash}. Lists of ranges delimited with \cmd{bibrangessep} are also supported. The scanner will normalise any comma or semi-colons surrounded by optional space by replacing them with \cmd{bibrangessep}. If you want to hide a character from the list/range scanner for some reason, wrap the character or the entire string in curly braces. The optional \prm{postpro} argument specifies a macro to be used for post-processing the \prm{text}. This is important if you want to combine \cmd{mkcomprange} with other formatting macros which also need to parse their \prm{text} argument, such as \cmd{mkpageprefix}. Simply nesting these commands will not work as expected. Use the \prm{postpro} argument to set up the processing chain as follows:
 
 \begin{ltxexample}
 \DeclareFieldFormat{postnote}{\mkcomprange[<<{>>\mkpageprefix[pagination]<<}>>]{#1}}
@@ -9942,6 +9942,11 @@ will output:
 pp. 5, 123-9, 423-39
 p. 5, pp. 123-9, pp. 423-39
 \end{ltxexample}
+
+\cmditem{mknormrange}[postpro]{text}
+\cmditem*{mknormrange*}[postpro]{text}
+
+This command, which is intended for use in field formatting directives, will parse its \prm{text} argument for page ranges and will normalise them. The command is similar to \cmd{mkcomprange} except that the page ranges will not be compressed. The scanner recognises \cmd{bibrangedash} and hyphens as range dashes. It will normalize the dash by replacing any number of consecutive hyphens with \cmd{bibrangedash}. Lists of ranges delimited with \cmd{bibrangessep} are also supported. The scanner will normalise any comma or semi-colons surrounded by optional space by replacing them with \cmd{bibrangessep}. If you want to hide a character from the list/range scanner for some reason, wrap the character or the entire string in curly braces. The optional \prm{postpro} argument specifies a macro to be used for post-processing the \prm{text}. See \cmd{mkcomprange} on how to use this argument. The starred version of this command differs from the regular one in the way the \prm{postpro} argument is applied to a list of values.
 
 \cmditem{mkfirstpage}[postpro]{text}
 \cmditem*{mkfirstpage*}[postpro]{text}
@@ -13240,6 +13245,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{changelog}
 \begin{release}{??}{20??-??-??}
 \item Added \opt{driver} and \opt{biblistfilter} options to \cmd{printbiblist}\see{use:bib:biblist}
+\item Added \cmd{mknormrange}\see{aut:aux:msc}
 \end{release}
 
 \begin{release}{3.10}{2017-12-19}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -419,9 +419,9 @@
   \ifcapital{\MakeCapital{#1}}{#1}\isdot}
 % citation commands
 \DeclareFieldFormat{prenote}{#1\isdot}
-\DeclareFieldFormat{postnote}{\mkpageprefix[pagination]{#1}}
+\DeclareFieldFormat{postnote}{\mkpageprefix[pagination][\mknormrange]{#1}}
 \DeclareFieldFormat{volcitevolume}{\bibstring{volume}\ppspace#1}
-\DeclareFieldFormat{volcitepages}{\mkpageprefix[pagination]{#1}}
+\DeclareFieldFormat{volcitepages}{\mkpageprefix[pagination][\mknormrange]{#1}}
 \DeclareFieldFormat{volcitenote}{\mkvolcitenote#1}
 \newrobustcmd*{\mkvolcitenote}[2]{%
   \printtext[volcitevolume]{#1}%
@@ -429,7 +429,7 @@
 
 % multicite commands
 \DeclareFieldFormat{multiprenote}{#1\isdot}
-\DeclareFieldFormat{multipostnote}{\mkpageprefix[pagination]{#1}}
+\DeclareFieldFormat{multipostnote}{\mkpageprefix[pagination][\mknormrange]{#1}}
 
 % Used by \citeurl
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -2978,20 +2978,119 @@
     {}}
 
 % <*>[<postpro>]{<string>}
+\newrobustcmd*{\mknormrange}{%
+  \begingroup
+  \@ifstar
+    {\blx@range@aux\blx@normrange@ii}
+    {\blx@range@aux\blx@normrange@i}}
+
+\def\blx@range@aux#1{%
+  \@ifnextchar[{#1}{#1[\@firstofone]}}
+
+\def\blx@normrange@i[#1]#2{%
+  \let\blx@tempa\@empty
+  \protected\def\blx@range@out@value{\appto\blx@tempa}%
+  \let\blx@range@out@delim\blx@range@out@value
+  \let\blx@range@split\blx@normrange@split
+  \let\blx@range@process\blx@normrange@process
+  \blx@range@chunk{#2}%
+  \edef\blx@tempa{\endgroup
+    \unexpanded{#1}{\expandonce\blx@tempa}}%
+  \blx@tempa}
+
+\def\blx@normrange@ii[#1]#2{%
+  \protected\def\blx@range@out@value{#1}%
+  \let\blx@range@out@delim\@firstofone
+  \let\blx@range@split\blx@normrange@split
+  \let\blx@range@process\blx@normrange@process
+  \blx@range@chunk{#2}%
+  \endgroup}
+
+\def\blx@range@chunk#1{%
+  \blx@range@chunk@semcol#1;&}
+
+\def\blx@range@chunk@semcol#1;#2&{%
+  \notblank{#1}
+    {\blx@range@chunk@comma#1,&}
+    {}%
+  \notblank{#2}
+    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
+     \blx@range@chunk@semcol#2&}
+    {}}
+
+\def\blx@range@chunk@comma#1,#2&{%
+  \notblank{#1}
+    {\blx@range@chunk@sep#1\bibrangessep&}
+    {}%
+  \notblank{#2}
+    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
+     \blx@range@chunk@comma#2&}
+    {}}
+
+\def\blx@range@chunk@sep#1\bibrangessep#2&{%
+  \notblank{#1}
+    {\expandafter\blx@range@split
+     \expandafter{\@firstofone#1}}
+    {}%
+  \notblank{#2}
+    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
+     \blx@range@chunk@sep#2&}
+    {}}
+
+\def\blx@normrange@split#1{%
+  \def\blx@normrange@abort{\blx@range@out@value{#1}}%
+  \blx@imc@ifpages{#1}
+    {\blx@normrange@range#1\bibrangedash\bibrangedash&}
+    {\blx@normrange@abort}}
+
+\def\blx@normrange@range#1\bibrangedash#2\bibrangedash#3&{%
+  \ifblank{#3}
+    {\blx@normrange@hyphen#1--&}
+    {\ifblank{#2}
+       {\blx@range@out@value{#1\bibrangedash}}
+       {\ifblank{#1}
+          {\blx@range@out@value{\bibrangedash#2}}
+          {\blx@range@process{#1}{#2}}}}}
+
+\def\blx@normrange@hyphen#1-#2-#3&{%
+  \ifblank{#3}
+    {\blx@normrange@abort}
+    {\ifblank{#2}
+       {\ifblank{#1}
+          {\let\blx@tempb\@empty}
+          {\def\blx@tempb{#1}}%
+        \blx@normrange@hyphen@i#3&}
+       {\ifblank{#1}
+          {\blx@range@out@value{\bibrangedash#2}}
+          {\blx@range@process{#1}{#2}}}}}
+
+\def\blx@normrange@hyphen@i#1-#2&{%
+  \ifblank{#1#2}
+    {\expandafter\blx@range@out@value
+     \expandafter{\blx@tempb\bibrangedash}}
+    {\notblank{#1}
+       {\ifdefempty\blx@tempb
+          {\blx@range@out@value{\bibrangedash#1}}
+          {\expandafter\blx@range@process
+           \expandafter{\blx@tempb}{#1}}}
+       {\blx@normrange@hyphen@i#2&}}}
+
+\def\blx@normrange@process#1#2{%
+  \blx@range@out@value{#1\bibrangedash#2}}
+
+% <*>[<postpro>]{<string>}
 \newrobustcmd*{\mkcomprange}{%
   \begingroup
   \@ifstar
-    {\blx@comprange\blx@comprange@ii}
-    {\blx@comprange\blx@comprange@i}}
-
-\def\blx@comprange#1{%
-  \@ifnextchar[{#1}{#1[\@firstofone]}}
+    {\blx@range@aux\blx@comprange@ii}
+    {\blx@range@aux\blx@comprange@i}}
 
 \def\blx@comprange@i[#1]#2{%
   \let\blx@tempa\@empty
   \protected\def\blx@range@out@value{\appto\blx@tempa}%
   \let\blx@range@out@delim\blx@range@out@value
-  \let\blx@range@split\blx@comprange@split
+  \let\blx@range@split\blx@normrange@split
+  \let\blx@range@process\blx@comprange@check
   \blx@range@chunk{#2}%
   \edef\blx@tempa{\endgroup
     \unexpanded{#1}{\expandonce\blx@tempa}}%
@@ -3000,47 +3099,10 @@
 \def\blx@comprange@ii[#1]#2{%
   \protected\def\blx@range@out@value{#1}%
   \let\blx@range@out@delim\@firstofone
-  \let\blx@range@split\blx@comprange@split
+  \let\blx@range@split\blx@normrange@split
+  \let\blx@range@process\blx@comprange@check
   \blx@range@chunk{#2}%
   \endgroup}
-
-\def\blx@comprange@split#1{%
-  \def\blx@comprange@abort{\blx@range@out@value{#1}}%
-  \blx@imc@ifpages{#1}
-    {\blx@comprange@range#1\bibrangedash\bibrangedash&}
-    {\blx@comprange@abort}}
-
-\def\blx@comprange@range#1\bibrangedash#2\bibrangedash#3&{%
-  \ifblank{#3}
-    {\blx@comprange@hyphen#1--&}
-    {\ifblank{#2}
-       {\blx@range@out@value{#1\bibrangedash}}
-       {\ifblank{#1}
-          {\blx@range@out@value{\bibrangedash#2}}
-          {\blx@comprange@check{#1}{#2}}}}}
-
-\def\blx@comprange@hyphen#1-#2-#3&{%
-  \ifblank{#3}
-    {\blx@comprange@abort}
-    {\ifblank{#2}
-       {\ifblank{#1}
-          {\let\blx@tempb\@empty}
-          {\def\blx@tempb{#1}}%
-        \blx@comprange@hyphen@i#3&}
-       {\ifblank{#1}
-          {\blx@range@out@value{\bibrangedash#2}}
-          {\blx@comprange@check{#1}{#2}}}}}
-
-\def\blx@comprange@hyphen@i#1-#2&{%
-  \ifblank{#1#2}
-    {\expandafter\blx@range@out@value
-     \expandafter{\blx@tempb\bibrangedash}}
-    {\notblank{#1}
-       {\ifdefempty\blx@tempb
-          {\blx@range@out@value{\bibrangedash#1}}
-          {\expandafter\blx@comprange@check
-           \expandafter{\blx@tempb}{#1}}}
-       {\blx@comprange@hyphen@i#2&}}}
 
 \def\blx@comprange@check#1#2{%
   \blx@imc@ifinteger{#1}
@@ -3101,37 +3163,6 @@
   \else
     \expandafter\blx@comprange@end
   \fi}
-
-\def\blx@range@chunk#1{%
-  \blx@range@chunk@semcol#1;&}
-
-\def\blx@range@chunk@semcol#1;#2&{%
-  \notblank{#1}
-    {\blx@range@chunk@comma#1,&}
-    {}%
-  \notblank{#2}
-    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
-     \blx@range@chunk@semcol#2&}
-    {}}
-
-\def\blx@range@chunk@comma#1,#2&{%
-  \notblank{#1}
-    {\blx@range@chunk@sep#1\bibrangessep&}
-    {}%
-  \notblank{#2}
-    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
-     \blx@range@chunk@comma#2&}
-    {}}
-
-\def\blx@range@chunk@sep#1\bibrangessep#2&{%
-  \notblank{#1}
-    {\expandafter\blx@range@split
-     \expandafter{\@firstofone#1}}
-    {}%
-  \notblank{#2}
-    {\notblank{#1}{\blx@range@out@delim{\bibrangessep}}{}%
-     \blx@range@chunk@sep#2&}
-    {}}
 
 % <*>[<postpro>]{<string>}
 \newrobustcmd*{\mkfirstpage}{%


### PR DESCRIPTION
Extract the normalisation bits of `\mkcomprange` as `\mknormrange` and share the code between the two macros.

Use `\mknormrange` to normalise page ranges in `postnote`-like fields. This change is strictly speaking backwards **incompatible** (cf. discussion in #293). Hopefully this is not too much of a problem, since users that are using `\bibrangedash`/`--` with standard spacing already shouldn't see much of a difference. Instructions are provided to restore the old non-normalising behaviour of the field formats.