### PR TITLE
Check for package incompatibilities earlier

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -5,6 +5,23 @@
   consider using a custom data model to turn `number` back into an integer type
   field, since sorting integers as literals has performance implications and
   might lead to undesired sorting such as "1", "10", "2".
+- **INCOMPATIBLE CHANGE** Removed the 'semi-hidden' option `noerroretextools`.
+  If you want to load `noerroretextools` now, you need to define the macro
+  `\blx@noerroretextools` instead. This can for example be done with
+  ```
+  \usepackage{etoolbox}
+  \cslet{blx@noerroretextools}\empty
+  \usepackage{biblatex}
+  ```
+  or
+  ```
+  \makeatletter
+  \let\blx@noerroretextools\@empty
+  \makeatother
+  \usepackage{biblatex}
+  ```
+  You still need to make sure that all macros used by `biblatex` are restored
+  to their `etoolbox` definitions before loading `biblatex`.
   
 # RELEASE NOTES FOR VERSION 3.11
 - `\printbiblist` now supports `driver` and `biblistfilter` options

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -335,9 +335,9 @@ The \sty{ucs} package provides support for \utf encoded input. Either use \sty{i
 The \sty{etextools} package provides enhancements to list macros defined by \sty{etoolbox} and a few other tools for command definitions.
 The package redefines list handling macros in a way incompatible with \biblatex.
 
-If you must load the \sty{etextools} package at all costs, use the load-time option \opt{noerroretextools}.
-With \kvopt{noerroretextools}{true} no error will be issued if \sty{etextools} is loaded, that message is degraded to a warning instead.
-In that case you need to make sure that \cmd{forlistloop} has its original \sty{etoolbox} definition when \biblatex\ is loaded.
+If you must load the \sty{etextools} package at all costs, define the control sequence \cs{blx@noerroretextools} before you load \biblatex.
+If \cs{blx@noerroretextools} is defined, no error will be issued if \sty{etextools} is loaded, the message is degraded to a warning instead.
+In that case you need to make sure that all redefined macros used by \biblatex\ (currently only \cmd{forlistloop}) have their original \sty{etoolbox} definitions when \biblatex\ is loaded.
 
 \end{marglist}
 
@@ -13341,6 +13341,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \bibfield{extraname}\see{aut:bbx:fld:lab}
 \item Added \opt{bibencoding} option to \cmd{addbibresource}\see{use:bib:res}
 \item Changed type of \bibfield{number} from integer to literal \see{bib:fld:dat}
+\item Removed \opt{noerroretextools} option\see{int:pre:inc}
 \end{release}
 
   \begin{release}{3.11}{2018-02-20}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -99,7 +99,94 @@
 \catcode`\^=7
 \def\blx@nl{^^J}
 
+\protected\def\blx@safe@actives{%
+  \let\blx@if@safe@actives\if@safe@actives
+  \let\if@safe@actives\iftrue}
+
+\protected\def\blx@rest@actives{%
+  \let\if@safe@actives\blx@if@safe@actives}
+
+%% Early errors and warnings
+\protected\def\blx@error#1#2{%
+  \begingroup
+  \blx@safe@actives
+  \PackageError{biblatex}{#1}{#2.}%
+  \endgroup}
+
+\protected\def\blx@warning@noline#1{%
+  \begingroup
+  \blx@safe@actives
+  \PackageWarningNoLine{biblatex}{#1}%
+  \endgroup}
+\let\blx@warning\blx@warning@noline
+\AtEndOfPackage{%
+  \protected\def\blx@warning#1{%
+    \begingroup
+    \blx@safe@actives
+    \PackageWarning{biblatex}{#1}%
+    \endgroup}}
+
 %% Compatibility
+\def\blx@packageincompatibility{%
+  \def\do##1{%
+    \@ifpackageloaded{##1}
+      {\ifcsundef{blx@pkgloaded@##1}
+         {\global\cslet{blx@pkgloaded@##1}\@empty
+          \blx@error
+            {Incompatible package '##1'}
+            {The '##1' package and biblatex are incompatible}}
+         {}}
+      {}}%
+  \docsvlist{%
+    amsrefs,apacite,babelbib,backref,bibtopic,bibunits,chapterbib,
+    cite,citeref,drftcite,footbib,inlinebib,jurabib,mcite,mciteplus,
+    mlbib,multibbl,multibib,natbib,opcit,overcite,splitbib,ucs}%
+  % etextools is special, it gets an option to demote the error to a warning
+  % remind people to restore \forlistloop
+  \ifcsdef{blx@noerroretextools}
+    {\@ifpackageloaded{etextools}
+       {\ifcsundef{blx@pkgloaded@etextools}
+          {\global\cslet{blx@pkgloaded@etextools}\@empty
+           \blx@warning@noline{%
+             Incompatible package 'etextools' loaded,\MessageBreak
+             no error is thrown because you defined\MessageBreak
+             '\string\blx@noerroretextools'.\MessageBreak
+             'etextools' redefines '\string\forlistloop', you must\MessageBreak
+             restore the definition from 'etoolbox'\MessageBreak
+             before you load biblatex}}
+          {}}
+       {}}
+    {\@ifpackageloaded{etextools}
+       {\ifcsundef{blx@pkgloaded@etextools}
+          {\global\cslet{blx@pkgloaded@etextools}\@empty
+           \blx@error
+             {Incompatible package 'etextools'}
+             {The 'etextools' package and biblatex are
+              incompatible.\MessageBreak
+              If you must load 'etextools' at all costs, define the command%
+              \MessageBreak '\string\blx@noerroretextools'}}
+          {}}
+       {}}}
+
+% Call this right here, almost immediately after loading to give sensible
+% errors for incompatibilities that arise at loading-time.
+% The macro is called again a second time in \AtEndPreamble when all packages
+% should be loaded.
+% This still can't catch all cases, \usepackage{biblatex}\usepackage{natbib}
+% still gives a weird error.
+\blx@packageincompatibility
+
+% people should not be abusing noerroretextools, so warn if it is not needed
+\def\blx@packageincompatibility@endpreambleonly{%
+  \ifcsdef{blx@noerroretextools}
+    {\@ifpackageloaded{etextools}
+       {}
+       {\blx@warning@noline{%
+          You defined '\string\blx@noerroretextools',\MessageBreak
+          but 'etextools' is not loaded.\MessageBreak
+          Please do not define '\string\blx@noerroretextools'\MessageBreak
+          unless you really need it}}}
+    {}}
 
 \begingroup
 \catcode`\#=12
@@ -122,35 +209,8 @@
 \endgroup
 
 \AtEndPreamble{%
-  \def\do#1{%
-    \@ifpackageloaded{#1}
-      {\blx@error
-         {Incompatible package '#1'}
-         {The '#1' package and biblatex are incompatible}}
-      {}}%
-  \docsvlist{%
-    amsrefs,apacite,babelbib,backref,bibtopic,bibunits,chapterbib,
-    cite,citeref,drftcite,footbib,inlinebib,jurabib,mcite,mciteplus,
-    mlbib,multibbl,multibib,natbib,opcit,overcite,splitbib,ucs}%
-  \iftoggle{blx@noerroretextools}
-    {\@ifpackageloaded{etextools}
-       {\blx@warning@noline{%
-          Incompatible package 'etextools' loaded,\MessageBreak
-          no error is thrown because you set\MessageBreak
-          'noerroretextools=true'.\MessageBreak
-          'etextools' redefines '\string\forlistloop', you will\MessageBreak
-          need to restore the definition from 'etoolbox'}}
-       {\blx@warning@noline{%
-          You set 'noerroretextools=true',\MessageBreak
-          but 'etextools' is not loaded.\MessageBreak
-          Please do not set 'noerroretextools' to 'true'\MessageBreak
-          unless you really need it}}}
-    {\@ifpackageloaded{etextools}
-       {\blx@error
-          {Incompatible package 'etextools'}
-          {The 'etextools' package and biblatex are incompatible.\MessageBreak
-           If you must load 'etextools' at all costs, set 'noerroretextools=true'}}
-       {}}%
+  \blx@packageincompatibility
+  \blx@packageincompatibility@endpreambleonly
   \def\blx@langstrings{}%
   % Set up sortlocale defaults and default language if babel/polyglossia is not loaded
   \ifdefstring\blx@sortlocale{auto}
@@ -762,13 +822,6 @@
     {}}
 
 %% Auxiliary commands
-\protected\def\blx@safe@actives{%
-  \let\blx@if@safe@actives\if@safe@actives
-  \let\if@safe@actives\iftrue}
-
-\protected\def\blx@rest@actives{%
-  \let\if@safe@actives\blx@if@safe@actives}
-
 \protected\def\blx@regimc#1{%
   \xappto\blx@blxinit{%
     \let\noexpand#1\expandafter\noexpand\csname
@@ -982,27 +1035,7 @@
   )
 }}
 
