### PR TITLE
Tweak autocite command generation (#758)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -10485,14 +10485,15 @@
     \blx@citecmdinit
     \noexpand\@ifstar
       {\expandafter\noexpand
-       \csname blx@mcite@#4\endcsname*%
+       \csname blx@macitei@#1\endcsname*%
        \expandafter\noexpand
-       \csname blx@macitei@#1\endcsname}
+       \csname blx@maciteii@#1\endcsname}
       {\expandafter\noexpand
-       \csname blx@mcite@#4\endcsname{}%
+       \csname blx@macitei@#1\endcsname{}%
        \expandafter\noexpand
-       \csname blx@macitei@#1\endcsname}}%
-  \protected\csedef{blx@macitei@#1}##1##2##3{%
+       \csname blx@maciteii@#1\endcsname}}%
+  \csedef{blx@macitei@#1}{\csname blx@mcite@#4\endcsname}%
+  \protected\csedef{blx@maciteii@#1}##1##2##3{%
     \if l#2\noexpand\unspace##3\fi
     \if f#2\noexpand\iftoggle{blx@footnote}{}{\unspace##3}\fi
     ##1{##2}%


### PR DESCRIPTION
This should allow redefinitions of the currently active `autocite` scheme
without having to execute the `autocite` option again afterwards.
Previously this worked for `\autocite` but not for `\autocites`
since the latter hard-coded the multicite command in the first-level
expansion of `\autocites`.

Ping back to #202, #758.