### PR TITLE
Revamp .lbx loading

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -34,6 +34,18 @@
 - Added `\ifdateannotation`. Added optional argument for field and item to
   `\iffieldannotation`, `\ifitemannotation`, and `\ifpartannotation`.
 - `\DeclareSourcemap` can now be used multiple times.
+- **INCOMPATIBLE CHANGE** Language aliases are now also resolved when loading
+  localisation files, only infinite recursion is avoided.
+  Assuming `\DeclareLanguageMappingSuffix{-apa}`, loading `ngerman` localisation
+  causes `ngerman-apa.lbx` to be read. If that file inherits from `german`,
+  `german-apa.lbx` will be read. Previously only `german.lbx` would have been
+  read at that point. Of course if `german-apa.lbx` inherits from `german`,
+  `german.lbx` is loaded at that point, so infinite recursion is avoided.
+- **CRITICAL CHANGE** The code to load localisation files was changed.
+  This is a an internal change and should not influence document output,
+  save for a few bug fixes. Style authors should check if the changes introduce
+  any bugs for their localisation handling and report them.
+  
 
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -10552,7 +10552,7 @@ This command defines a language file suffix which will be added when looking for
 %
 When the document language is <german>, \biblatex will look for the file \file{german-apa.lbx} which defines some APA specific strings and in turn loads \file{german.lbx}. If \cmd{DeclareLanguageMapping} is defined for a language, this overrides \cmd{DeclareLanguageMappingSuffix}.
 
-Note that the suffix will not be applied to language files loaded recursively by the loading of a language file. For example, given the suffix defined above, when loading <ngerman>, \biblatex will look for the file \file{ngerman-apa.lbx} and if this recursively loads <german>, then biblatex will look for \file{german.lbx} and \emph{not} \file{german-apa.lbx}.
+The suffix will be applied to other language files loaded recursively by the loading of a language file. For example, given the suffix defined above, when loading <ngerman>, \biblatex will look for the file \file{ngerman-apa.lbx} and if this recursively loads <german>, then biblatex will look for \file{german-apa.lbx}. Infinite recursion is of course avoided.
 
 \cmditem{NewBibliographyString}{key}
 
@@ -12556,6 +12556,8 @@ If the document language is set to \texttt{french}, \path{french-humanities.lbx}
 \DeclareLanguageMapping{american}{american-mla}
 \end{ltxexample}
 %
+Use \cmd{DeclareLanguageMappingSuffix} (see \secref{aut:lng:cmd}) to define such a mapping for all languages.
+
 Since the alternative \file{lbx} file can inherit strings from the standard \path{american.lbx} module, \path{american-mla.lbx} may be as short as this:
 
 \begin{ltxexample}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5023,6 +5023,8 @@
   \csgdef{blx@lng@explicit@#1}{#2}}
 \@onlypreamble\DeclareLanguageMapping
 
+% to avoid copying, these commands simply redefine the input handlers and
+% process and postprocess code
 % {<language>}{<success>}{<failure>}
 \def\blx@lbxinput#1{%
   \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@once}%
