### PR TITLE
Add fallback values for bibliography extras

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3501,7 +3501,7 @@
                   and not test {\ifdatehastime{#2}})
               or (not test {\ifdatehastime{#1}}
                   and test {\ifdatehastime{#2}})}}
-                  
+
 \def\blx@imc@ifdateyearsequal#1#2{%
   \ifboolexpr{ test {\iffieldsequal{#1year}{#2year}}
                and test {\iffieldsequal{#1dateera}{#2dateera}}}}
@@ -5684,6 +5684,11 @@
     {\mkbibtimezone{\thefield{#1#2timezone}}}
     {}}
 
+% some sane defaults for bibliography extras
+% many of these should be redefined in the .lbx files
+% all .lbx files should have date and time handling, so the fallback values
+% issue a warning to make people aware of the deficiency in their file
+% \mkbibordinal should also only be used if it is defined, so it warns as well
 % times
 \newrobustcmd*{\bibtimesep}{:}
 \newrobustcmd*{\bibtimerangesep}{\textendash}
@@ -5704,18 +5709,131 @@
 \newrobustcmd*{\bibrangessep}{,\space}
 % formatters
 \newrobustcmd*{\mkbibtimezone}[1]{\blx@xifstrcmp{#1}{UTC}{\bibutctimezone}{#1}}
-\newrobustcmd*{\mkbibdatelong}[3]{}
-\newrobustcmd*{\mkbibdateshort}[3]{}
-\newrobustcmd*{\mkbibseasondateshort}[2]{}
-\newrobustcmd*{\mkbibseasondatelong}[2]{}
-\expandafter\newrobustcmd\expandafter*\csname mkbibtime24h\endcsname[4]{}
-\expandafter\newrobustcmd\expandafter*\csname mkbibtime12h\endcsname[4]{}
+% you should never end up needing the next few definitions
+% but it is safer to do something than just swallow the input
+\newrobustcmd*{\mkbibdatelong}[3]{%
+  \blx@warning@noline{%
+    Using fallback definition for \string\mkbibdatelong.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \string\mkbibdatelong
+  }%
+  \iffieldundef{#3}
+    {}
+    {\mkbibordinal{\thefield{#3}}%
+     \iffieldundef{#2}{}{\nobreakspace}}%
+  \iffieldundef{#2}
+    {}
+    {\mkbibmonth{\thefield{#2}}%
+     \iffieldundef{#1}{}{\space}}%
+  \iffieldbibstring{#1}
+    {\bibstring{\thefield{#1}}}
+    {\dateeraprintpre{#1}\stripzeros{\thefield{#1}}}}
+
+\newrobustcmd*{\mkbibdateshort}[3]{%
+  \blx@warning@noline{%
+    Using fallback definition for \string\mkbibdateshort.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \string\mkbibdateshort
+  }%
+  \iffieldundef{#3}
+    {}
+    {\mkdayzeros{\thefield{#3}}%
+     \iffieldundef{#2}{}{/}}%
+  \iffieldundef{#2}
+    {}
+    {\mkmonthzeros{\thefield{#2}}%
+     \iffieldundef{#1}{}{/}}%
+  \iffieldbibstring{#1}
+    {\bibstring{\thefield{#1}}}
+    {\dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}}
+
+\expandafter\newrobustcmd\expandafter*\csname mkbibtime24h\endcsname[4]{%
+  \blx@warning@noline{%
+    Using fallback definition for
+    \expandafter\string\csname mkbibtime24h\endcsname.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \expandafter\string\csname mkbibtime24h\endcsname
+  }%
+    \iffieldundef{#1}{}
+      {\printtext{\mktimezeros{\thefield{#1}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#2}{}
+      {\printtext{\mktimezeros{\thefield{#2}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#3}{}
+      {\printtext{\mktimezeros{\thefield{#3}}}}%
+    \setunit{}%
+    \iffieldundef{#4}{}
+      {\bibtimezonesep
+       \mkbibtimezone{\thefield{#4}}}}
+
+\expandafter\newrobustcmd\expandafter*\csname mkbibtime12h\endcsname[4]{%
+  \blx@warning@noline{%
+    Using fallback definition for
+    \expandafter\string\csname mkbibtime12h\endcsname.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \expandafter\string\csname mkbibtime12h\endcsname
+  }%
+    \stripzeros{\mktimehh{\thefield{#1}}}%
+    \bibtimesep
+    \forcezerosmdt{\thefield{#2}}%
+    \iffieldundef{#3}{}
+      {\bibtimesep
+       \forcezeros{\thefield{#3}}}%
+     \space
+     \ifnumless{\thefield{#1}}{12}
+       {\bibstring{am}}
+       {\bibstring{pm}}%
+    \iffieldundef{#4}{}
+     {\space\bibtimezonesep
+      \parentext{\mkbibtimezone{\thefield{#4}}}}}
+
+\newrobustcmd*{\mkbibseasondateshort}[2]{%
+  \blx@warning@noline{%
+    Using fallback definition for \string\mkbibseasondateshort.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \string\mkbibseasondateshort
+  }%
+  \mkbibseason{\thefield{#2}}%
+  \iffieldundef{#1}{}{\space}%
+  \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}
+
+\newrobustcmd*{\mkbibseasondatelong}[2]{%
+  \blx@warning@noline{%
+    Using fallback definition for \string\mkbibseasondatelong.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \string\mkbibseasondatelong
+  }%
+  \mkbibseason{\thefield{#2}}%
+  \iffieldundef{#1}{}{\space}%
+  \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}
+
 \newrobustcmd*{\finalandcomma}{}
 \newrobustcmd*{\finalandsemicolon}{}
-\newrobustcmd*{\mkbibordinal}[1]{#1}
+\newrobustcmd*{\mkbibordinal}[1]{%
+  \blx@warning@noline{%
+    Using fallback definition for \string\mkbibordinal.\MessageBreak
+    The command should be defined in the .lbx file.\MessageBreak
+    If you see this message, the .lbx file could not be\MessageBreak
+    loaded, is faulty or does not contain a definition\MessageBreak
+    for \string\mkbibordinal
+  }%
+  #1%
+}
 \newrobustcmd*{\mkbibmascord}{\mkbibordinal}
 \newrobustcmd*{\mkbibfemord}{\mkbibordinal}
 \newrobustcmd*{\mkbibneutord}{\mkbibordinal}
+% the following is usually not redefined in an .lbx
 \newrobustcmd*{\mkbibseason}[1]{\abx@bibseason{#1}}
 \newrobustcmd*{\mkbibmonth}[1]{%
   \ifcase0#1\relax


### PR DESCRIPTION
Provide sensible defaults (from `british.lbx` -- `english.lbx` was not viable due to the different American date format that would have required other ancillary macros as well ...) for date and time macros
that should be redefined by all `.lbx` files.

This seems slightly safer than swallowing dates silently. The definitions should not be needed
and the warnings should never be encountered with the 'official' `.lbx` files - but they may help to debug custom `.lbx` files.

Cf. https://tex.stackexchange.com/q/442587/