### PR TITLE
Improve ability to customise \volcite postnotes (#868)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -29,6 +29,8 @@
   `uniquebaretitle`, `uniquework`, `uniqueprimaryauthor`).
 - Add `\ifvolcite` test to check if the current citation is in a `\volcite`
   context.
+- Add the special fields `volcitevolume` and `volcitepages` for finer control
+  over the `\volcite` postnote.
 
 # RELEASE NOTES FOR VERSION 3.12
 - **INCOMPATIBLE CHANGE** The syntax for defining data annotations in the

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -27,6 +27,8 @@
   `loccittracker`, `opcittracker`, `singletitle`, `skipbib`, `skipbiblist`,
   `skipbiblab` `terseinits`, `uniquelist`, `uniquename`, `uniquetitle`,
   `uniquebaretitle`, `uniquework`, `uniqueprimaryauthor`).
+- Add `\ifvolcite` test to check if the current citation is in a `\volcite`
+  context.
 
 # RELEASE NOTES FOR VERSION 3.12
 - **INCOMPATIBLE CHANGE** The syntax for defining data annotations in the

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -32,6 +32,8 @@
 - Add the special fields `volcitevolume` and `volcitepages` for finer control
   over the `\volcite` postnote.
 - Add `\AtVolcite` hook to initialise `\volcite` commands.
+- Add `multiprenotedelim` and `multipostnotedelim` and make all
+ `(pre|post)notedelim`-like commands context sensitive.
 
 # RELEASE NOTES FOR VERSION 3.12
 - **INCOMPATIBLE CHANGE** The syntax for defining data annotations in the

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -31,6 +31,7 @@
   context.
 - Add the special fields `volcitevolume` and `volcitepages` for finer control
   over the `\volcite` postnote.
