### PR TITLE
Fix entrysetcount for entries in multiple sets (#815)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -544,6 +544,8 @@
 \newcount\blx@parenlevel@text
 \newcount\blx@parenlevel@foot
 \expandafter\newcount\csname blx@sectionciteorder@0\endcsname
+\newcount\blx@entrysetcounter
+
 
 \def\blx@uniquename{0}
 \def\blx@uniquelist{0}
@@ -4399,7 +4401,8 @@
      \blx@getdata{#1}%
      \blx@setoptions@type\abx@field@entrytype
      \blx@setoptions@entry
-     \def\abx@field@entrysetcount{1}%
+     \global\blx@entrysetcounter\@ne
+     \edef\abx@field@entrysetcount{\the\blx@entrysetcounter}%
      \blx@execute
      \blx@beglangbib
      \blx@begunit
@@ -4418,9 +4421,10 @@
     {\begingroup
      \blx@resetdata
      \blx@getdata{#1}%
-     \blx@entrysetcount
      \blx@setoptions@type\abx@field@entrytype
      \blx@setoptions@entry
+     \global\advance\blx@entrysetcounter\@ne
+     \edef\abx@field@entrysetcount{\the\blx@entrysetcounter}%
      \addtocounter{instcount}\@ne
      \blx@execute
      \blx@beglangbib


### PR DESCRIPTION
This fixes the output in the bibliography, but the output in the document is still based on the last set that used the entry. See #815.