### PR TITLE
fixed abrrev in greek

### DIFF
--- a/tex/latex/biblatex/lbx/bulgarian.lbx
+++ b/tex/latex/biblatex/lbx/bulgarian.lbx
@@ -527,7 +527,7 @@
   fromfrench       = {{от френски}{от\addabbrvspace фр\adddot}},
   fromgalician     = {{от галисийски}{от\addabbrvspace гал\adddot}},
   fromgerman       = {{от немски}{от\addabbrvspace нем\adddot}},
-  fromgreek        = {{от гръцки}{от\addabbrvspace греч\adddot}},
+  fromgreek        = {{от гръцки}{от\addabbrvspace гр\adddot}},
   fromitalian      = {{от италиански}{от\addabbrvspace итал\adddot}},
   fromjapanese     = {{от японски}{от\addabbrvspace яп\adddot}},
   fromlatin        = {{от латински}{от\addabbrvspace лат\adddot}},


### PR DESCRIPTION
The source is a Bulgarian native speaker, who said the "e" is bad there and it should be shorter anyway. Cf. his example from a Bulgarian etymology dictionary: от гр. φθηνός „евтин“