### PR TITLE
Make forcezeros more robust

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -11720,27 +11720,27 @@ This command takes a season localisation string and prints the version of the st
 
 \cmditem{mkyearzeros}{integer}
 
-This command strips leading zeros from a year or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros.
+This command strips leading zeros from a year or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros. If zeros are enforced, this command calls \cmd{forcezerosy} and thus expands its argument with \cmd{protected@edef}.
 
 \cmditem{mkmonthzeros}{integer}
 
-This command strips leading zeros from a month or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros.
+This command strips leading zeros from a month or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros. If zeros are enforced, this command calls \cmd{forcezerosmdt} and thus expands its argument with \cmd{protected@edef}.
 
 \cmditem{mkdayzeros}{integer}
 
-This command strips leading zeros from a day or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros.
+This command strips leading zeros from a day or enforces them, depending on the \opt{datezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of date formatting macros. If zeros are enforced, this command calls \cmd{forcezerosmdt} and thus expands its argument with \cmd{protected@edef}.
 
 \cmditem{mktimezeros}{integer}
 
-This command strips leading zeros from a number or preserves them, depending on the \opt{timezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of time formatting macros.
+This command strips leading zeros from a number or preserves them, depending on the \opt{timezeros} package option (\secref{use:opt:pre:gen}). It is intended for use in the definition of time formatting macros. If zeros are enforced, this command calls \cmd{forcezerosmdt} and thus expands its argument with \cmd{protected@edef}.
 
 \cmditem{forcezerosy}{integer}
 
-This command adds zeros to a year (or any number supposed to be 4-digits). It is intended for date formatting and ordinals.
+This command adds zeros to a year (or any number supposed to be 4-digits). It is intended for date formatting and ordinals. The argument is expanded with \cmd{protected@edef} before it is processed.
 
 \cmditem{forcezerosmdt}{integer}
 
-This command adds zeros to a month, day or time part (or any number supposed to be 2-digits). It is intended for date/time formatting and ordinals.
+This command adds zeros to a month, day or time part (or any number supposed to be 2-digits). It is intended for date/time formatting and ordinals. The argument is expanded with \cmd{protected@edef} before it is processed.
 
 \cmditem{stripzeros}{integer}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -5899,7 +5899,11 @@
 % strip leading zeros and prepend zero for month/day/timeparts
 % Allow for non numeric labelyear values
 \protected\def\blx@imc@forcezerosmdt#1{%
-  \IfInteger{#1}
+  \protected@edef\blx@tempa{#1}%
+  \expandafter\blx@imc@forcezerosmdt@i\expandafter{\blx@tempa}}
+
+\protected\def\blx@imc@forcezerosmdt@i#1{%
+  \ifinteger{#1}
     {\ifnumless{#1}{10}
       {0\the\numexpr(#1)\relax}
       {#1}}
@@ -5908,7 +5912,11 @@
 % strip leading zeros and prepend zero(s) for year
 % Allow for non numeric labelyear values
 \protected\def\blx@imc@forcezerosy#1{%
-  \IfInteger{#1}
+  \protected@edef\blx@tempa{#1}%
+  \expandafter\blx@imc@forcezerosy@i\expandafter{\blx@tempa}}
+
+\protected\def\blx@imc@forcezerosy@i#1{%
+  \ifinteger{#1}
     {\ifnumless{#1}{10}% 1-digit year
        {000\the\numexpr(#1)\relax}
        {\ifnumless{#1}{100}% 2-digit year
@@ -5941,7 +5949,9 @@
 \let\blx@imc@printlabeltime\@empty
 \let\blx@imc@printlabeldateextra\@empty
 
-\blx@regimcs{\printlabeldate \printlabeltime \printlabeldateextra \stripzeros \forcezerosy \forcezerosmdt \mkyearzeros \mkmonthzeros \mkdayzeros \mktimezeros}
+\blx@regimcs{\printlabeldate \printlabeltime \printlabeldateextra
+  \stripzeros \forcezerosy \forcezerosmdt
+  \mkyearzeros \mkmonthzeros \mkdayzeros \mktimezeros}
 
 % User macro for retrieving currrent language
 \def\currentlang{\blx@languagename}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -2755,7 +2755,7 @@
   \blx@imc@iffieldundef{#1}
     {\@secondoftwo}
     {\expandafter\expandafter
-     \expandafter\ifinteger
+     \expandafter\blx@imc@ifinteger
      \expandafter\expandafter
      \expandafter{\csname abx@field@#1\endcsname}}}
 
@@ -5903,7 +5903,7 @@
   \expandafter\blx@imc@forcezerosmdt@i\expandafter{\blx@tempa}}
 
 \protected\def\blx@imc@forcezerosmdt@i#1{%
-  \ifinteger{#1}
+  \blx@imc@ifinteger{#1}
     {\ifnumless{#1}{10}
       {0\the\numexpr(#1)\relax}
       {#1}}
@@ -5916,7 +5916,7 @@
   \expandafter\blx@imc@forcezerosy@i\expandafter{\blx@tempa}}
 
 \protected\def\blx@imc@forcezerosy@i#1{%
-  \ifinteger{#1}
+  \blx@imc@ifinteger{#1}
     {\ifnumless{#1}{10}% 1-digit year
        {000\the\numexpr(#1)\relax}
        {\ifnumless{#1}{100}% 2-digit year

--- a/tex/latex/biblatex/lbx/brazilian.lbx
+++ b/tex/latex/biblatex/lbx/brazilian.lbx
@@ -58,7 +58,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/british.lbx
+++ b/tex/latex/biblatex/lbx/british.lbx
@@ -58,7 +58,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/bulgarian.lbx
+++ b/tex/latex/biblatex/lbx/bulgarian.lbx
@@ -85,7 +85,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/catalan.lbx
+++ b/tex/latex/biblatex/lbx/catalan.lbx
@@ -81,7 +81,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/croatian.lbx
+++ b/tex/latex/biblatex/lbx/croatian.lbx
@@ -61,7 +61,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/czech.lbx
+++ b/tex/latex/biblatex/lbx/czech.lbx
@@ -53,7 +53,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/danish.lbx
+++ b/tex/latex/biblatex/lbx/danish.lbx
@@ -51,7 +51,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/dutch.lbx
+++ b/tex/latex/biblatex/lbx/dutch.lbx
@@ -72,7 +72,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/english.lbx
+++ b/tex/latex/biblatex/lbx/english.lbx
@@ -66,7 +66,7 @@ canadian,australian,newzealand,USenglish,UKenglish}
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/estonian.lbx
+++ b/tex/latex/biblatex/lbx/estonian.lbx
@@ -95,7 +95,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/finnish.lbx
+++ b/tex/latex/biblatex/lbx/finnish.lbx
@@ -94,7 +94,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/french.lbx
+++ b/tex/latex/biblatex/lbx/french.lbx
@@ -81,7 +81,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/galician.lbx
+++ b/tex/latex/biblatex/lbx/galician.lbx
@@ -58,7 +58,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/german.lbx
+++ b/tex/latex/biblatex/lbx/german.lbx
@@ -65,7 +65,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/greek.lbx
+++ b/tex/latex/biblatex/lbx/greek.lbx
@@ -93,7 +93,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/icelandic.lbx
+++ b/tex/latex/biblatex/lbx/icelandic.lbx
@@ -71,7 +71,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/italian.lbx
+++ b/tex/latex/biblatex/lbx/italian.lbx
@@ -58,7 +58,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/latvian.lbx
+++ b/tex/latex/biblatex/lbx/latvian.lbx
@@ -84,7 +84,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/norsk.lbx
+++ b/tex/latex/biblatex/lbx/norsk.lbx
@@ -51,7 +51,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/polish.lbx
+++ b/tex/latex/biblatex/lbx/polish.lbx
@@ -59,7 +59,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/portuguese.lbx
+++ b/tex/latex/biblatex/lbx/portuguese.lbx
@@ -58,7 +58,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/russian.lbx
+++ b/tex/latex/biblatex/lbx/russian.lbx
@@ -85,7 +85,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/slovak.lbx
+++ b/tex/latex/biblatex/lbx/slovak.lbx
@@ -55,7 +55,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/slovene.lbx
+++ b/tex/latex/biblatex/lbx/slovene.lbx
@@ -55,7 +55,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/spanish.lbx
+++ b/tex/latex/biblatex/lbx/spanish.lbx
@@ -68,7 +68,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/swedish.lbx
+++ b/tex/latex/biblatex/lbx/swedish.lbx
@@ -92,7 +92,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}

--- a/tex/latex/biblatex/lbx/ukrainian.lbx
+++ b/tex/latex/biblatex/lbx/ukrainian.lbx
@@ -85,7 +85,7 @@
       \forcezerosmdt{\thefield{#2}}%
       \iffieldundef{#3}{}
         {\bibtimesep
-         \forcezeros{\thefield{#3}}}%
+         \forcezerosmdt{\thefield{#3}}}%
        \space
        \ifnumless{\thefield{#1}}{12}
          {\bibstring{am}}


### PR DESCRIPTION
This gets rid of `xstring`'s `\IfInteger` and makes the code test in `\forcezeros...` more robust.

This helps with issues mentioned in https://github.com/plk/biber/issues/237 and https://github.com/plk/biblatex/issues/768.