### PR TITLE
Enhance reprinfrom for articles

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -2966,7 +2966,9 @@
        \usebibmacro{publisher+location+date}%
        \newunit\newblock
        \usebibmacro{chapter+pages}}
-      {\printfield[title:hook]{journaltitle}%
+      {\renewbibmacro*{journal}{%
+         \printfield[title:hook]{journaltitle}}%
+       \usebibmacro{journal+issuetitle}%
        \newunit\newblock
        \usebibmacro{byeditor+others}%
        \newunit\newblock


### PR DESCRIPTION
Journal publication data should also be included here.

This would change the output in people's documents, but I can't really see this impacting a lot of people negatively. If merged, some tests may fail since the output for `moore:related` will change (for the better, I'd say)
```
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=authoryear, backend=biber]{biblatex}

\addbibresource{biblatex-examples.bib}

\begin{document}
\cite{moore:related}
\printbibliography
\end{document}
```