### PR TITLE
Group \blx@nameparser@i (#725)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -4156,19 +4156,16 @@
 
 % {name opts}{nameparts}
 \long\def\blx@nameparser@i#1#2{%
+  \begingroup
   \ifblank{#1}
     {}
     {\setkeys{blx@opt@name}{#1}}%
-  % reset all the nameparts to empty between names
-  \def\do##1{%
-    \cslet{namepart##1}\@empty
-    \cslet{namepart##1i}\@empty}%
-  \expandafter\docsvlist\expandafter{\blx@datamodel@constant@nameparts}%
   \setkeys{blx@opt@namepart}{#2}% Extract nameparts information
   % Still pass the nameparts forward for backwards compat
   % When \nameparts is finally removed, remove the "{2}" and remove the
   % arg to \blx@defformat@d in def of \blx@defnameformat
-  \blx@theformat{#2}}
+  \blx@theformat{#2}%
+  \endgroup}
 
 \long\def\blx@namebreak#1&{}
 


### PR DESCRIPTION
As discussed in #725 grouping should solve the problems of name parts leaking out.