### PR TITLE
Add wrappers for lists and name lists (#754)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -97,6 +97,11 @@
   ```
   \newrobustcmd*{\enquote}{\mkbibquote}
   ```
+- Add new list wrapper and name wrapper formats (`\DeclareListWrapperFormat`,
+  `\DeclareNameWrapperFormat`) to style a (name) lists in its entirety.
+  This is useful because name and lists formats normally style only one
+  particular item of the list. The wrapper format can be used to easily format
+  the entire list in italics, for example.
 
 # RELEASE NOTES FOR VERSION 3.11
 - `\printbiblist` now supports `driver` and `biblistfilter` options

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -7210,6 +7210,16 @@ The value of the datamodel <nameparts> constant (see \secref{aut:bbx:drv}) creat
 %
 If a certain part of a name is not available, the corresponding macro will be empty, hence you may use, for example, the \sty{etoolbox} tests like \cmd{ifdefvoid} to check for the individual parts of a name. The name of the name list currently being processed is available to the \prm{code} as \cmd{currentname}. Note that the formatting directive also handles the punctuation to be inserted between separate names and between the individual parts of a name. You need to check whether you are in the middle of or at the end of the list, \ie whether \cnt{listcount} is smaller than or equal to \cnt{liststop}. See also \secref{use:cav:nam}. The starred variant of this command is similar to the regular version, except that all type-specific formats are cleared. \emph{Do not put any whitespace between the arguments to this macro as the definitions are quite complex and you will get unexpected results}.
 
+\cmditem{DeclareListWrapperFormat}[entrytype, \dots]{format}{code}
+\cmditem*{DeclareListWrapperFormat}*{format}{code}
+
+Defines the list wrapper format \prm{format}. This formatting directive is arbitrary \prm{code} to be executed once for the entire list processed by \cmd{printlist}. The name of the literal list currently being processed is available to the \prm{code} as \cmd{currentlist}. If an \prm{entrytype} is specified, the format is specific to that type. The \prm{entrytype} argument may be a comma"=separated list of values. The starred variant of this command is similar to the regular version, except that all type-specific formats are cleared.
+
+\cmditem{DeclareNameWrapperFormat}[entrytype, \dots]{format}{code}
+\cmditem*{DeclareNameWrapperFormat}*{format}{code}
+
+Defines the list wrapper format \prm{format}. This formatting directive is arbitrary \prm{code} to be executed once for the entire name list processed by \cmd{printnames}. The name of the literal list currently being processed is available to the \prm{code} as \cmd{currentname}. If an \prm{entrytype} is specified, the format is specific to that type. The \prm{entrytype} argument may be a comma"=separated list of values. The starred variant of this command is similar to the regular version, except that all type-specific formats are cleared.
+
 \cmditem{DeclareIndexFieldFormat}[entrytype, \dots]{format}{code}
 \cmditem*{DeclareIndexFieldFormat}*{format}{code}
 
@@ -7225,6 +7235,17 @@ Defines the literal list format \prm{format}. This formatting directive is arbit
 
 Defines the name list format \prm{format}. This formatting directive is arbitrary \prm{code} to be executed for every name in a list processed by \cmd{indexnames}. The name of the name list currently being processed is available to the \prm{code} as \cmd{currentname}. If an \prm{entrytype} is specified, the format is specific to that type. The \prm{entrytype} argument may be a comma"=separated list of values. The parts of the name will be passed to the \prm{code} as separate arguments. This command is very similar to \cmd{DeclareNameFormat} except that the data handled by the \prm{code} is not intended to be printed but written to the index. Note that \cmd{indexnames} will execute the \prm{code} as is, \ie the \prm{code} must include \cmd{index} or a similar command. The starred variant of this command is similar to the regular version, except that all type-specific formats are cleared.
 
+\cmditem{DeclareIndexListWrapperFormat}[entrytype, \dots]{format}{code}
+\cmditem*{DeclareIndexListWrapperFormat}*{format}{code}
+
+Similar to \cmd{DeclareIndexListFormat} but for the list format used for indices.
+
+
+\cmditem{DeclareIndexNameWrapperFormat}[entrytype, \dots]{format}{code}
+\cmditem*{DeclareIndexNameWrapperFormat}*{format}{code}
+
+Similar to \cmd{DeclareIndexNameFormat} but for the name list format used for indices.
+
 \cmditem{DeclareFieldAlias}[entry type]{alias}[format entry type]{format}
 
 Declares \prm{alias} to be an alias for the field format \prm{format}. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
@@ -7236,6 +7257,14 @@ Declares \prm{alias} to be an alias for the literal list format \prm{format}. If
 \cmditem{DeclareNameAlias}[entry type]{alias}[format entry type]{format}
 
 Declares \prm{alias} to be an alias for the name list format \prm{format}. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
+
+\cmditem{DeclareListWrapperAlias}[entry type]{alias}[format entry type]{format}
+
+Declares \prm{alias} to be an alias for the outer list format \prm{format}. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
+
+\cmditem{DeclareNameWrapperAlias}[entry type]{alias}[format entry type]{format}
+
+Declares \prm{alias} to be an alias for the outer name list format \prm{format}. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
 
 \cmditem{DeclareIndexFieldAlias}[entry type]{alias}[format entry type]{format}
 
@@ -7249,6 +7278,14 @@ Declares \prm{alias} to be an alias for the literal list format \prm{format}. If
 
 Declares \prm{alias} to be an alias for the name list format \prm{format}. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
 
+\cmditem{DeclareIndexListWrapperAlias}[entrytype, \dots]{format}{code}
+
+Similar to \cmd{DeclareIndexListFormat} but for the list format used for indices.
+
+\cmditem{DeclareIndexNameWrapperAlias}[entrytype, \dots]{format}{code}
+
+Similar to \cmd{DeclareIndexNameFormat} but for the name list format used for indices.
+
 \cmditem{DeprecateFieldFormatWithReplacement}[entry type]{alias}[format entry type]{format}
 
 Declares \prm{alias} to be an alias for the name list format \prm{format} and issue a deprecation warning. If an \prm{entrytype} is specified, the alias is specific to that type. The \prm{format entry type} is the entry type of the backend format. This is only required when declaring an alias for a type"=specific formatting directive.
@@ -7261,6 +7298,14 @@ Similar to \cmd{DeprecateFieldFormatWithReplacement} but for list formats.
 
 Similar to \cmd{DeprecateFieldFormatWithReplacement} but for name formats.
 
+\cmditem{DeprecateListWrapperFormatWithReplacement}[entry type]{alias}[format entry type]{format}
+
+Similar to \cmd{DeprecateFieldFormatWithReplacement} but for outer list formats.
+
+\cmditem{DeprecateNameWrapperFormatWithReplacement}[entry type]{alias}[format entry type]{format}
+
+Similar to \cmd{DeprecateFieldFormatWithReplacement} but for outer name formats.
+
 \cmditem{DeprecateIndexFieldFormatWithReplacement}[entry type]{alias}[format entry type]{format}
 
 Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index field formats.
@@ -7270,6 +7315,14 @@ Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index field formats
 Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index list formats.
 
 \cmditem{DeprecateIndexNameFormatWithReplacement}[entry type]{alias}[format entry type]{format}
+
+Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index name formats.
+
+\cmditem{DeprecateIndexListWrapperFormatWithReplacement}[entry type]{alias}[format entry type]{format}
+
+Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index list formats.
+
+\cmditem{DeprecateIndexNameWrapperFormatWithReplacement}[entry type]{alias}[format entry type]{format}
 
 Similar to \cmd{DeprecateFieldFormatWithReplacement} but for index name formats.
 
@@ -9975,6 +10028,16 @@ These commands save and restore the formatting directive \prm{format}, as define
 
 These commands save and restore the formatting directive \prm{format}, as defined with \cmd{DeclareNameFormat}. Both commands work within a local scope. They are mainly provided for use in localisation files.
 
+\cmditem{savelistwrapperformat}[entry type]{format}
+\cmditem{restorelistwrapperformat}[entry type]{format}
+
+These commands save and restore the formatting directive \prm{format}, as defined with \cmd{DeclareListWrapperFormat}. Both commands work within a local scope. They are mainly provided for use in localisation files.
+
+\cmditem{savenamewrapperformat}[entry type]{format}
+\cmditem{restorenamewrapperformat}[entry type]{format}
+
+These commands save and restore the formatting directive \prm{format}, as defined with \cmd{DeclareNameWrapperFormat}. Both commands work within a local scope. They are mainly provided for use in localisation files.
+
 \cmditem{ifbibmacroundef}{name}{true}{false}
 
 Expands to \prm{true} if the bibliography macro \prm{name} is undefined, and to \prm{false} otherwise.
@@ -9982,6 +10045,8 @@ Expands to \prm{true} if the bibliography macro \prm{name} is undefined, and to 
 \cmditem{iffieldformatundef}[entry type]{name}{true}{false}
 \cmditem{iflistformatundef}[entry type]{name}{true}{false}
 \cmditem{ifnameformatundef}[entry type]{name}{true}{false}
+\cmditem{iflistwrapperformatundef}[entry type]{name}{true}{false}
+\cmditem{ifnamewrapperformatundef}[entry type]{name}{true}{false}
 
 Expands to \prm{true} if the formatting directive \prm{format} is undefined, and to \prm{false}
 otherwise.
@@ -13479,6 +13544,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Removed \opt{noerroretextools} option\see{int:pre:inc}
 \item Added \opt{maxsortnames} and \opt{minsortnames}\see{use:opt:pre:gen}
 \item Added \cmd{DeprecateFieldFormatWithReplacement} and friends\see{aut:bib:fmt}
+\item Added list and name wrappers\see{aut:bib:fmt}
 \item Added \cs{ifdateyearsequal}\see{aut:aux:tst}
 \item Added <and higher> sectioning values for \opt{citereset}, \opt{refsection} and \opt{refsegment} options\see{use:opt:pre:gen}
 \item Added Hungarian localisation\see{use:loc:hun}

--- a/tex/latex/biblatex/bbx/authortitle.bbx
+++ b/tex/latex/biblatex/bbx/authortitle.bbx
@@ -17,6 +17,10 @@
 \DeclareNameAlias{editor}{sortname}
 \DeclareNameAlias{translator}{sortname}
 
+\DeclareNameWrapperAlias{author}{sortname}
+\DeclareNameWrapperAlias{editor}{sortname}
+\DeclareNameWrapperAlias{translator}{sortname}
+
 \defbibenvironment{bibliography}
   {\list
      {}

--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -153,6 +153,10 @@
 \DeclareNameAlias{editor}{sortname}
 \DeclareNameAlias{translator}{sortname}
 
+\DeclareNameWrapperAlias{author}{sortname}
+\DeclareNameWrapperAlias{editor}{sortname}
+\DeclareNameWrapperAlias{translator}{sortname}
+
 \defbibenvironment{bibliography}
   {\list
      {}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -562,6 +562,8 @@
 % Formatting directives for literal lists
 % ------------------------------------------------------------------
 
+\DeclareListWrapperFormat{default}{#1}
+
 % The fallback used by \printlist
 
 \DeclareListFormat{default}{%
@@ -809,7 +811,8 @@
 % Formatting directives for name lists
 % ------------------------------------------------------------------
 
-\DeprecateNameFormatWithReplacement{first-last}{given-family}
+\DeclareNameWrapperFormat{default}{#1}
+
 \DeclareNameFormat{given-family}{%
   \ifgiveninits
     {\usebibmacro{name:given-family}
@@ -824,7 +827,8 @@
       {\namepartsuffix}}%
   \usebibmacro{name:andothers}}
 
-\DeprecateNameFormatWithReplacement{last-first}{family-given}
+\DeprecateNameFormatWithReplacement{first-last}{given-family}
+
 \DeclareNameFormat{family-given}{%
   \ifgiveninits
     {\usebibmacro{name:family-given}
@@ -838,8 +842,10 @@
       {\namepartprefix}
       {\namepartsuffix}}%
   \usebibmacro{name:andothers}}
+  
+\DeprecateNameFormatWithReplacement{last-first}{family-given}
 
-\DeprecateNameFormatWithReplacement{last-first/first-last}{family-given/given-family}
+
 \DeclareNameFormat{family-given/given-family}{%
   \ifnumequal{\value{listcount}}{1}
     {\ifgiveninits
@@ -871,6 +877,8 @@
          {\namepartprefix}
          {\namepartsuffix}}}%
   \usebibmacro{name:andothers}}
+
+\DeprecateNameFormatWithReplacement{last-first/first-last}{family-given/given-family}
 
 \DeclareNameFormat{initsonly}{%
   \usebibmacro{name:given-family}
@@ -1091,6 +1099,8 @@
 
 % The fallback used by \indexlist
 
+\DeclareIndexListWrapperFormat{default}{#1}
+
 \DeclareIndexListFormat{default}{\index{#1}}
 
 % ------------------------------------------------------------------
@@ -1101,6 +1111,8 @@
 % ------------------------------------------------------------------
 
 % The fallback used by \indexnames
+
+\DeclareIndexNameWrapperFormat{default}{#1}
 
 \DeclareIndexNameFormat{default}{%
   \usebibmacro{index:name}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3964,6 +3964,24 @@
     {\blx@defformat\blx@defplainformat{fid}*}
     {\blx@defformat\blx@defplainformat{fid}{}}}
 
+\newrobustcmd*{\DeclareNameWrapperFormat}{%
+  \@ifstar
+    {\blx@defformat\blx@defnameformat{nwd}*}
+    {\blx@defformat\blx@defnameformat{nwd}{}}}
+\newrobustcmd*{\DeclareIndexNameWrapperFormat}{%
+  \@ifstar
+    {\blx@defformat\blx@defnameformat{nxd}*}
+    {\blx@defformat\blx@defnameformat{nxd}{}}}
+
+\newrobustcmd*{\DeclareListWrapperFormat}{%
+  \@ifstar
+    {\blx@defformat\blx@defplainformat{lwd}*}
+    {\blx@defformat\blx@defplainformat{lwd}{}}}
+\newrobustcmd*{\DeclareIndexListWrapperFormat}{%
+  \@ifstar
+    {\blx@defformat\blx@defplainformat{lxd}*}
+    {\blx@defformat\blx@defplainformat{lxd}{}}}
+
 % {<macro>}{<class>}{<*>}
 \def\blx@defformat#1#2#3{%
   \@ifnextchar[%]
@@ -4049,15 +4067,21 @@
 \newrobustcmd*{\savefieldformat}[2][*]{\blx@save{abx@ffd@#1@#2}}
 \newrobustcmd*{\savelistformat}[2][*]{\blx@save{abx@lfd@#1@#2}}
 \newrobustcmd*{\savenameformat}[2][*]{\blx@save{abx@nfd@#1@#2}}
+\newrobustcmd*{\savelistwrapperformat}[2][*]{\blx@save{abx@lwd@#1@#2}}
+\newrobustcmd*{\savenamewrapperformat}[2][*]{\blx@save{abx@nwd@#1@#2}}
 
 \newrobustcmd*{\restorefieldformat}[2][*]{\blx@restore{abx@ffd@#1@#2}}
 \newrobustcmd*{\restorelistformat}[2][*]{\blx@restore{abx@lfd@#1@#2}}
 \newrobustcmd*{\restorenameformat}[2][*]{\blx@restore{abx@nfd@#1@#2}}
+\newrobustcmd*{\restorelistwrapperformat}[2][*]{\blx@restore{abx@lwd@#1@#2}}
+\newrobustcmd*{\restorenamewrapperformat}[2][*]{\blx@restore{abx@nwd@#1@#2}}
 
 % [<entrytype>]{<name>}{<true>}{<false>}
 \newrobustcmd*{\iffieldformatundef}[2][*]{\ifcsundef{abx@ffd@#1@#2}}
 \newrobustcmd*{\iflistformatundef}[2][*]{\ifcsundef{abx@lfd@#1@#2}}
 \newrobustcmd*{\ifnameformatundef}[2][*]{\ifcsundef{abx@nfd@#1@#2}}
+\newrobustcmd*{\iflistwrapperformatundef}[2][*]{\ifcsundef{abx@lwd@#1@#2}}
+\newrobustcmd*{\ifnamewrapperformatundef}[2][*]{\ifcsundef{abx@nwd@#1@#2}}
 
 % [<entrytype>]{<alias>}[<entrytype>]{<name>}
 \newrobustcmd*{\DeclareNameAlias}{\blx@defalias{nfd}}
@@ -4068,6 +4092,12 @@
 
 \newrobustcmd*{\DeclareFieldAlias}{\blx@defalias{ffd}}
 \newrobustcmd*{\DeclareIndexFieldAlias}{\blx@defalias{fid}}
+
+\newrobustcmd*{\DeclareNameWrapperAlias}{\blx@defalias{nwd}}
+\newrobustcmd*{\DeclareIndexNameWrapperAlias}{\blx@defalias{nxd}}
+
+\newrobustcmd*{\DeclareListWrapperAlias}{\blx@defalias{lwd}}
+\newrobustcmd*{\DeclareIndexListWrapperAlias}{\blx@defalias{lxd}}
 
 % #1: internal type signature, #2: type text for warning
 %      #3         #4         #5          #6
@@ -4108,6 +4138,16 @@
   \blx@deprecateformat{ffd}{Field format}}
 \newrobustcmd*{\DeprecateIndexFieldFormatWithReplacement}{%
   \blx@deprecateformat{fid}{Index field format}}
+
+\newrobustcmd*{\DeprecateNameWrapperFormatWithReplacement}{%
+  \blx@deprecateformat{nwd}{Name wrapper format}}
+\newrobustcmd*{\DeprecateIndexNameWrapperFormatWithReplacement}{%
+  \blx@deprecateformat{nxd}{Index name wrapper format}}
+
+\newrobustcmd*{\DeprecateListWrapperFormatWithReplacement}{%
+  \blx@deprecateformat{lwd}{List wrapper format}}
+\newrobustcmd*{\DeprecateIndexListWrapperFormatWithReplacement}{%
+  \blx@deprecateformat{lxd}{Index list wrapper format}}
 
 % [<format>]{<text>}
 \newrobustcmd{\blx@imc@printtext}[2][]{%
@@ -4185,13 +4225,16 @@
 \def\blx@printnames#1#2#3#4{%
   \blx@imc@ifnameundef{#4}
     {\blx@nounit}
-    {\blx@getformat\blx@theformat{nfd}{#1}{#4}%
-     \ifdefvoid\blx@theformat
+    {\blx@getformat\blx@thewrapperformat{nwd}{#1}{#4}%
+     \ifdefvoid\blx@thewrapperformat
        {\blx@nounit}
-       {\blx@begunit
-        \blx@namesetup{#2}{#3}{#4}%
-        \expandafter\blx@nameparser\blx@thedata{}&%
-        \blx@endunit}}}
+       {\blx@getformat\blx@theformat{nfd}{#1}{#4}%
+        \ifdefvoid\blx@theformat
+          {\blx@nounit}
+          {\blx@begunit
+           \blx@namesetup{#2}{#3}{#4}%
+           \blx@thewrapperformat{\expandafter\blx@nameparser\blx@thedata{}&}%
+           \blx@endunit}}}}
 
 \def\blx@namesetup#1#2#3{%
   \def\currentname{#3}%
@@ -4272,14 +4315,17 @@
 \def\blx@indexnames#1#2#3#4{%
   \blx@imc@ifnameundef{#4}
     {}
-    {\blx@getformat\blx@theformat{nid}{#1}{#4}%
-     \ifdefvoid\blx@theformat
+    {\blx@getformat\blx@thewrapperformat{nxd}{#1}{#4}%
+     \ifdefvoid\blx@thewrapperformat
        {}
-       {\begingroup
-        \blx@namesetup{#2}{#3}{#4}%
-        \blx@indexnamesetup
-        \expandafter\blx@nameparser\blx@thedata{}&%
-        \endgroup}}}
+       {\blx@getformat\blx@theformat{nid}{#1}{#4}%
+        \ifdefvoid\blx@theformat
+          {}
+          {\begingroup
+           \blx@namesetup{#2}{#3}{#4}%
+           \blx@indexnamesetup
+           \expandafter\blx@nameparser\blx@thedata{}&%
+           \endgroup}}}}
 
 \def\blx@indexnamesetup{%
   \let\bibinitperiod\bibindexinitperiod
@@ -4328,13 +4374,16 @@
 \def\blx@printlist#1#2#3#4{%
   \blx@imc@iflistundef{#4}
     {\blx@nounit}
-    {\blx@getformat\blx@theformat{lfd}{#1}{#4}%
-     \ifdefvoid\blx@theformat
+    {\blx@getformat\blx@thewrapperformat{lwd}{#1}{#4}%
+     \ifdefvoid\blx@thewrapperformat
        {\blx@nounit}
-       {\blx@begunit
-        \blx@listsetup{#2}{#3}{#4}%
-        \expandafter\blx@listparser\blx@thedata{}&%
-        \blx@endunit}}}
+       {\blx@getformat\blx@theformat{lfd}{#1}{#4}%
+        \ifdefvoid\blx@theformat
+          {\blx@nounit}
+          {\blx@begunit
+           \blx@listsetup{#2}{#3}{#4}%
+           \blx@thewrapperformat{\expandafter\blx@listparser\blx@thedata{}&}%
+           \blx@endunit}}}}
 
 \def\blx@listsetup#1#2#3{%
   \def\currentlist{#3}%
@@ -4371,13 +4420,16 @@
 \def\blx@indexlist#1#2#3#4{%
   \blx@imc@iflistundef{#4}
     {}
-    {\blx@getformat\blx@theformat{lid}{#1}{#4}%
-     \ifdefvoid\blx@theformat
+    {\blx@getformat\blx@thewrapperformat{lxd}{#1}{#4}%
+     \ifdefvoid\blx@thewrapperformat
        {}
-       {\begingroup
-        \blx@listsetup{#2}{#3}{#4}%
-        \expandafter\blx@listparser\blx@thedata{}&%
-        \endgroup}}}
+       {\blx@getformat\blx@theformat{lid}{#1}{#4}%
+        \ifdefvoid\blx@theformat
+          {}
+          {\begingroup
+           \blx@listsetup{#2}{#3}{#4}%
+           \expandafter\blx@listparser\blx@thedata{}&%
+           \endgroup}}}}
 
 % {<item1>}{<item2>}{...}
 \long\def\blx@listparser#1{%


### PR DESCRIPTION
Cf. #754.

Wrappers for name lists and lists can be used to format the complete (name) list at once.
