### PR TITLE
Make faked csquotes commands private (#737)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -75,7 +75,28 @@
   each different value. No backwards compatibility issues are expected,
   but style authors are encouraged to test the changes and see if the new
   macro could be useful for their styles.
+- For a long time `biblatex` has defined `\enquote` if `csquotes` was not
+  loaded. This behaviour was not documented, the official command intended
+  for quotation marks was always `\mkbibquote`. Because `biblatex` should not
+  (re)define user-level commands that are not primarily associated with
+  citations or the bibliography, from this release on `\enquote` is not defined
+  any more, instead the internal command `\blx@enquote` is defined and used.
+  The same holds for `\initoquote`, `\initiquote`, `\textooquote`,
+  `\textcoquote`, `\textoiquote`, `\textciquote`.
+  `biblatex` still defines the internal commands `\@quotelevel`, `\@quotereset`
+  and `\@setquotesfcodes` if `csquotes` is not loaded.
 
+  Users are encouraged to use `csquotes` for proper quotation marks, but can
+  get back the old behaviour with
+  ```
+  \makeatletter
+  \providerobustcmd*{\enquote}{\blx@enquote}
+  \makeatother
+  ```
+  or
+  ```
+  \newrobustcmd*{\enquote}{\mkbibquote}
+  ```
 
 # RELEASE NOTES FOR VERSION 3.11
 - `\printbiblist` now supports `driver` and `biblistfilter` options

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -441,7 +441,14 @@
        {}%
      \@ifpackagelater{csquotes}{2010/06/09}
        {}
-       {\newcommand*{\@quotereset}{}\newcount\@quotereset}}
+       {\newcommand*{\@quotereset}{}\newcount\@quotereset}%
+     \newcommand*{\blx@initoquote}{\initoquote}%
+     \newcommand*{\blx@textooquote}{\textooquote}%
+     \newcommand*{\blx@textcoquote}{\textcoquote}%
+     \newcommand*{\blx@initiquote}{\initiquote}%
+     \newcommand*{\blx@textoiquote}{\textoiquote}%
+     \newcommand*{\blx@textciquote}{\textciquote}%
+     \newcommand*{\blx@enquote}{\enquote}}
     {\@ifpackageloaded{babel}
        {\blx@warning@noline{%
           'babel/polyglossia' detected but 'csquotes' missing.\MessageBreak
@@ -453,26 +460,27 @@
      \newcount\@quotereset
      \newcommand*{\@setquotesfcodes}{}%
      \let\@setquotesfcodes\relax
-     \newrobustcmd*{\initoquote}{\@quotelevel\@ne}%
-     \newrobustcmd*{\initiquote}{\@quotelevel\tw@}%
-     \newrobustcmd*{\textooquote}{``}%
-     \newrobustcmd*{\textcoquote}{''}%
-     \newrobustcmd*{\textoiquote}{`\relax}% block ligs
-     \newrobustcmd*{\textciquote}{'\relax}% block ligs
-     \newrobustcmd*{\enquote}{\@ifstar\blx@enquote@ii\blx@enquote}%
-     \def\blx@enquote{%
+     \newrobustcmd*{\blx@initoquote}{\@quotelevel\@ne}%
+     \newrobustcmd*{\blx@initiquote}{\@quotelevel\tw@}%
+     \newrobustcmd*{\blx@textooquote}{``}%
+     \newrobustcmd*{\blx@textcoquote}{''}%
+     \newrobustcmd*{\blx@textoiquote}{`\relax}% block ligs
+     \newrobustcmd*{\blx@textciquote}{'\relax}% block ligs
+     \newrobustcmd*{\blx@enquote}
+       {\@ifstar\blx@enquote@iii\blx@enquote@i}%
+     \def\blx@enquote@i{%
        \ifnum\@quotelevel>\z@
-         \expandafter\blx@enquote@ii
+         \expandafter\blx@enquote@iii
        \else
-         \expandafter\blx@enquote@i
+         \expandafter\blx@enquote@ii
        \fi}%
-     \long\def\blx@enquote@i#1{%
-       \begingroup\initoquote
-       \textooquote#1\textcoquote
-       \endgroup}%
      \long\def\blx@enquote@ii#1{%
-       \begingroup\initiquote
-       \textoiquote#1\textciquote
+       \begingroup\blx@initoquote
+       \blx@textooquote#1\blx@textcoquote
+       \endgroup}%
+     \long\def\blx@enquote@iii#1{%
+       \begingroup\blx@initiquote
+       \blx@textoiquote#1\blx@textciquote
        \endgroup}%
      \appto\blx@setsfcodes{%
        \sfcode`\`=\z@
@@ -11340,9 +11348,9 @@
   \blx@tempa}
 
 %% Auxiliary macros
-\newrobustcmd*{\mkbibquote}{\enquote}
+\newrobustcmd*{\mkbibquote}{\blx@enquote}
 \protected\def\blx@imc@mkbibquote{%
-  \blx@ifuspunct\blx@usquote\enquote}
+  \blx@ifuspunct\blx@usquote\blx@enquote}
 
 \def\blx@usquote{%
   \ifnum\@quotelevel>\z@
@@ -11353,26 +11361,26 @@
 
 \long\def\blx@usoquote#1{%
   \begingroup
-  \initoquote
-  \textooquote#1%
+  \blx@initoquote
+  \blx@textooquote#1%
   \futurelet\@let@token\blx@usoquote@i}
 
 \def\blx@usoquote@i{%
   \blx@usqcheck
     {\ifx\blx@postpunct\@empty\else\blx@dopostpunct\fi
-     \textcoquote\endgroup}
-    {\blx@setpostpunct\textcoquote\endgroup}}
+     \blx@textcoquote\endgroup}
+    {\blx@setpostpunct\blx@textcoquote\endgroup}}
 
 \long\def\blx@usiquote#1{%
   \begingroup
-  \initiquote
-  \textoiquote#1%
+  \blx@initiquote
+  \blx@textoiquote#1%
   \futurelet\@let@token\blx@usiquote@i}
 
 \def\blx@usiquote@i{%
   \blx@usqcheck
-    {\textciquote\endgroup}
-    {\blx@setpostpunct\textciquote\endgroup}}
+    {\blx@textciquote\endgroup}
+    {\blx@setpostpunct\blx@textciquote\endgroup}}
 
 \long\def\blx@usqcheck#1#2{%
   \def\blx@tempa{#1}%


### PR DESCRIPTION
As discussed in #737 `biblatex` should not define `\enquote` if `csquotes` is not loaded.

Users can get the old `\enquote` back with
```
\AtBeginDocument{\letcs\enquote{blx@enquote}}
```
or
```
\def\enquote{\csuse{blx@enquote}}
```
when `csquotes` is not loaded.