### PR TITLE
Detokenize keys more aggressively (#707)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -9279,6 +9279,8 @@
 
 % {<entrykey>,...}
 \protected\def\blx@citeloop#1{%
+  \expandafter\blx@citeloop@i\expandafter{\detokenize{#1}}}
+\protected\def\blx@citeloop@i#1{%
   \begingroup
   % This must be here and not after \blx@citeadd as this changes the refcontext
   \letcs\blx@tempb{blx@dlist@centry@\the\c@refsection @\blx@refcontext@context}%


### PR DESCRIPTION
See #707.

This makes sure that cite keys are detokenized even if the citation command is expanded a bit further than usual.