### PR TITLE
typos annotatationname->annotationname

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -3242,39 +3242,39 @@ To access the annotation information when formatting bibliography data, macros a
 
 \cmditem{iffieldannotation}[field][annotationname]{annotation}{true}{false}
 
-Executes \prm{true} if the data field \prm{field} has an annotation \prm{annotation} for the annotation called \prm{annotationname} and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
+Executes \prm{true} if the data field \prm{field} has an annotation \prm{annotation} for the annotation called \prm{annotationname} and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
 
 \cmditem{ifitemannotation}[field][annotationname][item]{annotation}{true}{false}
 
-Executes \prm{true} if the item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{iffieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
+Executes \prm{true} if the item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{iffieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
 
 \cmditem{ifpartannotation}[field][annotationname][item]{part}{annotation}{true}{false}
 
-Executes \prm{true} if the part named \prm{part} in item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{ifitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
+Executes \prm{true} if the part named \prm{part} in item \prm{item} in the data field \prm{field} has an annotation \prm{annotation} and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{ifitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
 
 Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to test annotations for dates.
 
 \cmditem{ifdateannotation}[annotationname]{datetype}{annotation}{true}{false}
 
-Executes \prm{true} if the date field \prm{datetype} has an annotation \prm{annotation} and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{ifdateannotation} will be used.
+Executes \prm{true} if the date field \prm{datetype} has an annotation \prm{annotation} and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{ifdateannotation} will be used.
 
 \cmditem{hasfieldannotation}[field][annotationname]{true}{false}
 
-Executes \prm{true} if the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
+Executes \prm{true} if the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
 
 \cmditem{hasitemannotation}[field][annotationname][item]{true}{false}
 
-Executes \prm{true} if the item \prm{item} in the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{iffieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
+Executes \prm{true} if the item \prm{item} in the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{iffieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
 
 \cmditem{haspartannotation}[field][annotationname][item]{part}{true}{false}
 
-Executes \prm{true} if the part named \prm{part} in the item \prm{item} in the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{ifitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
+Executes \prm{true} if the part named \prm{part} in the item \prm{item} in the data field \prm{field} has a literal annotation \prm{annotationname} defined and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{ifitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
 
 Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to test the existence of annotations for dates.
 
 \cmditem{hasdateannotation}[annotationname]{datetype}{true}{false}
 
-Executes \prm{true} if the date field \prm{datetype} has any annotation \prm{annotationname} defined and false otherwise. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{ifdateannotation} will be used.
+Executes \prm{true} if the date field \prm{datetype} has any annotation \prm{annotationname} defined and false otherwise. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{ifdateannotation} will be used.
 
 \end{ltxsyntax}
 %
@@ -3317,21 +3317,21 @@ Such annotations are not keys whose presence can be tested for but are rather li
 
 \cmditem{getfieldannotation}[field][annotationname]
 
-Retrieves any literal annotation for the field \prm{field}. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
+Retrieves any literal annotation for the field \prm{field}. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). If \prm{field} is not given, the current data field as indicated by \cmd{currentfield}, \cmd{currentlist} or \cmd{currentname} (see \secref{aut:bib:fmt}) is assumed. Of course, this is only possible if these commands are defined, that is, inside formatting directives.
 
 \cmditem{getitemannotation}[field][annotationname][item]
 
-Retrieves any literal annotation for the item \prm{item} in the field \prm{field}. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{getfieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
+Retrieves any literal annotation for the item \prm{item} in the field \prm{field}. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The optional argument \prm{field} can be inferred if not provided as with \cmd{getfieldannotation}. If \prm{item} is not given, the number of the item currently being processed as given by \cnt{listcount} is used.
 
 \cmditem{getpartannotation}[field][annotationname][item]{part}
 
-Retrieves any literal annotation for the part \prm{part}. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{getitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
+Retrieves any literal annotation for the part \prm{part}. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The two optional arguments \prm{field} and \prm{item} can be inferred as in \cmd{getitemannotation}. The parameter \prm{part} can never be inferred and is therefore a mandatory argument.
 
 Date fields are special and handled in a context where \cmd{currentfield} is not accessible. Thus there is a fourth command to access literal annotations for dates.
 
 \cmditem{getdateannotation}[annotationname]{datetype}
 
-Retrieve a literal annotation for the datefield \prm{datetype}. If \prm{annotatationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{getdateannotation} will be used.
+Retrieve a literal annotation for the datefield \prm{datetype}. If \prm{annotationname} is not given, then the annotation named <default> is assumed (this is the name given to annotations defined without an explicit name). The \prm{datetype} argument is mandatory, because it cannot be inferred in most contexts where \cmd{getdateannotation} will be used.
 
 \end{ltxsyntax}
 %


### PR DESCRIPTION
Hello.
Found these typos while reading the current version of the documentation.