### PR TITLE
Add sortings where volume comes before year

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -1998,7 +1998,7 @@ The following options may be used in the optional argument to \cmd{usepackage} a
 
 \begin{optionlist}
 
-\optitem[nty]{sorting}{\opt{nty}, \opt{nyt}, \opt{nyvt}, \opt{anyt}, \opt{anyvt}, \opt{ynt}, \opt{ydnt}, \opt{none}, \opt{debug}, \prm{name}}
+\optitem[nty]{sorting}{\opt{nty}, \opt{nyt}, \opt{nyvt}, \opt{nvyt}, \opt{anyt}, \opt{anyvt}, \opt{anvyt}, \opt{ynt}, \opt{ydnt}, \opt{none}, \opt{debug}, \prm{name}}
 
 The sorting order of the bibliography. Unless stated otherwise, the entries are sorted in ascending order. The following choices are available by default:
 
@@ -2006,8 +2006,10 @@ The sorting order of the bibliography. Unless stated otherwise, the entries are 
 \item[nty] Sort by name, title, year.
 \item[nyt] Sort by name, year, title.
 \item[nyvt] Sort by name, year, volume, title.
+\item[nvyt] Sort by name, volume, year, title.
 \item[anyt] Sort by alphabetic label, name, year, title.
 \item[anyvt] Sort by alphabetic label, name, year, volume, title.
+\item[anvyt] Sort by alphabetic label, name, volume, year, title.
 \item[ynt] Sort by year, name, title.
 \item[ydnt] Sort by year (descending), name, title.
 \item[none] Do not sort at all. All entries are processed in citation order.
@@ -12907,6 +12909,11 @@ nyvt &	presort\alt mm &
 	\new sortyear\alt year &
 	\new volume &
 	\new sorttitle\alt title \\
+nvyt &	presort\alt mm &
+	\new sortname\alt author\alt editor\alt translator\alt sorttitle\alt title &
+	\new volume &
+	\new sortyear\alt year &
+	\new sorttitle\alt title \\
 \textrm{all} & presort\alt mm &
 	\new sortkey \\
 \end{longtable}
@@ -12944,6 +12951,12 @@ anyvt &	presort\alt mm &
 	\new sortname\alt author\alt editor\alt translator\alt sorttitle\alt title &
 	\new sortyear\alt year &
 	\new volume &
+	\new sorttitle\alt title \\
+anvyt &	presort\alt mm &
+	\new labelalpha &
+	\new sortname\alt author\alt editor\alt translator\alt sorttitle\alt title &
+	\new volume &
+	\new sortyear\alt year &
 	\new sorttitle\alt title \\
 \textrm{all} & presort\alt mm &
 	\new labelalpha &

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -1448,6 +1448,35 @@
   }
 }
 
+\DeclareSortingTemplate{nvyt}{
+  \sort{
+    \field{presort}
+  }
+  \sort[final]{
+    \field{sortkey}
+  }
+  \sort{
+    \field{sortname}
+    \field{author}
+    \field{editor}
+    \field{translator}
+    \field{sorttitle}
+    \field{title}
+  }
+  \sort{
+    \field{volume}
+    \literal{0}
+  }
+  \sort{
+    \field{sortyear}
+    \field{year}
+  }
+  \sort{
+    \field{sorttitle}
+    \field{title}
+  }
+}
+
 \DeclareSortingTemplate{anyt}{
   \sort{
     \field{presort}
@@ -1505,6 +1534,38 @@
   \sort{
     \field{volume}
     \literal{0}
+  }
+  \sort{
+    \field{sorttitle}
+    \field{title}
+  }
+}
+
+\DeclareSortingTemplate{anvyt}{
+  \sort{
+    \field{presort}
+  }
+  \sort{
+    \field{labelalpha}
+  }
+  \sort[final]{
+    \field{sortkey}
+  }
+  \sort{
+    \field{sortname}
+    \field{author}
+    \field{editor}
+    \field{translator}
+    \field{sorttitle}
+    \field{title}
+  }
+  \sort{
+    \field{volume}
+    \literal{0}
+  }
+  \sort{
+    \field{sortyear}
+    \field{year}
   }
   \sort{
     \field{sorttitle}


### PR DESCRIPTION
This could be useful for reissues. The new sortings are basically copied from `nyvt` and `anyvt`.