### PR TITLE
Update biblatex-examples.bib

### DIFF
--- a/bibtex/bib/biblatex/biblatex-examples.bib
+++ b/bibtex/bib/biblatex/biblatex-examples.bib
@@ -684,7 +684,7 @@
 
 @book{knuth:ct:a,
   author       = {Knuth, Donald E.},
-  title        = {The {\TeX} book},
+  title        = {The {\TeX book}},
   date         = 1984,
   maintitle    = {Computers \& Typesetting},
   volume       = {A},


### PR DESCRIPTION
Currently there is only a fix for the spacing in 'TeXbook'. This will change the output in the test files.

There are a few other things we may want to look at: Many titles use title case, while other English titles are written in sentence case. Since the general advice is to always give titles in title case and use a style that converts to sentence case if needed, should `biblatex-examples.bib` follow that best practice. Or do we stick to the titles exactly as written on the work?

