### PR TITLE
Make entrytype/entrykey available at bbl input

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6987,10 +6987,10 @@
   \blx@bbl@options{#3}%
   \blx@setoptions@entry
   \edef\blx@bbl@data{blx@data@\the\c@refsection @\blx@dlist@name @\abx@field@entrykey}%
-  \csuse\blx@bbl@data
   \blx@bbl@addfield{entrykey}{\abx@field@entrykey}%
   \listxadd\blx@entries{\abx@field@entrykey}%
   \blx@bbl@addfield{entrytype}{#2}%
+  \csuse\blx@bbl@data
   \blx@imc@iffieldundef{options}
     {}
     {\blx@bbl@fieldedef{options}{\expandonce\abx@field@options}}}


### PR DESCRIPTION
Execute `\blx@bbl@data` just a tad later, so `entrykey` and `entrytype` are
already known.

Now the input handlers can filter by `entrytype` or `entrykey` with `\DeclareFieldInputHandler{title}{\ifentrytype{article}{\def\NewValue{}}{}}`. See https://tex.stackexchange.com/q/410384/35864

Preliminary tests have shown no problem with this change. But a run of the test suite would be appreciated.