+- Add `\AtVolcite` hook to initialise `\volcite` commands.
 
 # RELEASE NOTES FOR VERSION 3.12
 - **INCOMPATIBLE CHANGE** The syntax for defining data annotations in the

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -12383,7 +12383,7 @@ Similar to \cmd{AtBeginBibliography} but only affecting the next \cmd{printbibli
 \cmditem{AtUsedriver}{code}
 \cmditem*{AtUsedriver}*{code}
 
-Appends the \prm{code} to an internal hook executed when initializing \cmd{uisedriver}. The starred variant of the command clears the initialisation hook, so the defaults can be overwritten. This command may only be used in the preamble.
+Appends the \prm{code} to an internal hook executed when initializing \cmd{usedriver}. The starred variant of the command clears the initialisation hook, so the defaults can be overwritten. This command may only be used in the preamble.
 The default setting is:
 
 \begin{ltxexample}
@@ -12422,6 +12422,17 @@ Similar to \cmd{AtEveryCitekey} but only affecting the next entry key. The inter
 
 Similar to \cmd{AtEveryMultiCite} but only affecting the next multicite command. The internal hook is cleared after being executed once. This command may be used in the document body.
 
+\cmditem{AtVolcite}{code}
+\cmditem*{AtVolcite}*{code}
+
+Appends the \prm{code} to an internal hook executed when initializing \cmd{volcite}. The starred variant of the command clears the initialisation hook, so the defaults can be overwritten. This command may only be used in the preamble.
+The default setting is:
+
+\begin{ltxexample}
+\AtVolcite{%
+  \DeclareFieldAlias{postnote}{volcitenote}}
+\end{ltxexample}
+
 \cmditem{AtDataInput}[entrytype]{code}
 
 Appends the \prm{code} to an internal hook executed once for every entry as the bibliographic data is imported from the \file{bbl} file. The \prm{entrytype} is the entry type the \prm{code} applies to. If it applies to all entry types, omit the optional argument. The \prm{code} is executed immediately after the entry has been imported. This command may only be used in the preamble. Note that \prm{code} may be executed multiple times for an entry. This occurs when the same entry is cited in different \env{refsection} environments or the \opt{sorting} option settings incorporate more than one sorting template. The \cnt{refsection} counter holds the number of the respective reference section while the data is imported.
@@ -12457,6 +12468,10 @@ Executes and clears the internal hook corresponding to \cmd{AtNextCitekey}.
 \cmditem{UseNextMultiCiteHook}
 
 Executes and clears the internal hook corresponding to \cmd{AtNextMultiCite}.
+
+\cmditem{UseVolciteHook}
+
+Executes the internal hook corresponding to \cmd{AtVolcite}.
 
 \cmditem{DeferNextCitekeyHook}
 
@@ -13850,6 +13865,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \cmd{ifvolcite} test\see{aut:aux:tst}
 \item Added special fields \bibfield{volcitevolume} and \bibfield{volcitepages}%
   \see{aut:cbx:fld}
+\item Added \cmd{AtVolcite} hook\see{aut:fmt:hok}
 \end{release}
 
 \begin{release}{3.12}{2018-10-30}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4468,63 +4468,63 @@ This command uses the bibliography driver for the respective entry type to creat
 
 Similar to \cmd{fullcite} but puts the entire citation in a footnote and adds a period at the end.
 
-\cmditem{volcite}[prenote]{volume}[page]{key}
-\cmditem{Volcite}[prenote]{volume}[page]{key}
+\cmditem{volcite}[prenote]{volume}[pages]{key}
+\cmditem{Volcite}[prenote]{volume}[pages]{key}
 
-These commands are similar to \cmd{cite} and \cmd{Cite} but intended for references to multi"=volume works which are cited by volume and page number. Instead of the \prm{postnote}, they take a mandatory \prm{volume} and an optional \prm{page} argument. Since they merely compose the postnote and pass it to the \cmd{cite} command provided by the citation style as a \prm{postnote} argument, these commands are style independent. The format of the volume portion is controlled by the field formatting directive \opt{volcitevolume}, the format of the page/text portion is controlled by the field formatting directive \opt{volcitepages} (\secref{aut:fmt:ich}). The delimiter printed between the volume portion and the page/text portion may be modified by redefining the macro \cmd{volcitedelim} (\secref{aut:fmt:fmt}).
+These commands are similar to \cmd{cite} and \cmd{Cite} but intended for references to multi"=volume works which are cited by volume and page number. Instead of the \prm{postnote}, they take a mandatory \prm{volume} and an optional \prm{pages} argument. Since they merely compose the postnote and pass it to the \cmd{cite} command provided by the citation style as a \prm{postnote} argument, these commands are style independent. The volume and pages/text portion are formatted with the macro \cmd{mkvolcitenote} when they are passed on to the citation command. Additionally they are made available in the special fields \bibfield{volcitevolume} and \bibfield{volcitevolume} (\secref{aut:cbx:fld}) The format of the volume portion is controlled by the field formatting directive \opt{volcitevolume}, the format of the pages/text portion is controlled by the field formatting directive \opt{volcitepages} (\secref{aut:fmt:ich}). The delimiter printed between the volume portion and the pages/text portion may be modified by redefining the macro \cmd{volcitedelim} (\secref{aut:fmt:fmt}).
 
-\cmditem{volcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Volcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{volcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Volcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{volcite} and \cmd{Volcite}, respectively.
 
-\cmditem{pvolcite}[prenote]{volume}[page]{key}
-\cmditem{Pvolcite}[prenote]{volume}[page]{key}
+\cmditem{pvolcite}[prenote]{volume}[pages]{key}
+\cmditem{Pvolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{parencite}.
 
-\cmditem{pvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Pvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{pvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Pvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{pvolcite} and \cmd{Pvolcite}, respectively.
 
-\cmditem{fvolcite}[prenote]{volume}[page]{key}
-\cmditem{ftvolcite}[prenote]{volume}[page]{key}
+\cmditem{fvolcite}[prenote]{volume}[pages]{key}
+\cmditem{ftvolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{footcite} and \cmd{footcitetext}, respectively.
 
-\cmditem{fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{fvolcite} and \cmd{Fvolcite}, respectively.
 
-\cmditem{svolcite}[prenote]{volume}[page]{key}
-\cmditem{Svolcite}[prenote]{volume}[page]{key}
+\cmditem{svolcite}[prenote]{volume}[pages]{key}
+\cmditem{Svolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{smartcite}.
 
-\cmditem{svolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Svolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{svolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Svolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{svolcite} and \cmd{Svolcite}, respectively.
 
-\cmditem{tvolcite}[prenote]{volume}[page]{key}
-\cmditem{Tvolcite}[prenote]{volume}[page]{key}
+\cmditem{tvolcite}[prenote]{volume}[pages]{key}
+\cmditem{Tvolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{textcite}.
 
-\cmditem{tvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Tvolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{tvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Tvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{tvolcite} and \cmd{Tvolcite}, respectively.
 
-\cmditem{avolcite}[prenote]{volume}[page]{key}
-\cmditem{Avolcite}[prenote]{volume}[page]{key}
+\cmditem{avolcite}[prenote]{volume}[pages]{key}
+\cmditem{Avolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{autocite}.
 
-\cmditem{avolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
-\cmditem{Avolcites}(multiprenote)(multipostnote)[prenote]{volume}[page]{key}|\\...|[prenote]{volume}[page]{key}
+\cmditem{avolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{Avolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
 The multicite version of \cmd{avolcite} and \cmd{Avolcite}, respectively.
 
@@ -4956,6 +4956,10 @@ If \cmd{sortalphaothers} is not redefined, it defaults to \cmd{labelalphaothers}
 
 \csitem{volcitedelim}
 The delimiter printed between the volume portion and the page/text portion of \cmd{volcite} and related commands (\secref{use:cit:spc}).
+
+\cmditem{mkvolcitenote}{volume}{pages}
+
+This macro formats the \prm{volume} and \prm{pages} arguments of \cmd{volcite} and related commands (\secref{use:cit:spc}) when they are passed on to the underlying citation command.
 
 \csitem{prenotedelim}
 The delimiter printed after the \prm{prenote} argument of a citation command. See \secref{use:cit} for details. The default is an interword space.
@@ -7229,6 +7233,14 @@ The \prm{multiprenote} argument passed to a multicite command. This field is spe
 \fielditem{multipostnote}{literal}
 
 The \prm{multipostnote} argument passed to a multicite command. This field is specific to citations and not available in the bibliography. If the \prm{multipostnote} argument is missing or empty, this field is undefined.
+
+\fielditem{volcitevolume}{literal}
+
+The \prm{volume} argument passed to \cmd{volcite} or a related citation command (\secref{use:cit:spc}). This field is specific to \cmd{volcite} citations and not available in the bibliography or other citations.
+
+\fielditem{volcitepages}{literal}
+
+The \prm{pages} argument passed to \cmd{volcite} or a related citation command (\secref{use:cit:spc}). This field is specific to \cmd{volcite} citations and not available in the bibliography or other citations. If the \prm{pages} argument is missing or empty, this field is undefined.
 
 \fielditem{postpunct}{punctuation command}
 
@@ -13836,6 +13848,8 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \cmd{DeclareBiblatexOption}\see{aut:bbx:bbx}
 \item Expanded scope possibilities for several options\see{apx:opt}
 \item Added \cmd{ifvolcite} test\see{aut:aux:tst}
+\item Added special fields \bibfield{volcitevolume} and \bibfield{volcitepages}%
+  \see{aut:cbx:fld}
 \end{release}
 
 \begin{release}{3.12}{2018-10-30}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -10108,6 +10108,10 @@ Executes \prm{true} if \biblatex's punctuation tracker would capitalize a locali
 \cmditem{ifcitation}{true}{false}
 
 Expands to \prm{true} when located in a citation, and to \prm{false} otherwise. Note that this command is responsive to the outermost context in which it is used. For example, if a citation command defined with \cmd{DeclareCiteCommand} executes a driver defined with \cmd{DeclareBibliographyDriver}, any \cmd{ifcitation} tests in the driver code will yield \prm{true}. See \secref{aut:cav:mif} for a practical example.
+ 
+\cmditem{ifvolcite}{true}{false}
+
+Expands to \prm{true} when located in \cmd{volcite} or a related citation command (\secref{use:cit:spc}), and to \prm{false} otherwise.
 
 \cmditem{ifbibliography}{true}{false}
 
@@ -13831,6 +13835,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Enhanced \cmd{addbibresource} with globbing\see{use:bib:res}
 \item Added \cmd{DeclareBiblatexOption}\see{aut:bbx:bbx}
 \item Expanded scope possibilities for several options\see{apx:opt}
+\item Added \cmd{ifvolcite} test\see{aut:aux:tst}
 \end{release}
 
 \begin{release}{3.12}{2018-10-30}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4961,14 +4961,20 @@ The delimiter printed between the volume portion and the page/text portion of \c
 
 This macro formats the \prm{volume} and \prm{pages} arguments of \cmd{volcite} and related commands (\secref{use:cit:spc}) when they are passed on to the underlying citation command.
 
-\csitem{prenotedelim}
+\csitem{prenotedelim}\CSdelimMark
 The delimiter printed after the \prm{prenote} argument of a citation command. See \secref{use:cit} for details. The default is an interword space.
 
-\csitem{postnotedelim}
+\csitem{postnotedelim}\CSdelimMark
 The delimiter printed before the \prm{postnote} argument of a citation command. See \secref{use:cit} for details. The default is a comma plus an interword space.
 
-\csitem{extpostnotedelim}
+\csitem{extpostnotedelim}\CSdelimMark
 The delimiter printed between the citation and the parenthetical \prm{postnote} argument of a citation command when the postnote occurs outside of the citation parentheses. In the standard styles, this occurs when the citation uses the shorthand field of the entry. See \secref{use:cit} for details. The default is an interword space.
+
+\csitem{multiprenotedelim}\CSdelimMark
+The delimiter printed after the \prm{multiprenote} argument of a citation command. See \secref{use:cit} for details. The default is \cs{prenotedelim}.
+
+\csitem{multipostnotedelim}\CSdelimMark
+The delimiter printed before the \prm{multipostnote} argument of a citation command. See \secref{use:cit} for details. The default is \cs{postnotedelim}.
 
 \cmditem{mkbibname<namepart>}{text}
 This command, which takes one argument, is used to format the name part <namepart> of name list fields. The default datamodel defines the name parts <family>, <given>, <prefix> and <suffix> and therefore the following macros are automatically defined:
@@ -11813,14 +11819,20 @@ Similar to \cmd{labelalphaothers} but used in the sorting process. Setting it to
 \csitem{volcitedelim}
 The delimiter to be printed between the volume portion and the page/text portion of \cmd{volcite} and related commands (\secref{use:cit:spc}).
 
-\csitem{prenotedelim}
+\csitem{prenotedelim}\CSdelimMark
 The delimiter to be printed after the \prm{prenote} argument of a citation command. The default is an interword space.
 
-\csitem{postnotedelim}
+\csitem{postnotedelim}\CSdelimMark
 The delimiter to be printed before the \prm{postnote} argument of a citation command. The default is a comma plus an interword space.
 
-\csitem{extpostnotedelim}
+\csitem{extpostnotedelim}\CSdelimMark
 The delimiter printed between the citation and the parenthetical \prm{postnote} argument of a citation command when the postnote occurs outside of the citation parentheses. In the standard styles, this occurs when the citation uses the shorthand field of the entry. The default is an interword space.
+
+\csitem{multiprenotedelim}\CSdelimMark
+The delimiter to be printed after the \prm{multiprenote} argument of a citation command.
+
+\csitem{multipostnotedelim}\CSdelimMark
+The delimiter to be printed before the \prm{multipostnote} argument of a citation command.
 
 \cmditem{mkbibnamefamily}{text}
 Formatting hook for the family name, to be used in all formatting directives for name lists.
@@ -13866,6 +13878,8 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added special fields \bibfield{volcitevolume} and \bibfield{volcitepages}%
   \see{aut:cbx:fld}
 \item Added \cmd{AtVolcite} hook\see{aut:fmt:hok}
+\item Made \cmd{postnotedelim} and friends context sensitive\see{use:fmt:fmt}
+\item Added \cmd{multipostnotedelim} and \cmd{multiprenotedelim}\see{use:fmt:fmt}
 \end{release}
 
 \begin{release}{3.12}{2018-10-30}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -97,9 +97,11 @@
 \newcommand*{\multicitedelim}{\addsemicolon\space}
 \newcommand*{\compcitedelim}{\addcomma\space}
 \newcommand*{\supercitedelim}{\addcomma}
-\newcommand*{\prenotedelim}{\addspace}
-\newcommand*{\postnotedelim}{\addcomma\space}
-\newcommand*{\extpostnotedelim}{\addspace}
+\DeclareDelimFormat{prenotedelim}{\addspace}
+\DeclareDelimFormat{postnotedelim}{\addcomma\space}
+\DeclareDelimAlias{multiprenotedelim}{prenotedelim}
+\DeclareDelimAlias{multipostnotedelim}{postnotedelim}
+\DeclareDelimFormat{extpostnotedelim}{\addspace}
 \newcommand*{\volcitedelim}{\addcomma\space}
 \newcommand*{\textcitedelim}{%
   \iffinalcitedelim
@@ -2143,21 +2145,21 @@
 
 \DeclareCiteCommand{\notecite}
   {\printfield{prenote}%
-   \setunit*{\prenotedelim}}
+   \setunit*{\printdelim{prenotedelim}}}
   {\nocite{\thefield{entrykey}}}
   {}
   {\printfield{postnote}}
 
 \DeclareCiteCommand{\pnotecite}[\mkbibparens]
   {\printfield{prenote}%
-   \setunit*{\prenotedelim}}
+   \setunit*{\printdelim{prenotedelim}}}
   {\nocite{\thefield{entrykey}}}
   {}
   {\printfield{postnote}}
 
 \DeclareCiteCommand{\fnotecite}[\mkbibfootnote]
   {\printfield{prenote}%
-   \setunit*{\prenotedelim}}
+   \setunit*{\printdelim{prenotedelim}}}
   {\nocite{\thefield{entrykey}}}
   {}
   {\printfield{postnote}}
@@ -2262,12 +2264,12 @@
   \iffieldundef{prenote}
     {}
     {\printfield{prenote}%
-     \setunit{\prenotedelim}}}
+     \setunit{\printdelim{prenotedelim}}}}
 
 \newbibmacro*{postnote}{%
   \iffieldundef{postnote}
     {}
-    {\setunit{\postnotedelim}%
+    {\setunit{\printdelim{postnotedelim}}%
      \printfield{postnote}}}
 
 % multicite commands
@@ -2276,12 +2278,12 @@
   \iffieldundef{multiprenote}
     {}
     {\printfield{multiprenote}%
-     \prenotedelim}}
+     \printdelim{multiprenotedelim}}}
 
 \newbibmacro*{multipostnote}{%
   \iffieldundef{multipostnote}
     {}
-    {\postnotedelim
+    {\printdelim{multipostnotedelim}
      \printfield{multipostnote}}}
 
 % ------------------------------------------------------------------

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -748,6 +748,7 @@
 \newtoggle{blx@skipbiblist}
 \newtoggle{blx@skiplab}
 \newtoggle{blx@citation}
+\newtoggle{blx@volcite}
 \newtoggle{blx@bibliography}
 \newtoggle{blx@citeindex}
 \newtoggle{blx@bibindex}
@@ -3675,6 +3676,7 @@
 \appto\blx@blxinit{%
   \def\ifnatbibmode{\iftoggle{blx@natbib}}%
   \def\ifcitation{\iftoggle{blx@citation}}%
+  \def\ifvolcite{\iftoggle{blx@volcite}}%
   \def\ifbibliography{\iftoggle{blx@bibliography}}%
   \def\ifciteindex{\iftoggle{blx@citeindex}}%
   \def\ifbibindex{\iftoggle{blx@bibindex}}%
@@ -11556,6 +11558,7 @@
     \def\iffieldbibstring#1{\blx@TE{\blx@imc@iffieldbibstring{#1}}}%
     \def\ifnatbibmode{\blx@TE{\iftoggle{blx@natbib}}}%
     \def\ifcitation{\blx@TE{\iftoggle{blx@citation}}}%
+    \def\ifvolcite{\blx@TE{\iftoggle{blx@volcite}}}%
     \def\ifbibliography{\blx@TE{\iftoggle{blx@bibliography}}}%
     \def\ifciteindex{\blx@TE{\iftoggle{blx@citeindex}}}%
     \def\ifbibindex{\blx@TE{\iftoggle{blx@bibindex}}}%
@@ -11895,7 +11898,9 @@
 % {<macro>}[<pre>]{<vol>}[<post>] => <macro>{<pre>}{{<vol>}{<post>}}
 
 \newrobustcmd*{\volcitecmd}{%
-  \AtNextCite{\DeclareFieldAlias{postnote}{volcitenote}}%
+  \AtNextCite{%
+    \toggletrue{blx@volcite}%
+    \DeclareFieldAlias{postnote}{volcitenote}}%
   \begingroup\let\blx@citeargs\blx@volciteargs}
 
 \protected\def\blx@volciteargs#1{%
@@ -11913,7 +11918,9 @@
   \blx@citeargs@iii{#1{#2}{{#3}{#4}}}}
 
 \newrobustcmd*{\multivolcitecmd}{%
-  \AtNextCite{\DeclareFieldAlias{postnote}{volcitenote}}%
+  \AtNextCite{%
+    \toggletrue{blx@volcite}%
+    \DeclareFieldAlias{postnote}{volcitenote}}%
   \def\blx@hook@mcite@before{%
     \global\undef\blx@hook@mcite@before
     \let\blx@citeargs\blx@volmciteargs}}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -11117,7 +11117,10 @@
       {\def\abx@field@prenote{##1}}%
     \ifblank{##2}
       {\let\blx@thenotecheck\relax}
-      {\def\abx@field@postnote{##2}}%
+      {\def\abx@field@postnote{##2}%
+       \iftoggle{blx@volcite}
+         {\blx@defvolcitepostnote##2}
+         {}}%
     \def\blx@precode{\delimcontext{#1}#2}%
     \def\blx@loopcode{#3}%
     \def\blx@dlimcode{#4}%
@@ -11929,6 +11932,12 @@
   \@ifnextchar[%]
     {\blx@volciteargs@i{#1}}
     {\blx@volciteargs@i{#1}[]}}
+
+\long\def\blx@defvolcitepostnote#1#2{%
+  \def\abx@field@volcitevolume{#1}%
+  \ifblank{#2}
+    {}
+    {\def\abx@field@volcitepages{#2}}}
 
 %% Control file
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -11903,7 +11903,7 @@
 \newrobustcmd*{\volcitecmd}{%
   \AtNextCite{%
     \toggletrue{blx@volcite}%
-    \DeclareFieldAlias{postnote}{volcitenote}}%
+    \csuse{blx@hook@volcite}}%
   \begingroup\let\blx@citeargs\blx@volciteargs}
 
 \protected\def\blx@volciteargs#1{%
@@ -11923,7 +11923,7 @@
 \newrobustcmd*{\multivolcitecmd}{%
   \AtNextCite{%
     \toggletrue{blx@volcite}%
-    \DeclareFieldAlias{postnote}{volcitenote}}%
+    \csuse{blx@hook@volcite}}%
   \def\blx@hook@mcite@before{%
     \global\undef\blx@hook@mcite@before
     \let\blx@citeargs\blx@volmciteargs}}
@@ -11938,6 +11938,18 @@
   \ifblank{#2}
     {}
     {\def\abx@field@volcitepages{#2}}}
+
+\newrobustcmd*{\AtVolcite}{%
+  \@ifstar
+    {\global\undef\blx@hook@volcite
+     \gappto\blx@hook@volcite}
+    {\gappto\blx@hook@volcite}}
+\@onlypreamble\AtVolcite
+\def\blx@imc@UseVolciteHook{\csuse{blx@hook@volcite}}
+\blx@regimcs{\UseVolciteHook}
+
+\AtVolcite{%
+  \DeclareFieldAlias{postnote}{volcitenote}}
 
 %% Control file
 

--- a/tex/latex/biblatex/cbx/authortitle-comp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-comp.cbx
@@ -70,8 +70,8 @@
   \ifnameundef{labelname}
     {\setunit{%
        \global\booltrue{cbx:parens}%
-       \extpostnotedelim\bibopenparen}}
-    {\setunit{\postnotedelim}}%
+       \printdelim{extpostnotedelim}\bibopenparen}}
+    {\setunit{\printdelim{postnotedelim}}}%
   \printfield{postnote}%
   \ifthenelse{\value{multicitecount}=\value{multicitetotal}}
     {\setunit{}%

--- a/tex/latex/biblatex/cbx/authortitle-ibid.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-ibid.cbx
@@ -72,8 +72,8 @@
        {\bibcloseparen}
        {}}
     {\ifbool{cbx:parens}
-       {\postnotedelim}
-       {\extpostnotedelim\bibopenparen}%
+       {\printdelim{postnotedelim}}
+       {\printdelim{extpostnotedelim}\bibopenparen}%
      \printfield{postnote}\bibcloseparen}}
 
 \DeclareCiteCommand{\cite}

--- a/tex/latex/biblatex/cbx/authortitle-icomp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-icomp.cbx
@@ -90,7 +90,7 @@
 \newbibmacro*{cite:postnote}{%
   \ifbool{cbx:loccit}
     {}
-    {\setunit{\postnotedelim}%
+    {\setunit{\printdelim{postnotedelim}}%
      \printfield{postnote}}}
 
 \newbibmacro*{textcite:postnote}{%
@@ -99,8 +99,8 @@
     {\ifnameundef{labelname}
        {\setunit{%
           \global\booltrue{cbx:parens}%
-          \extpostnotedelim\bibopenparen}}
-       {\setunit{\postnotedelim}}%
+          \printdelim{extpostnotedelim}\bibopenparen}}
+       {\setunit{\printdelim{postnotedelim}}}%
      \printfield{postnote}}%
   \ifthenelse{\value{multicitecount}=\value{multicitetotal}}
     {\setunit{}%

--- a/tex/latex/biblatex/cbx/authortitle-tcomp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-tcomp.cbx
@@ -70,10 +70,10 @@
 
 \renewbibmacro*{textcite:postnote}{%
   \ifbool{cbx:parens}
-    {\setunit{\postnotedelim}}
+    {\setunit{\printdelim{postnotedelim}}}
     {\setunit{%
        \global\booltrue{cbx:parens}%
-       \extpostnotedelim\bibopenparen}}%
+       \printdelim{extpostnotedelim}\bibopenparen}}%
   \printfield{postnote}%
   \ifthenelse{\value{multicitecount}=\value{multicitetotal}}
     {\setunit{}%

--- a/tex/latex/biblatex/cbx/authortitle-ticomp.cbx
+++ b/tex/latex/biblatex/cbx/authortitle-ticomp.cbx
@@ -80,10 +80,10 @@
 
 \renewbibmacro*{textcite:postnote}{%
   \ifbool{cbx:parens}
-    {\setunit{\postnotedelim}}
+    {\setunit{\printdelim{postnotedelim}}}
     {\setunit{%
        \global\booltrue{cbx:parens}%
-       \extpostnotedelim\bibopenparen}}%
+       \printdelim{extpostnotedelim}\bibopenparen}}%
   \printfield{postnote}%
   \ifthenelse{\value{multicitecount}=\value{multicitetotal}}
     {\setunit{}%

--- a/tex/latex/biblatex/cbx/authortitle.cbx
+++ b/tex/latex/biblatex/cbx/authortitle.cbx
@@ -44,8 +44,8 @@
        {\bibcloseparen}
        {}}
     {\ifbool{cbx:parens}
-       {\postnotedelim}
-       {\extpostnotedelim\bibopenparen}%
+       {\printdelim{postnotedelim}}
+       {\printdelim{extpostnotedelim}\bibopenparen}%
      \printfield{postnote}\bibcloseparen}}
 
 \DeclareCiteCommand{\cite}

--- a/tex/latex/biblatex/cbx/authoryear-ibid.cbx
+++ b/tex/latex/biblatex/cbx/authoryear-ibid.cbx
@@ -102,8 +102,8 @@
        {\bibcloseparen}
        {}}
     {\ifbool{cbx:parens}
-       {\postnotedelim}
-       {\extpostnotedelim\bibopenparen}%
+       {\printdelim{postnotedelim}}
+       {\printdelim{extpostnotedelim}\bibopenparen}%
      \printfield{postnote}\bibcloseparen}}
 
 \DeclareCiteCommand{\cite}

--- a/tex/latex/biblatex/cbx/authoryear.cbx
+++ b/tex/latex/biblatex/cbx/authoryear.cbx
@@ -70,8 +70,8 @@
        {\bibcloseparen}
        {}}
     {\ifbool{cbx:parens}
-       {\setunit{\postnotedelim}}
-       {\setunit{\extpostnotedelim\bibopenparen}}%
+       {\setunit{\printdelim{postnotedelim}}}
+       {\setunit{\printdelim{extpostnotedelim}\bibopenparen}}%
      \printfield{postnote}\bibcloseparen}}
 
 \DeclareCiteCommand{\cite}

--- a/tex/latex/biblatex/cbx/draft.cbx
+++ b/tex/latex/biblatex/cbx/draft.cbx
@@ -27,7 +27,7 @@
        {\bibcloseparen}
        {}}
     {\ifbool{cbx:parens}
-       {\setunit{\postnotedelim}}
+       {\setunit{\printdelim{postnotedelim}}}
        {\setunit{\addspace\bibopenparen}}%
      \printfield{postnote}\bibcloseparen}}
 

--- a/tex/latex/biblatex/cbx/verbose-ibid.cbx
+++ b/tex/latex/biblatex/cbx/verbose-ibid.cbx
@@ -86,7 +86,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{cite:postnote:ibidpage}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose-inote.cbx
+++ b/tex/latex/biblatex/cbx/verbose-inote.cbx
@@ -87,7 +87,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{cite:postnote:ibidpage}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose-note.cbx
+++ b/tex/latex/biblatex/cbx/verbose-note.cbx
@@ -81,7 +81,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{postnote}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose-trad1.cbx
+++ b/tex/latex/biblatex/cbx/verbose-trad1.cbx
@@ -87,7 +87,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{cite:postnote:ibidpage}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose-trad2.cbx
+++ b/tex/latex/biblatex/cbx/verbose-trad2.cbx
@@ -94,7 +94,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{cite:postnote:ibidpage}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose-trad3.cbx
+++ b/tex/latex/biblatex/cbx/verbose-trad3.cbx
@@ -82,7 +82,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{cite:postnote:ibidpage}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}

--- a/tex/latex/biblatex/cbx/verbose.cbx
+++ b/tex/latex/biblatex/cbx/verbose.cbx
@@ -75,7 +75,7 @@
       {\usebibmacro{cite:postnote:pages}}
       {\usebibmacro{postnote}}}
   \providebibmacro*{cite:postnote:pages}{%
-    \setunit{\postnotedelim}%
+    \setunit{\printdelim{postnotedelim}}%
     \bibstring{thiscite}%
     \setunit{\addspace}%
     \printfield{postnote}}}


### PR DESCRIPTION
See #868 

* Implement
  * `\ifvolcite` test
  * `volcitevolume` and `volcitepages` fields (analogous to the `postnote` field)
  * `\AtVolcite` hook
  * `multi(pre|post)notedelim`
* Make `postnotedelim` and friends context sensitive

Thanks to David Purton (@dcpurton) for his great implementation suggestions.