### PR TITLE
Two fixes for BibTeX

### DIFF
--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -259,8 +259,8 @@ FUNCTION {ctrl:skiplab} {
 }
 
 FUNCTION {ctrl:labelalpha} {
-  ctrl.labelalpha ctrl:skiplab not and
-  shorthand empty$
+  ctrl.labelalpha
+  ctrl:skiplab not
   and
 }
 
@@ -2281,33 +2281,36 @@ FUNCTION {makelabel:hash:format:full} {
 
 FUNCTION {makelabel:ctrl:alpha} {
   ctrl:labelalpha
-    { label empty$
-        { push:cite purify #1 #3 substring$
-          "u" change.case$ "t" change.case$ }
-        { label makelabel:alpha:year * }
-      if$
-    }
     { shorthand empty$
-        { "" }
+        { label empty$
+            { push:cite purify #1 #3 substring$
+              "u" change.case$ "t" change.case$ }
+            { label makelabel:alpha:year * }
+          if$
+        }
         { shorthand }
       if$
     }
+    { "" }
   if$
 }
 
 FUNCTION {makelabel:ctrl:alpha:format} {
   ctrl:labelalpha
-    { label empty$
-        { makelabel:alpha:format }
-        { pop$ label }
+    { shorthand empty$
+        { label empty$
+            { makelabel:alpha:format }
+            { pop$ label }
+          if$
+          makelabel:alpha:year *
+        }
+        { pop$
+          shorthand
+        }
       if$
-      makelabel:alpha:year *
     }
     { pop$
-      ctrl.labelalpha not shorthand empty$ or
-        { "" }
-        { shorthand }
-      if$
+      "" 
     }
   if$
 }
@@ -2361,7 +2364,8 @@ FUNCTION {labelsort:main} {
 
 FUNCTION {labelsort:alph} {
   ctrl:labelalpha
-    { labelalpha normalize delimiter.1 *
+    { labelalpha ctrl.alphaothers ctrl.sortalphaothers str:replace
+      purify delimiter.1 *
       push:presort * delimiter.1 *
       sortkey empty$
         { ctrl.sorting #10 >

--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -171,7 +171,7 @@ INTEGERS { ctrl.debug ctrl.bibtex8 ctrl.maxline ctrl.sorting ctrl.cssort
            tempctra tempctrb tempctrc resvctra resvctrb resvctrc
            last.extra.num }
 
-STRINGS  { ctrl.alphaothers ctrl.sortstr
+STRINGS  { ctrl.alphaothers ctrl.sortalphaothers ctrl.sortstr
            templist tempstrga tempstrgb resvstrga resvstrgb resvstrgc
            last.name last.hash last.year last.extra }
 
@@ -195,6 +195,7 @@ FUNCTION {initialize} {
    #3   'ctrl.maxalphanames :=
   #79   'ctrl.maxline :=
   "+"   'ctrl.alphaothers :=
+  " "   'ctrl.sortalphaothers :=
   "nty" 'ctrl.sortstr :=
 }
 
@@ -1926,6 +1927,7 @@ FUNCTION {input:control} {
           input:control:options 'ctrl.minalphanames :=
           input:control:options 'ctrl.maxline :=
           input:control:parse   'ctrl.alphaothers :=
+          input:control:parse   'ctrl.sortalphaothers :=
           'ctrl.sortstr :=
         }
       if$
@@ -2626,8 +2628,13 @@ FUNCTION {labelsort:alph:reverse} {
       labelalpha empty$
         'skip$
         { extraalpha empty$
-            { labelalpha normalize 'sortkey.alpha := }
-            { labelalpha normalize extraalpha #4 pad.number * 'sortkey.alpha := }
+            { labelalpha ctrl.alphaothers ctrl.sortalphaothers str:replace
+              purify
+              'sortkey.alpha := }
+            { labelalpha ctrl.alphaothers ctrl.sortalphaothers str:replace
+              purify
+              extraalpha #4 pad.number *
+              'sortkey.alpha := }
           if$
         }
       if$

--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -159,7 +159,7 @@ ENTRY {
     verbc
   }
   { skipbib skiplos skiplab useauthor useeditor usetranslator useprefix singletitle }
-  { entryoptions labelhash namehash fullhash dateyear dateendyear extradate labelalpha extraalpha 
+  { entryoptions labelhash namehash fullhash dateyear dateendyear extradate labelalpha extraalpha
     sortinit label.name label.year sortkey.nosort sortkey.name sortkey.year
     sortkey.title sortkey.alpha sort.year sort.alph warningmsg }
 
@@ -167,7 +167,7 @@ INTEGERS { ctrl.debug ctrl.bibtex8 ctrl.maxline ctrl.sorting ctrl.cssort
            ctrl.maxnames ctrl.minnames ctrl.maxalphanames ctrl.minalphanames
            ctrl.useauthor ctrl.useeditor ctrl.usetranslator
            ctrl.useprefix ctrl.labelalpha ctrl.singletitle
-           ctrl.labeldate citecount 
+           ctrl.labeldate citecount
            tempctra tempctrb tempctrc resvctra resvctrb resvctrc
            last.extra.num }
 
@@ -477,7 +477,7 @@ FUNCTION {push:labelname:editor} {
           if$
         }
         { "shorteditor" }
-      if$  
+      if$
     }
     { push:labelname:translator }
   if$
@@ -599,7 +599,7 @@ FUNCTION {push:labelname} {
           if$
         }
         { "shortauthor" }
-      if$  
+      if$
     }
     { push:labelname:editor }
   if$
@@ -613,7 +613,7 @@ FUNCTION {check:sortname} {
 }
 
 FUNCTION {warning} {
-  "\item " swap$ * 
+  "\item " swap$ *
   warningmsg empty$
     'skip$
     { warningmsg " " * swap$ * }
@@ -689,7 +689,7 @@ FUNCTION {format:name:initials} {
 FUNCTION {is.number} {
   #1
   { #0 > }
-    { duplicate$ #1 #1 substring$ chr.to.int$ 
+    { duplicate$ #1 #1 substring$ chr.to.int$
       duplicate$ #47 >
       swap$      #58 <
       and
@@ -876,7 +876,7 @@ FUNCTION {split.date} {
       split.date:date
       tempctra
         'skip$
-        { pop$ pop$ pop$ pop$ pop$ pop$ "" "" "" "" "" "" 
+        { pop$ pop$ pop$ pop$ pop$ pop$ "" "" "" "" "" ""
           templist warning:invalid
         }
       if$
@@ -909,7 +909,7 @@ FUNCTION {sortkey:name:format} {
         { templist tempctra "{vv}" format.name$
           duplicate$ empty$
             { pop$ "" }
-            { "u" change.case$ "t" change.case$ 
+            { "u" change.case$ "t" change.case$
               delimiter.3 * }
           if$
           templist tempctra
@@ -1125,7 +1125,7 @@ FUNCTION {output:write:year} {
         'skip$
       if$
       swap$ "\field" swap$ wrap:braces *
-      swap$ wrap:braces * output:indent:field 
+      swap$ wrap:braces * output:indent:field
       }
   if$
 }
@@ -1318,7 +1318,7 @@ FUNCTION {output:write:name} {
           output:write:name:prefix
           output:write:name:last
           output:write:name:suffix
-	      output:write:name:first
+          output:write:name:first
           "}}%" output:indent:subfield
           tempctra #1 + 'tempctra :=
           tempctrb #1 - 'tempctrb :=
@@ -1349,28 +1349,28 @@ FUNCTION {output:write:list} {
       #0 'tempctrc :=
       { templist purify tempctrb global.max$ substring$ num.names$ #0 > }
         { templist tempctrb #1 substring$ "{" =
-	    { tempctrc #1 + 'tempctrc :=
-	      tempctrb #1 + 'tempctrb := }
-	    { templist tempctrb #1 substring$ "}" =
-		{ tempctrc #1 - 'tempctrc :=
-		  tempctrb #1 + 'tempctrb := }
-		{ templist tempctrb #5 substring$
-        	  duplicate$ " AND " =
-        	  swap$      " and " =
-        	  or
-		  tempctrc #1 <
-		  and
-        	    { templist tempctra tempctrb tempctra - substring$
-        	      wrap:braces "%" * output:indent:subfield
-        	      tempctrb #5 + duplicate$
-        	      'tempctra :=
-        	      'tempctrb :=
-        	    }
-        	    { tempctrb #1 + 'tempctrb := }
-        	  if$
-		}
+            { tempctrc #1 + 'tempctrc :=
+              tempctrb #1 + 'tempctrb := }
+            { templist tempctrb #1 substring$ "}" =
+                { tempctrc #1 - 'tempctrc :=
+                  tempctrb #1 + 'tempctrb := }
+                { templist tempctrb #5 substring$
+                  duplicate$ " AND " =
+                  swap$      " and " =
+                  or
+                  tempctrc #1 <
+                  and
+                    { templist tempctra tempctrb tempctra - substring$
+                      wrap:braces "%" * output:indent:subfield
+                      tempctrb #5 + duplicate$
+                      'tempctra :=
+                      'tempctrb :=
+                    }
+                    { tempctrb #1 + 'tempctrb := }
+                  if$
+                }
               if$
-	    }
+            }
           if$
         }
       while$
@@ -1391,7 +1391,7 @@ FUNCTION {output:specials} {
         { "\set"   }
         { "\inset" }
       if$
-      entryset wrap:braces * output:indent:field 
+      entryset wrap:braces * output:indent:field
     }
   if$
   xref empty$
@@ -1664,7 +1664,7 @@ FUNCTION {output:compat.1} {
       if$
     }
   if$
-  output:write:field 
+  output:write:field
   "location" location
   duplicate$ empty$
     { pop$ address }
@@ -1958,10 +1958,10 @@ FUNCTION {input:options:known} {
     { tempstrgb input:options:add
       #1 }
     { duplicate$ "true" =
-        { pop$ "" tempstrgb input:options:add 
+        { pop$ "" tempstrgb input:options:add
           #1 }
         { duplicate$ tempstrgb input:options:add
-          bol.to.int 
+          bol.to.int
         }
       if$
     }
@@ -1984,11 +1984,11 @@ FUNCTION {input:options:parse} {
                         { input:options:known 'skiplos := }
                         { tempstrgb "skiplab" =
                             { input:options:known 'skiplab := }
-                            { tempstrgb "dataonly" = 
-                                { input:options:known 
+                            { tempstrgb "dataonly" =
+                                { input:options:known
                                   duplicate$ 'skipbib :=
-                                  duplicate$ 'skiplos := 
-                                             'skiplab := 
+                                  duplicate$ 'skiplos :=
+                                             'skiplab :=
                                 }
                                 { tempstrgb input:options:add }
                               if$
@@ -2078,8 +2078,8 @@ FUNCTION {input:iterate} {
       ctrl:set entryset empty$ or
         'skip$
         { #1 'skipbib :=
-          #1 'skiplos := 
-          #1 'skiplab := 
+          #1 'skiplos :=
+          #1 'skiplab :=
         }
       if$
       "date" date split.date
@@ -2128,7 +2128,7 @@ FUNCTION {makelabel:name:format} {
         { templist tempctra "{vv}" format.name$
           duplicate$ empty$
             { pop$ "" }
-            { "u" change.case$ "t" change.case$ 
+            { "u" change.case$ "t" change.case$
               delimiter.3 * }
           if$
         }

--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -176,7 +176,7 @@ STRINGS  { ctrl.alphaothers ctrl.sortstr
            last.name last.hash last.year last.extra }
 
 FUNCTION {initialize} {
-  "$Revision: 3.8 $"
+  "$Revision: 3.11 $"
   #12 entry.max$ substring$
   #-3 entry.max$ substring$
   "Biblatex version: " swap$ * top$
@@ -1896,8 +1896,9 @@ FUNCTION {input:control:version} {
   'tempstrga :=
   duplicate$ tempstrga =
     { pop$ }
-    { "Version mismatch: biblatex.bst=" tempstrga *
-      ", biblatex.sty=" * swap$ * warning$
+    { "bbl version mismatch: biblatex.bst has " tempstrga *
+      ", but biblatex.sty has " * swap$ * warning$
+      "         The bbl version need not be the same as the biblatex version." top$
       pop$ "" }
   if$
 }

--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -158,10 +158,14 @@ ENTRY {
     verbb
     verbc
   }
-  { skipbib skiplos skiplab useauthor useeditor usetranslator useprefix singletitle }
-  { entryoptions labelhash namehash fullhash dateyear dateendyear extradate labelalpha extraalpha
-    sortinit label.name label.year sortkey.nosort sortkey.name sortkey.year
-    sortkey.title sortkey.alpha sort.year sort.alph warningmsg }
+  { skipbib skiplos skiplab
+    useauthor useeditor usetranslator useprefix
+    singletitle }
+  { entryoptions labelhash namehash fullhash
+    dateyear dateendyear extradate labelalpha extraalpha label.name label.year
+    sortinit sortkey.nosort sortkey.name sortkey.year
+    sortkey.title sortkey.alpha sort.year sort.alph
+    warningmsg }
 
 INTEGERS { ctrl.debug ctrl.bibtex8 ctrl.maxline ctrl.sorting ctrl.cssort
            ctrl.maxnames ctrl.minnames ctrl.maxalphanames ctrl.minalphanames
@@ -1205,7 +1209,8 @@ FUNCTION {output:write:verb} {
     { 'tempstrga :=
       "\verb" swap$ wrap:braces * output:indent:field
       { tempstrga empty$ not }
-        { "\verb " tempstrga #1 ctrl.maxline #10 - substring$ * output:indent:field
+        { "\verb " tempstrga #1 ctrl.maxline #10 - substring$ *
+          output:indent:field
           tempstrga ctrl.maxline #9 - global.max$ substring$ 'tempstrga :=
         }
       while$
@@ -1899,7 +1904,8 @@ FUNCTION {input:control:version} {
     { pop$ }
     { "bbl version mismatch: biblatex.bst has " tempstrga *
       ", but biblatex.sty has " * swap$ * warning$
-      "         The bbl version need not be the same as the biblatex version." top$
+      "         The bbl version need not be the same as the biblatex version."
+      top$
       pop$ "" }
   if$
 }
@@ -2310,7 +2316,7 @@ FUNCTION {makelabel:ctrl:alpha:format} {
       if$
     }
     { pop$
-      "" 
+      ""
     }
   if$
 }
@@ -2740,7 +2746,7 @@ FUNCTION {output:main:begin} {
   "  {}"                                                        write$ newline$
   "\endgroup"                                                   write$ newline$
   newline$
-  "\datalist[entry]{" ctrl.sortstr * "/global//global/global}" *              write$
+  "\datalist[entry]{" ctrl.sortstr * "/global//global/global}" *         write$
 }
 
 FUNCTION {output:main:preamble} {

--- a/tex/latex/biblatex/blx-bibtex.def
+++ b/tex/latex/biblatex/blx-bibtex.def
@@ -53,7 +53,8 @@
      \string\citation{biblatex-control}}}
 
 \def\blx@sig@bib{@Comment{$ biblatex control file $}}
-\edef\blx@ver@bib{@Comment{$ biblatex bbl format version \blx@bblversion\space $}}
+\edef\blx@ver@bib{%
+  @Comment{$ biblatex bbl format version \blx@bblversion\space $}}
 
 \let\blx@sig@aux\blx@sig@bbl
 \let\blx@ver@aux\blx@ver@bbl
@@ -425,6 +426,8 @@
 }
 
 \def\blx@ctrlwrite{%
+  % \sortalphaothers should only contain safe characters,
+  % so we should be able to \edef it
   \edef\blx@sortalphaothers{\sortalphaothers}%
   \immediate\openout\blx@write\blx@ctrlfile\blxauxsuffix.bib\relax
   \blx@auxwrite\blx@write{}{\blx@ctrl}%

--- a/tex/latex/biblatex/blx-bibtex.def
+++ b/tex/latex/biblatex/blx-bibtex.def
@@ -53,31 +53,29 @@
      \string\citation{biblatex-control}}}
 
 \def\blx@sig@bib{@Comment{$ biblatex control file $}}
-\edef\blx@ver@bib{@Comment{$ biblatex version \blx@bblversion\space $}}
+\edef\blx@ver@bib{@Comment{$ biblatex bbl format version \blx@bblversion\space $}}
 
 \let\blx@sig@aux\blx@sig@bbl
 \let\blx@ver@aux\blx@ver@bbl
 
-\edef\blx@msg@aux{%
-  \blx@sig@aux\blx@nl
-  \blx@ver@aux\blx@nl
+\edef\blx@msg@text{%
   \@percentchar\space Do not modify this file!\blx@nl
   \@percentchar\blx@nl
   \@percentchar\space This is an auxiliary file
   used by the 'biblatex' package.\blx@nl
   \@percentchar\space This file may safely be deleted.
   It will be recreated as\blx@nl
-  \@percentchar\space required.\blx@nl
+  \@percentchar\space required.\blx@nl}
+
+\edef\blx@msg@aux{%
+  \blx@sig@aux\blx@nl
+  \blx@ver@aux\blx@nl
+  \blx@msg@text
   \@percentchar\blx@nl\string\relax\blx@nl}
 \edef\blx@msg@bib{%
   \blx@sig@bib\blx@nl
   \blx@ver@bib\blx@nl
-  Do not modify this file!\blx@nl\blx@nl
-  This is an auxiliary file used
-  by the 'biblatex' package.\blx@nl
-  This file may safely be deleted.
-  It will be recreated as\blx@nl
-  required.\blx@nl\blx@nl}
+  \blx@msg@text\blx@nl}
 
 % User feedback
 

--- a/tex/latex/biblatex/blx-bibtex.def
+++ b/tex/latex/biblatex/blx-bibtex.def
@@ -418,12 +418,14 @@
     \noexpand\blx@minalphanames:%
     \noexpand\blx@maxline:%
     \noexpand\detokenize\noexpand\expandafter{\noexpand\labelalphaothers}:%
+    \noexpand\detokenize\noexpand\expandafter{\noexpand\blx@sortalphaothers}:%
     \noexpand\detokenize\noexpand\expandafter{\noexpand\blx@sorting}%
   \string},\blx@nl
   \string}%
 }
 
 \def\blx@ctrlwrite{%
+  \edef\blx@sortalphaothers{\sortalphaothers}%
   \immediate\openout\blx@write\blx@ctrlfile\blxauxsuffix.bib\relax
   \blx@auxwrite\blx@write{}{\blx@ctrl}%
   \immediate\closeout\blx@write}


### PR DESCRIPTION
- Remove braces for sorting in alphabetic labels (see #601)
- Allow `shorthand` labels in alphabetic to have a `extraalpha` (consistent with Biber's behaviour)
- Zap tabs and spaces and end of line