### PR TITLE
Fix \bibinitdelim and \bibinithyphendelim for BibTeX (#806)

### DIFF
--- a/bibtex/bst/biblatex/biblatex.bst
+++ b/bibtex/bst/biblatex/biblatex.bst
@@ -687,7 +687,9 @@ FUNCTION {format:name:part} {
 }
 
 FUNCTION {format:name:initials} {
+  ".-" "\bibinithyphendelim " str:replace
   ".~" "\bibinitperiod\bibinitdelim " str:replace
+  ". " "\bibinitperiod\bibinitdelim " str:replace
   "." "\bibinitperiod" str:replace
 }
 


### PR DESCRIPTION
This should make `\bibinitperiod\bibinitdelim` work for all initials as documented and avoids BibTeX being clever and deciding where to put ties and where spaces.