-%% User feedback
-
-\protected\def\blx@error#1#2{%
-  \begingroup
-  \blx@safe@actives
-  \PackageError{biblatex}{#1}{#2.}%
-  \endgroup}
-
-\protected\def\blx@warning@noline#1{%
-  \begingroup
-  \blx@safe@actives
-  \PackageWarningNoLine{biblatex}{#1}%
-  \endgroup}
-\let\blx@warning\blx@warning@noline
-\AtEndOfPackage{%
-  \protected\def\blx@warning#1{%
-    \begingroup
-    \blx@safe@actives
-    \PackageWarning{biblatex}{#1}%
-    \endgroup}}
-
+%% More user feedback
 \protected\def\blx@warning@entry#1{%
   \ifdef\abx@field@entrykey
     {\blx@warning{#1\MessageBreak at entry '\abx@field@entrykey'}}
@@ -12623,9 +12656,14 @@
 \define@key{blx@opt@ldt}{mcite}[true]{%
   \settoggle{blx@mcite}{#1}}
 
-\newtoggle{blx@noerroretextools}
 \define@key{blx@opt@ldt}{noerroretextools}[true]{%
-  \settoggle{blx@noerroretextools}{#1}}
+  \blx@warning@noline{%
+    The option 'noerroretextools' is deprecated.\MessageBreak
+    Define the control sequence '\string\blx@noerroretextools'\MessageBreak
+    before loading biblatex instead}%
+  \ifstrequal{#1}{true}
+    {\global\cslet{blx@noerroretextools}\@empty}
+    {\csgundef{blx@noerroretextools}}}
 
 % load-time and preamble
 


### PR DESCRIPTION
If incompatible packages are loaded before `biblatex` they can cause problems already at the loading stage. To allow for more meaningful messages in some of these cases it makes sense to test for incompatible packages immediately at the beginning of the package.

A few definitions needed to be moved around.

**INCOMPATIBLE CHANGE** Because options are not set up that early, `noerroretextools` could not be honoured. This means that we need to go back to a more primitive approach of checking for the existence of `\blx@noerroretextools`.

This still does not catch some package incompatibilities if an incompatible package is loaded after `biblatex` and the mere loading of the two causes errors.

Ping back to https://github.com/plk/biblatex/issues/669 and https://github.com/plk/biblatex/issues/587