### PR TITLE
Fix typo

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -348,7 +348,7 @@ In that case you need to make sure that all redefined macros used by \biblatex\ 
 \biber\ versions are closely coupled with \biblatex\ versions. You
 need to have the right combination of the two. \biber\ will throw a fatal error
 during processing if it encounters information which comes from a
-\biblatex\ version which is incompatible. \tabref{tab:int:pre:bibercompat} shows a
+\biblatex\ version which is incompatible. \Tabref{tab:int:pre:bibercompat} shows a
 compatibility matrix for the recent versions.
 
 \begin{table}


### PR DESCRIPTION
BTW, it would be worth consider using `cleveref`'s `\cref` instead of `\secref`, `\Secref`, `\apxref`, `\Apxref`, `\tabref`, `\Tabref`: this unique command would insert the right term (\S -- needs some configuration--, "appendix", "table") depending on the object which is referenced and would save the doc's author from worrying about the type of the object they want to reference.