### PR TITLE
Extend field annotations (#690)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -31,6 +31,8 @@
   versions.
 - The `@unpublished` entry type now also supports `type`, `eventtitle`,
   `eventdate` and `venue`.
+- Added `\ifdateannotation`. Added optional argument for field and item to
+  `\iffieldannotation`, `\ifitemannotation`, and `\ifpartannotation`.
 
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3174,21 +3174,27 @@ To access the annotation information when formatting bibliography data, three ma
 
 \begin{ltxsyntax}
 
-\cmditem{iffieldannotation}{annotation}{true}{false}
+\cmditem{iffieldannotation}[field]{annotation}{true}{false}
 
-Executes \prm{true} if the current data field has an annotation \prm{annotation} and false otherwise.
+Executes \prm{true} if the data field \prm{field} has an annotation \prm{annotation} and false otherwise. If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
 
-\cmditem{ifitemannotation}{annotation}{true}{false}
+\cmditem{ifitemannotation}[field][item]{annotation}{true}{false}
 
-Executes \prm{true} if the current item in the current data field has an annotation \prm{annotation} and false otherwise.
+Executes \prm{true} if the item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. The optional argument \prm{field} can be inferred if not provided as with \cmd{iffieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
 
-\cmditem{ifpartannotation}{part}{annotation}{true}{false}
+\cmditem{ifpartannotation}[field][item]{part}{annotation}{true}{false}
 
-Executes \prm{true} if the part named \prm{part} in current item in the current data field has an annotation \prm{annotation} and false otherwise.
+Executes \prm{true} if the part named \prm{part} in item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{ifitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
+
+Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to access annotations for dates.
+
+\cmditem{ifdateannotation}{datetype}{annotation}{true}{false}
+
+Executes \prm{true} if the date field \prm{datetype} has an annotation \prm{annotation} and false otherwise. The \prm{datetype} argument is mandatory, because it can not be inferred in most contexts where \cmd{ifdateannotation} will be used.
 
 \end{ltxsyntax}
 %
-These macros are available in the same places as \cmd{currentfield}, \cmd{currentlist} and \cmd{currentname} (see \secref{aut:bib:fmt}), that is, inside formatting directives. They automatically determine the name of the current data field being processed and also the current \opt{listcount} value which determines the current item in list fields. Parts such as name parts need to be named explicitly. As an example of how to use the annotation information to solve the problem originally presented in this section, this could be used in the name formatting directives to put an asterisk after all family names annotated as «student»:
+As an example of how to use the annotation information to solve the problem originally presented in this section, this could be used in the name formatting directives to put an asterisk after all family names annotated as «student»:
 
 \begin{lstlisting}[style=latex]{}
   \ifpartannotation{family}{student}
@@ -3209,15 +3215,6 @@ To put the given and family names of name list items annotated as «correspondin
     {\textbf{#1}}
     {#1}}
 \end{lstlisting}
-
-Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to access annotations for dates.
-
-\begin{ltxsyntax}
-\cmditem{ifdateannotation}{datetype}{annotation}{true}{false}
-
-Executes \prm{true} if the date \prm{datetype} has an annotation \prm{annotation} and false otherwise.
-
-\end{ltxsyntax}
 
 \subsection{Bibliography Commands}
 \label{use:bib}
@@ -13257,6 +13254,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \opt{driver} and \opt{biblistfilter} options to \cmd{printbiblist}\see{use:bib:biblist}
 \item Added \cmd{mknormrange}\see{aut:aux:msc}
 \item Added \cmd{ifdateannotation}\see{use:annote}
+\item Extended \cmd{iffieldannotation} and friends\see{use:annote}
 \end{release}
 
 \begin{release}{3.10}{2017-12-19}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3213,9 +3213,9 @@ To put the given and family names of name list items annotated as «correspondin
 Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to access annotations for dates.
 
 \begin{ltxsyntax}
-\cmditem{ifdateannotation}{datetype prefix}{annotation}{true}{false}
+\cmditem{ifdateannotation}{datetype}{annotation}{true}{false}
 
-Executes \prm{true} if \mbox{\prm{datetype prefix}\bibfield{date}} has an annotation \prm{annotation} and false otherwise.
+Executes \prm{true} if the date \prm{datetype} has an annotation \prm{annotation} and false otherwise.
 
 \end{ltxsyntax}
 

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3210,6 +3210,15 @@ To put the given and family names of name list items annotated as «correspondin
     {#1}}
 \end{lstlisting}
 
+Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to access annotations for dates.
+
+\begin{ltxsyntax}
+\cmditem{ifdateannotation}{datetype prefix}{annotation}{true}{false}
+
+Executes \prm{true} if \mbox{\prm{datetype prefix}\bibfield{date}} has an annotation \prm{annotation} and false otherwise.
+
+\end{ltxsyntax}
+
 \subsection{Bibliography Commands}
 \label{use:bib}
 
@@ -7010,7 +7019,7 @@ contains the value of the name, \cmd{NewCount} contains the number of individual
 \subsubsection{Formatting Directives}
 \label{aut:bib:fmt}
 
-This section introduces the commands used to define the formatting directives required by the data commands from \secref{aut:bib:dat}. Note that all standard formats are defined in \path{biblatex_.def}.
+This section introduces the commands used to define the formatting directives required by the data commands from \secref{aut:bib:dat}. Note that all standard formats are defined in \path{biblatex.def}.
 
 \begin{ltxsyntax}
 
@@ -13247,6 +13256,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{release}{??}{20??-??-??}
 \item Added \opt{driver} and \opt{biblistfilter} options to \cmd{printbiblist}\see{use:bib:biblist}
 \item Added \cmd{mknormrange}\see{aut:aux:msc}
+\item Added \cmd{ifdateannotation}\see{use:annote}
 \end{release}
 
 \begin{release}{3.10}{2017-12-19}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6586,13 +6586,13 @@
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
-  \@ifnextchar[%
+  \@ifnextchar[%]
     {\blx@imc@ifitemannotation@i}
     {\blx@imc@ifitemannotation@i[\blx@tempa]}
 }
 
 \def\blx@imc@ifitemannotation@i[#1]{%
-  \@ifnextchar[%
+  \@ifnextchar[%]
     {\blx@imc@ifitemannotation@ii{#1}}
     {\blx@imc@ifitemannotation@ii{#1}[\the\value{listcount}]}}
 
@@ -6606,13 +6606,12 @@
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
-  \@ifnextchar[%
+  \@ifnextchar[%]
     {\blx@imc@ifpartannotation@i}
-    {\blx@imc@ifpartannotation@i[\blx@tempa]}
-}
+    {\blx@imc@ifpartannotation@i[\blx@tempa]}}
 
 \def\blx@imc@ifpartannotation@i[#1]{%
-  \@ifnextchar[%
+  \@ifnextchar[%]
     {\blx@imc@ifpartannotation@ii{#1}}
     {\blx@imc@ifpartannotation@ii{#1}[\the\value{listcount}]}}
 
@@ -6622,6 +6621,10 @@
   \ifinlistcs{#4}{abx@annotation@part@\blx@tempb @#2@#3}}
 
 % {<datetype>}{<annotation>}
+% labeldatesource has a slightly different format than other <field>sources
+% that's one reason for a dedicated command, the other being that this command
+% is probably only used in contexts where \currentfield is not defined, so
+% the <datetype> argument is always required
 \newcommand*{\blx@imc@ifdateannotation}[2]{%
   \def\blx@tempa{#1}%
   \ifcsundef{abx@field@\blx@tempa source}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6571,29 +6571,55 @@
          \docsvlist{#5}}}
      {}}
 
-% {<annotation>}
-\newcommand*{\blx@imc@iffieldannotation}[1]{%
-  \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
-  \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
-  \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
+% [<field>]{<annotation>}
+\newcommand*{\blx@imc@iffieldannotation}[2][]{%
+  \ifblank{#1}
+    {\ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
+     \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
+     \ifdefvoid\currentname{}{\let\blx@tempa\currentname}}
+    {\def\blx@tempa{#1}}%
   \blx@resolve@annotation@label{\blx@tempa}%
-  \ifinlistcs{#1}{abx@annotation@field@\blx@tempa}}
+  \ifinlistcs{#2}{abx@annotation@field@\blx@tempa}}
 
-% {<annotation>}
-\newcommand*{\blx@imc@ifitemannotation}[1]{%
+% [<field>][<item>]{<annotation>}
+\def\blx@imc@ifitemannotation{%
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
-  \blx@resolve@annotation@label{\blx@tempa}%
-  \ifinlistcs{#1}{abx@annotation@item@\blx@tempa @\the\value{listcount}}}
+  \@ifnextchar[%
+    {\blx@imc@ifitemannotation@i}
+    {\blx@imc@ifitemannotation@i[\blx@tempa]}
+}
 
-% {<part>}{<annotation>}
-\newcommand*{\blx@imc@ifpartannotation}[2]{%
+\def\blx@imc@ifitemannotation@i[#1]{%
+  \@ifnextchar[%
+    {\blx@imc@ifitemannotation@ii{#1}}
+    {\blx@imc@ifitemannotation@ii{#1}[\the\value{listcount}]}}
+
+\def\blx@imc@ifitemannotation@ii#1[#2]#3{%
+  \def\blx@tempb{#1}%
+  \blx@resolve@annotation@label{\blx@tempb}%
+  \ifinlistcs{#3}{abx@annotation@item@\blx@tempb @#2}}
+
+% [<field>][<item>]{<part>}{<annotation>}
+\def\blx@imc@ifpartannotation{%
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
-  \blx@resolve@annotation@label{\blx@tempa}%
-  \ifinlistcs{#2}{abx@annotation@part@\blx@tempa @\the\value{listcount}@#1}}
+  \@ifnextchar[%
+    {\blx@imc@ifpartannotation@i}
+    {\blx@imc@ifpartannotation@i[\blx@tempa]}
+}
+
+\def\blx@imc@ifpartannotation@i[#1]{%
+  \@ifnextchar[%
+    {\blx@imc@ifpartannotation@ii{#1}}
+    {\blx@imc@ifpartannotation@ii{#1}[\the\value{listcount}]}}
+
+\def\blx@imc@ifpartannotation@ii#1[#2]#3#4{%
+  \def\blx@tempb{#1}%
+  \blx@resolve@annotation@label{\blx@tempb}%
+  \ifinlistcs{#4}{abx@annotation@part@\blx@tempb @#2@#3}}
 
 % {<datetype>}{<annotation>}
 \newcommand*{\blx@imc@ifdateannotation}[2]{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6572,7 +6572,7 @@
      {}}
 
 % {<annotation>}
-\newcommand*{\iffieldannotation}[1]{%
+\newcommand*{\blx@imc@iffieldannotation}[1]{%
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
@@ -6580,7 +6580,7 @@
   \ifinlistcs{#1}{abx@annotation@field@\blx@tempa}}
 
 % {<annotation>}
-\newcommand*{\ifitemannotation}[1]{%
+\newcommand*{\blx@imc@ifitemannotation}[1]{%
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
@@ -6588,12 +6588,24 @@
   \ifinlistcs{#1}{abx@annotation@item@\blx@tempa @\the\value{listcount}}}
 
 % {<part>}{<annotation>}
-\newcommand*{\ifpartannotation}[2]{%
+\newcommand*{\blx@imc@ifpartannotation}[2]{%
   \ifdefvoid\currentfield{}{\let\blx@tempa\currentfield}%
   \ifdefvoid\currentlist{}{\let\blx@tempa\currentlist}%
   \ifdefvoid\currentname{}{\let\blx@tempa\currentname}%
   \blx@resolve@annotation@label{\blx@tempa}%
   \ifinlistcs{#2}{abx@annotation@part@\blx@tempa @\the\value{listcount}@#1}}
+
+% {<date type prefix>}{<annotation>}
+\newcommand*{\blx@imc@ifdateannotation}[2]{%
+  \def\blx@tempa{#1}%
+  \ifcsundef{abx@field@\blx@tempa source}
+    {}%
+    {\letcs\blx@tempa{abx@field@\blx@tempa source}%
+     \edef\blx@tempa{\blx@tempa date}}%
+  \ifinlistcs{#2}{abx@annotation@field@\blx@tempa}}
+
+\blx@regimcs{\iffieldannotation \ifitemannotation \ifpartannotation
+             \ifdateannotation}
 
 % {<fieldname>}
 \def\blx@resolve@annotation@label#1{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6595,7 +6595,7 @@
   \blx@resolve@annotation@label{\blx@tempa}%
   \ifinlistcs{#2}{abx@annotation@part@\blx@tempa @\the\value{listcount}@#1}}
 
-% {<date type prefix>}{<annotation>}
+% {<datetype>}{<annotation>}
 \newcommand*{\blx@imc@ifdateannotation}[2]{%
   \def\blx@tempa{#1}%
   \ifcsundef{abx@field@\blx@tempa source}


### PR DESCRIPTION
* Implement `\ifdateannotation`
* Extend `\iffieldannotation` and friend to accept an optional argument to explicitly give the field and item.

See #690