@@ -5072,6 +5074,9 @@
        \global\cslet{blx@suffmaptried@#2}\@empty}%
      \blx@lbxinput@iv{#2}{#2}{language '#2'}}}
 
+% .lbx files must be read with one of the two following commands,
+% do not use \blx@inputonce. Only the commands here make sure that the file
+% is read as many times as necessary.
 % {<file>}{<message>}{<preload>}{<postload>}{<success>}{<failure>}
 \protected\long\def\blx@lbx@input@handler@simple#1#2#3#4#5#6{%
   \blx@info@noline{Trying to load #2..}%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -613,7 +613,6 @@
 \newtoggle{blx@bibindex}
 \newtoggle{blx@localnumber}
 \newtoggle{blx@refcontext}
-\newtoggle{blx@nosuffrecurse}
 
 % Nice command from etextools which causes too many problems if you load
 % the whole package
@@ -4906,8 +4905,7 @@
 % in *.cbx/bbx/tex: (implicit)
 % in *.lbx:         inherit = {<language>},
 \define@key{blx@lbx}{inherit}{%
-  \global\toggletrue{blx@nosuffrecurse}%
-  \blx@lbxinput{#1}{}{\blx@err@nolang{#1}}%
+  \blx@lbxinput@strings{#1}{}{\blx@err@nolang{#1}}%
   \csuse{abx@strings@#1}}
 
 \def\blx@cfg@defstring#1#2{%
@@ -4950,8 +4948,7 @@
 
 % {<language>}{<language>}
 \def\blx@letbibextras#1#2{%
-  \global\toggletrue{blx@nosuffrecurse}%
-  \blx@lbxinput{#2}{}{\blx@err@nolang{#2}}%
+  \blx@lbxinput@extras{#2}{}{\blx@err@nolang{#2}}%
   \global\csletcs{abx@extras@#1}{abx@extras@#2}
   \global\csletcs{abx@noextras@#1}{abx@noextras@#2}}%
 
@@ -4995,8 +4992,7 @@
 
 % {<language>}{<language>}
 \def\blx@letbibstrings#1#2{%
-  \global\toggletrue{blx@nosuffrecurse}%
-  \blx@lbxinput{#2}{}{\blx@err@nolang{#2}}%
+  \blx@lbxinput@strings{#2}{}{\blx@err@nolang{#2}}%
   \global\csletcs{abx@strings@#1}{abx@strings@#2}}%
 
 % {<language>}{<exceptions>}
@@ -5029,76 +5025,121 @@
 
 % {<language>}{<success>}{<failure>}
 \def\blx@lbxinput#1{%
-  \ifdefempty\blx@lng@suff
-    {}
-    {\ifcsdef{blx@lng@explicit@#1}% \DeclareLanguageMapping overrides \DeclareLanguageMappingSuffix
-      {}
-      {\nottoggle{blx@nosuffrecurse}
-        {\csgdef{blx@lng@#1}{#1\blx@lng@suff}}
-        {}}}%
-    \blx@lbxinput@0{#1}}
+  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@all}%
+  \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@once}%
+  \blx@lbxinput@i{#1}}
 
-\def\blx@lbxinput@0#1{%
+\def\blx@lbxinput@strings#1{%
+  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@strings}%
+  \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@simple}%
+  \blx@lbxinput@i{#1}}
+  
+\def\blx@lbxinput@extras#1{%
+  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@extras}%
+  \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@simple}%
+  \blx@lbxinput@i{#1}}
+
+\def\blx@lbxinput@i#1{%
+  \ifcsundef{blx@nolbxrecurse@#1}
+    {\ifcsdef{blx@lng@explicit@#1}
+       {\global\csletcs{blx@lng@#1}{blx@lng@explicit@#1}}
+       {\ifdefempty\blx@lng@suff
+          {}
+          {\csgdef{blx@lng@#1}{#1\blx@lng@suff}}}}
+    {}%
+  \blx@lbxinput@ii{#1}}
+
+\def\blx@lbxinput@ii#1{%
   \ifcsdef{blx@lng@#1}
-    {\expandafter\expandafter\expandafter\blx@lbxinput@i
+    {\expandafter\expandafter\expandafter\blx@lbxinput@iii
      \expandafter\expandafter\expandafter{%
        \csname blx@lng@#1\endcsname}{#1}}
-    {\blx@lbxinput@ii{#1}{#1}{language '#1'}}}
+    {\blx@lbxinput@iv{#1}{#1}{language '#1'}}}
 
 % {<mapping>}{<language>}
-\def\blx@lbxinput@i#1#2{%
+\def\blx@lbxinput@iii#1#2{%
   \global\csundef{blx@lng@#2}%
   \IfFileExists{#1.lbx}
-    {\blx@lbxinput@ii{#2}{#1}{language '#2' -> '#1'}}
+    {\blx@lbxinput@iv{#2}{#1}{language '#2' -> '#1'}}
     {\ifcsdef{blx@suffmaptried@#2}
       {}
       {\blx@warning@noline{%
           File '#1.lbx' not found!\MessageBreak
           Ignoring mapping '#2' -> '#1'}%
-       \cslet{blx@suffmaptried@#2}\@empty}%
-     \blx@lbxinput@0{#2}}}
+       \global\cslet{blx@suffmaptried@#2}\@empty}%
+     \blx@lbxinput@iv{#2}{#2}{language '#2'}}}
+
+\def\blx@lbx@input@process@strings#1{
+  \global\cslet{abx@strings@#1}\@empty
+  \def\InheritBibliographyStrings{%
+    \blx@letbibstrings{#1}}%
+  \def\DeclareBibliographyStrings##1{%
+    \begingroup
+      \let\blx@defstring\blx@lbx@defstring
+      \blx@defbibstrings{#1}{##1}%
+    \endgroup}}
+
+\def\blx@lbx@input@process@extras#1{%
+  \global\cslet{abx@extras@#1}\@empty
+  \global\cslet{abx@noextras@#1}\@empty
+  \def\InheritBibliographyExtras{\blx@letbibextras{#1}}%
+  \def\DeclareBibliographyExtras{\blx@defbibextras{#1}}%
+  \def\UndeclareBibliographyExtras{\blx@undefbibextras{#1}}}
+
+\def\blx@lbx@input@process@all#1{%
+  \blx@lbx@input@process@strings{#1}%
+  \blx@lbx@input@process@extras{#1}%
+  \def\DeclareHyphenationExceptions{\blx@hyphexcept{#1}}}
+
+% {<file>}{<message>}{<preload>}{<postload>}{<success>}{<failure>}
+\protected\long\def\blx@lbx@input@handler@simple#1#2#3#4#5#6{%
+  \blx@info@noline{Trying to load #2..}%
+  \IfFileExists{#1}
+    {\blx@info@noline{... file '#1' found}%
+     \ifcsundef{blx@file@lbx@#1}
+       {\listxadd\blx@list@req@stat{#1}%
+        \@addtofilelist{#1}
+        \global\cslet{blx@file@lbx@#1}\@empty}
+       {}%
+     #3\@@input\@filef@und#4#5}
+    {\blx@info@noline{... file '#1' not found}#6}}
+
+% {<file>}{<message>}{<preload>}{<postload>}{<success>}{<failure>}
+\protected\long\def\blx@lbx@input@handler@once#1#2#3#4#5#6{%
+  \ifcsundef{blx@file@lbx@#1}
+    {\blx@info@noline{Trying to load #2..}%
+     \global\cslet{blx@file@lbx@#1}\@empty
+     \IfFileExists{#1}
+       {\blx@info@noline{... file '#1' found}%
+        \listxadd\blx@list@req@stat{#1}%
+        \@addtofilelist{#1}%
+        #3\@@input\@filef@und#4#5}
+       {\blx@info@noline{... file '#1' not found}#6}}
+    {#5}}
 
 % {<language>}{<lbxfile>}{<message>}
-% toggle 'blx@nosuffrecurse' is set to true at the places where recursion into here
-% can occur when loading a .lbx otherwise, when using \DeclareLanguageMappingSuffix
-% it is possible to get into infinite loops. We only want to apply the suffix to explicitly
-% loaded languages, not those loaded by recursion.
-\def\blx@lbxinput@ii#1#2#3{%
+\def\blx@lbxinput@iv#1#2#3{%
   \begingroup
-  \setbox\@tempboxa=\hbox\bgroup
-    \aftergroup\endgroup
-    \blx@inputonce{#2.lbx}{#3}
-      {\global\cslet{abx@strings@#1}\@empty
-       \global\cslet{abx@extras@#1}\@empty
-       \global\cslet{abx@noextras@#1}\@empty
-       \blx@maplang{#1}{#1}%
-       \def\InheritBibliographyStrings{%
-         \blx@letbibstrings{#1}}%
-       \def\DeclareBibliographyStrings####1{%
-         \begingroup
-         \let\blx@defstring\blx@lbx@defstring
-         \blx@defbibstrings{#1}{####1}%
-         \endgroup}%
-       \def\InheritBibliographyExtras{\blx@letbibextras{#1}}%
-       \def\DeclareBibliographyExtras{\blx@defbibextras{#1}}%
-       \def\UndeclareBibliographyExtras{\blx@undefbibextras{#1}}%
-       \def\DeclareHyphenationExceptions{\blx@hyphexcept{#1}}%
+    \blx@lbx@input@handler{#2.lbx}{#3}
+      {\blx@maplang{#1}{#1}%
+       \let\InheritBibliographyStrings\@gobble
+       \let\DeclareBibliographyStrings\@gobble
+       \let\InheritBibliographyExtras\@gobble
+       \let\DeclareBibliographyExtras\@gobble
+       \let\UndeclareBibliographyExtras\@gobble
+       \blx@lbx@input@process{#1}%
        \begingroup
+       \cslet{blx@nolbxrecurse@#1}\@empty
        \blx@saneccodes
        \makeatletter}
       {\endgroup
        \csuse{blx@hook@strings@#1}%
-       \csuse{blx@hook@strings@#2}%
        \csuse{blx@hook@extras@#1}%
-       \csuse{blx@hook@extras@#2}%
        \csuse{blx@hook@noextras@#1}%
-       \csuse{blx@hook@noextras@#2}%
-       \csuse{blx@hook@hyph@#1}%
-       \csuse{blx@hook@hyph@#2}%
-       \global\togglefalse{blx@nosuffrecurse}}
+       \csuse{blx@hook@hyph@#1}}
       {\aftergroup\@firstoftwo}
       {\aftergroup\@secondoftwo}%
-  \egroup}
+  \endgroup}
 
 % {<language>}
 \def\blx@langsetup#1{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5025,18 +5025,21 @@
 
 % {<language>}{<success>}{<failure>}
 \def\blx@lbxinput#1{%
-  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@all}%
   \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@once}%
+  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@all}%
+  \csletcs{blx@lbx@input@postprocess}{blx@lbx@input@postprocess@all}%
   \blx@lbxinput@i{#1}}
 
 \def\blx@lbxinput@strings#1{%
+  \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@simple}%
   \csletcs{blx@lbx@input@process}{blx@lbx@input@process@strings}%
-  \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@simple}%
+  \csletcs{blx@lbx@input@postprocess}{blx@lbx@input@postprocess@strings}%
   \blx@lbxinput@i{#1}}
-  
+
 \def\blx@lbxinput@extras#1{%
-  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@extras}%
   \csletcs{blx@lbx@input@handler}{blx@lbx@input@handler@simple}%
+  \csletcs{blx@lbx@input@process}{blx@lbx@input@process@extras}%
+  \csletcs{blx@lbx@input@postprocess}{blx@lbx@input@postprocess@extras}%
   \blx@lbxinput@i{#1}}
 
 \def\blx@lbxinput@i#1{%
@@ -5069,28 +5072,6 @@
        \global\cslet{blx@suffmaptried@#2}\@empty}%
      \blx@lbxinput@iv{#2}{#2}{language '#2'}}}
 
-\def\blx@lbx@input@process@strings#1{
-  \global\cslet{abx@strings@#1}\@empty
-  \def\InheritBibliographyStrings{%
-    \blx@letbibstrings{#1}}%
-  \def\DeclareBibliographyStrings##1{%
-    \begingroup
-      \let\blx@defstring\blx@lbx@defstring
-      \blx@defbibstrings{#1}{##1}%
-    \endgroup}}
-
-\def\blx@lbx@input@process@extras#1{%
-  \global\cslet{abx@extras@#1}\@empty
-  \global\cslet{abx@noextras@#1}\@empty
-  \def\InheritBibliographyExtras{\blx@letbibextras{#1}}%
-  \def\DeclareBibliographyExtras{\blx@defbibextras{#1}}%
-  \def\UndeclareBibliographyExtras{\blx@undefbibextras{#1}}}
-
-\def\blx@lbx@input@process@all#1{%
-  \blx@lbx@input@process@strings{#1}%
-  \blx@lbx@input@process@extras{#1}%
-  \def\DeclareHyphenationExceptions{\blx@hyphexcept{#1}}}
-
 % {<file>}{<message>}{<preload>}{<postload>}{<success>}{<failure>}
 \protected\long\def\blx@lbx@input@handler@simple#1#2#3#4#5#6{%
   \blx@info@noline{Trying to load #2..}%
@@ -5117,6 +5098,40 @@
        {\blx@info@noline{... file '#1' not found}#6}}
     {#5}}
 
+\def\blx@lbx@input@process@strings#1{
+  \global\cslet{abx@strings@#1}\@empty
+  \def\InheritBibliographyStrings{%
+    \blx@letbibstrings{#1}}%
+  \def\DeclareBibliographyStrings##1{%
+    \begingroup
+      \let\blx@defstring\blx@lbx@defstring
+      \blx@defbibstrings{#1}{##1}%
+    \endgroup}}
+
+\def\blx@lbx@input@process@extras#1{%
+  \global\cslet{abx@extras@#1}\@empty
+  \global\cslet{abx@noextras@#1}\@empty
+  \def\InheritBibliographyExtras{\blx@letbibextras{#1}}%
+  \def\DeclareBibliographyExtras{\blx@defbibextras{#1}}%
+  \def\UndeclareBibliographyExtras{\blx@undefbibextras{#1}}}
+
+\def\blx@lbx@input@process@all#1{%
+  \blx@lbx@input@process@strings{#1}%
+  \blx@lbx@input@process@extras{#1}%
+  \def\DeclareHyphenationExceptions{\blx@hyphexcept{#1}}}
+
+\def\blx@lbx@input@postprocess@strings#1{
+  \csuse{blx@hook@strings@#1}}
+
+\def\blx@lbx@input@postprocess@extras#1{%
+  \csuse{blx@hook@extras@#1}%
+  \csuse{blx@hook@noextras@#1}}
+
+\def\blx@lbx@input@postprocess@all#1{%
+  \blx@lbx@input@postprocess@strings{#1}%
+  \blx@lbx@input@postprocess@extras{#1}%
+  \csuse{blx@hook@hyph@#1}}
+
 % {<language>}{<lbxfile>}{<message>}
 \def\blx@lbxinput@iv#1#2#3{%
   \begingroup
@@ -5133,10 +5148,7 @@
        \blx@saneccodes
        \makeatletter}
       {\endgroup
-       \csuse{blx@hook@strings@#1}%
-       \csuse{blx@hook@extras@#1}%
-       \csuse{blx@hook@noextras@#1}%
-       \csuse{blx@hook@hyph@#1}}
+       \blx@lbx@input@postprocess{#1}}
       {\aftergroup\@firstoftwo}
       {\aftergroup\@secondoftwo}%
   \endgroup}


### PR DESCRIPTION
Revamp loading of `.lbx` files.

Solves #677, #696. Ping back to #612, #525.

The changes are to critical infrastructure, so they need close scrutiny. The incompatible change is unlikely to cause any problems for existing `.lbx` files provided they are used as described in the docs.

Comments and testing are very welcome. I would like to wait a bit before merging this pull request. If nothing serious comes up I will merge in a few days.