### PR TITLE
Implement test for merged date (#752)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -37,6 +37,19 @@
   `nametitledelim`.
   For compatibility reasons `\labelnamepunct` still pops up in the code here
   and there, but `nametitledelim` should be preferred now.
+- `authoryear.bbx` now has a macro `bbx:ifmergeddate` that can be used to
+  check whether the date has been printed at the beginning of an entry
+  and can thus be suppressed later in the `date` and `issue+date` macros.
+  The macro works like a test and expands to the `<true>` branch if the date
+  has been merged and can be suppressed, it expands to `<false>` if the date
+  has not been merged. In practice `\printdate` should then be issued
+  if and only if the test yields false.
+
+  This change means that the definition of the `date` macro can be the same for
+  all mergedate settings and that only `bbx:ifmergeddate` is redefined for
+  each different value. No backwards compatibility issues are expected,
+  but style authors are encouraged to test the changes and see if the new
+  macro could be useful for their styles.
 
 # RELEASE NOTES FOR VERSION 3.11
 - `\printbiblist` now supports `driver` and `biblistfilter` options

--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -24,6 +24,13 @@
     Using 'date+extradate' instead}%
   \usebibmacro{date+extradate}}
 
+\newbibmacro*{bbx:ifmergeddate}{\@secondoftwo}
+
+\renewbibmacro*{date}{%
+  \usebibmacro{bbx:ifmergeddate}
+    {}
+    {\printdate}}%
+
 \def\bbx@opt@mergedate@true{\bbx@opt@mergedate@compact}
 
 % merge date/issue with date label
@@ -37,12 +44,9 @@
             \setunit*{\addspace}%
             \printdateextra}
            {\printlabeldateextra}}}}%
-  \renewbibmacro*{date}{%
-    \iflabeldateisdate
-      {}
-      {\printdate}}%
+  \renewbibmacro*{bbx:ifmergeddate}{\iflabeldateisdate}%
   \renewbibmacro*{issue+date}{%
-    \iflabeldateisdate
+    \usebibmacro{bbx:ifmergeddate}
       {}
       {\printtext[parens]{%
          \printfield{issue}%
@@ -58,20 +62,18 @@
          \iflabeldateisdate
            {\printdateextra}
            {\printlabeldateextra}}}}%
-  \renewbibmacro*{date}{%
-    \iflabeldateisdate
-      {}
-      {\printdate}}%
+  \renewbibmacro*{bbx:ifmergeddate}{\iflabeldateisdate}%
   \renewbibmacro*{issue+date}{%
-    \ifboolexpr{not test {\iffieldundef{issue}}
-                or not test {\iflabeldateisdate}}
+    \ifboolexpr{test {\usebibmacro{bbx:ifmergeddate}}
+                and
+                test {\iffieldundef{issue}}}
+      {}
       {\printtext[parens]{%
          \printfield{issue}%
          \setunit*{\addspace}%
-         \iflabeldateisdate
+         \usebibmacro{bbx:ifmergeddate}
            {}
-           {\printdate}}}
-      {}%
+           {\printdate}}}%
     \newunit}}
 
 % merge year-only date with date label
@@ -80,19 +82,16 @@
     \iffieldundef{labelyear}
       {}
       {\printtext[parens]{\printlabeldateextra}}}%
-  \renewbibmacro*{date}{%
+  \renewbibmacro*{bbx:ifmergeddate}{%
     \ifboolexpr{
       test {\iflabeldateisdate}
       and
       not test {\ifdateshavedifferentprecision{label}{}}
-    }
-      {}
-      {\printdate}}%
+    }%
+  }%
   \renewbibmacro*{issue+date}{%
     \ifboolexpr{
-      test {\iflabeldateisdate}
-      and
-      not test {\ifdateshavedifferentprecision{label}{}}
+      test {\usebibmacro{bbx:ifmergeddate}}
       and
       test {\iffieldundef{issue}}
     }
@@ -109,23 +108,18 @@
     \iffieldundef{labelyear}
       {}
       {\printtext[parens]{\printlabeldateextra}}}%
-  \renewbibmacro*{date}{%
+  \renewbibmacro*{bbx:ifmergeddate}{%
     \ifboolexpr{
       test {\iflabeldateisdate}
       and
       not test {\ifdateshavedifferentprecision{label}{}}
       and
       test {\iffieldundef{extradate}}
-    }
-      {}
-      {\printdate}}%
+    }%
+  }%
   \renewbibmacro*{issue+date}{%
     \ifboolexpr{
-      test {\iflabeldateisdate}
-      and
-      not test {\ifdateshavedifferentprecision{label}{}}
-      and
-      test {\iffieldundef{extradate}}
+      test {\usebibmacro{bbx:ifmergeddate}}
       and
       test {\iffieldundef{issue}}
     }
@@ -142,7 +136,7 @@
     \iffieldundef{labelyear}
       {}
       {\printtext[parens]{\printlabeldateextra}}}%
-  \renewbibmacro*{date}{\printdate}%
+  \renewbibmacro*{bbx:ifmergeddate}{\@secondoftwo}%
   \renewbibmacro*{issue+date}{%
     \printtext[parens]{%
       \printfield{issue}%


### PR DESCRIPTION
If `bbx:ifmergeddate` is true, the date has already been printed and need not be printed again.

The `date` bibmacro can be moved out of the `mergedate` definitions now, `issue+date` is still defined within the `mergedate` setup.

Cf. #752.