### PR TITLE
Add begrelateddelim (#694)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -45,7 +45,8 @@
   This is a an internal change and should not influence document output,
   save for a few bug fixes. Style authors should check if the changes introduce
   any bugs for their localisation handling and report them.
-  
+- Added `\begrelateddelim` and `\begrelateddelim<relatedtype>` for punctuation
+  before the related block.
 
 # RELEASE NOTES FOR VERSION 3.10
 - **INCOMPATIBLE CHANGE** The recent ISO8601:201x standard supersedes

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4724,8 +4724,7 @@ A. Smith. Title. 2000, (Orig. pub. as<<->>Origtitle)
 The generic separator between the data of multiple related entries. The default definition is an optional dot plus linebreak. Here is an example where volumes A-E are related entries of the 5 volume main work:
 
 \begin{ltxexample}
-Donald E. Knuth. Computers & Typesetting. 5 vols. Reading, Mass.: Addison-
-Wesley, 1984-1986.
+Donald E. Knuth. Computers & Typesetting. 5 vols. Reading, Mass.: Addison-Wesley, 1984-1986.
 Vol. A: The TEXbook. 1984.
 Vol. B: TEX: The Program. 1986.
 Vol. C: The METAFONTbook. By. 1986.
@@ -4735,6 +4734,12 @@ Vol. E: Computer Modern Typefaces. 1986.
 
 \csitem{relateddelim$<$relatedtype$>$}
 The separator between the data of multiple related entries inside related entries of type <relatedtype>. There is no default, if such a type-specific delimiter does not exist, \cmd{relateddelim} is used.
+
+\csitem{begrelateddelim}
+The generic separator before the block of related entries. The default definition is \cmd{newunitpunct}.
+
+\csitem{begrelateddelim$<$relatedtype$>$}
+The separator between the block of related entries of type <relatedtype>. There is no default, if such a type-specific delimiter does not exist, \cmd{relateddelim} is used.
 
 \end{ltxsyntax}
 
@@ -11336,6 +11341,12 @@ The separator between the data of multiple related entries. The default definiti
 
 \csitem{relateddelim$<$relatedtype$>$}
 The separator between the data of multiple related entries inside related entries of type <relatedtype>. There is no default, if such a type-specific delimiter does not exist, \cmd{relateddelim} is used.
+
+\csitem{begrelateddelim}
+The generic separator before the block of related entries. The default definition is \cmd{newunitpunct}.
+
+\csitem{begrelateddelim$<$relatedtype$>$}
+The separator between the block of related entries of type <relatedtype>. There is no default, if such a type-specific delimiter does not exist, \cmd{relateddelim} is used.
 
 \end{ltxsyntax}
 

--- a/tex/latex/biblatex/bbx/standard.bbx
+++ b/tex/latex/biblatex/bbx/standard.bbx
@@ -896,7 +896,10 @@
 \newbibmacro*{related}{%
   \ifboolexpr{ test {\iffieldundef{related}} or test {\ifrelatedloop} }
     {}
-    {\usebibmacro{begrelated}%
+    {\ifcsundef{begrelateddelim\strfield{relatedtype}}
+       {\printunit{\begrelateddelim}}
+       {\printunit{\csuse{begrelateddelim\strfield{relatedtype}}}}%
+     \usebibmacro{begrelated}%
      \def\bbx@tempa{}%
      \setcounter{bbx:relatedtotal}{0}%
      \def\do##1{%
@@ -917,8 +920,8 @@
           \stepcounter{bbx:relatedcount}%
           \ifnumgreater{\value{bbx:relatedcount}}{1}
             {\ifcsundef{relateddelim\strfield{relatedtype}}
-              {\printtext{\relateddelim}}
-              {\printtext{\csuse{relateddelim\strfield{relatedtype}}}}}
+              {\printunit{\relateddelim}}
+              {\printunit{\csuse{relateddelim\strfield{relatedtype}}}}}
             {}}%
         \ifbibmacroundef{related:\strfield{relatedtype}}
           {\appto{\do}{\usebibmacro{related:default}}}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -177,6 +177,11 @@
          {\textemdash}}}}
 \newcommand*{\relatedpunct}{\addspace}
 \newcommand*{\relateddelim}{\adddot\par\nobreak}
+\newcommand*{\begrelateddelim}{\newunitpunct}
+\newcommand*{\begrelateddelimmultivolume}{\newunitpunct\par\nobreak}
+% Examples of use, uncommenting these would break backwards compatibility
+%\newcommand*{\begrelateddelimorigpubin}{\addspace}
+%\newcommand*{\begrelateddelimorigpubas}{\addspace}
 \newcommand{\mkrelatedstring}{\mainlang}
 
 % Used for indexing
@@ -531,7 +536,7 @@
 \DeclareFieldFormat[article,periodical]{volume}{#1}% volume of a journal
 \DeclareFieldFormat{volumes}{#1~\bibstring{volumes}}
 \DeclareFieldFormat{related}{#1}
-\DeclareFieldFormat{related:multivolume}{\par\nobreak#1}
+\DeclareFieldFormat{related:multivolume}{#1}
 \DeclareFieldFormat{related:origpubin}{\mkbibparens{#1}}
 \DeclareFieldFormat{related:origpubas}{\mkbibparens{#1}}
 \DeclareFieldFormat{relatedstring:default}{#1\printunit{\relatedpunct}}


### PR DESCRIPTION
- Add begrelateddelim to customise the delimiter before the related
  block.
- Change \printtext for punctuation to \printunit.
- Document begrelateddelim

Fixes #694.