### PR TITLE
Inconsistent example filename in biblatex quickstart guide

### DIFF
--- a/doc/latex/biblatex/biblatex-quickstart.tex
+++ b/doc/latex/biblatex/biblatex-quickstart.tex
@@ -159,8 +159,8 @@ You would run the \latex engine of choice\footnote{Typically one of \texttt{pdfl
 \begin{verbatim}
 latex test
 biber test
-latex text
-latex text
+latex test
+latex test
 \end{verbatim}
 %
 Notice that we didn't need to specify the file extensions as \latex knows to look for the \file{.tex} file and \biber knows to look for the \file{.bcf} file. So, this is all equivalent to doing:
@@ -168,8 +168,8 @@ Notice that we didn't need to specify the file extensions as \latex knows to loo
 \begin{verbatim}
 latex test.tex
 biber test.bcf
-latex text.tex
-latex text.tex
+latex test.tex
+latex test.tex
 \end{verbatim}
 %
 Many people will be using \latex editing applications which hide these commands from the user anyway and which will be activated by keyboard shortcuts or menu items.


### PR DESCRIPTION
This was probably just a typo or went wrong during some revision. Just thought I'd let you know.