### PR TITLE
Fix type option handling

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -12210,15 +12210,13 @@
   \ifdef\blx@opts@type
     {\def\do##1{%
        \begingroup
+       \let\protect\relax
        \blx@setoptions@type{##1}%
        % Expand the type use* name toggles
        \let\blx@xml@nametoggles\@empty
        \def\do####1{\eappto\blx@xml@nametoggles{\blx@xml@toggle{use####1}}}%
        \abx@donames
-       \begingroup
-       \let\protect\relax
        \blx@checkoptions@type
-       \endgroup
        \xappto\blx@tempa{\blx@bcf@options@type{##1}}%
        \endgroup}%
      \dolistloop\blx@opts@type}


### PR DESCRIPTION
Protected macros could break when used in type options due to the `\let\protect\string`. This should resolve the undesirable situation.