### PR TITLE
Extend style options to more scopes (#875)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -27,6 +27,11 @@
   `loccittracker`, `opcittracker`, `singletitle`, `skipbib`, `skipbiblist`,
   `skipbiblab` `terseinits`, `uniquelist`, `uniquename`, `uniquetitle`,
   `uniquebaretitle`, `uniquework`, `uniqueprimaryauthor`).
+- Furthermore, the standard style options `doi`, `eprint`, `isbn`, `url`,
+  `related` are now available also on a per-type and per-entry level.
+  The same holds for `mergedate`, `subentry` and the options of `reading.bbx`.
+  This change has the potential to clash with custom styles that already define
+  the standard options at these scopes.
 - Add `\ifvolcite` test to check if the current citation is in a `\volcite`
   context.
 - Add the special fields `volcitevolume` and `volcitepages` for finer control

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -2510,7 +2510,7 @@ As \opt{mincrossrefs} but for \bibfield{xref} fields.
 \paragraph{Style-specific}
 \label{use:opt:pre:bbx}
 
-The following options are provided by all standard bibliography styles (as opposed to the core package). Technically, they are preamble options like those in \secref{use:opt:pre:gen}.
+The following options are provided by all standard bibliography styles (as opposed to the core package). The options are available as preamble options like those in \secref{use:opt:pre:gen} and at a per-type and per-entry scope.
 
 \begin{optionlist}
 
@@ -2536,7 +2536,7 @@ Whether to use information from related entries or not. See \secref{use:rel}.
 
 \end{optionlist}
 
-\subparagraph{\texttt{alphabetic}/\texttt{numeric}} Additionally, styles of the \texttt{alphabetic} and \texttt{numeric} family support the \opt{subentry} option.
+\subparagraph{\texttt{alphabetic}/\texttt{numeric}} Additionally, styles of the \texttt{alphabetic} and \texttt{numeric} family support the \opt{subentry} option in global, per-type and per-entry scope.
 
 \begin{optionlist}
 
@@ -2548,7 +2548,7 @@ Suppose \texttt{key1} and \texttt{key2} are members of the set \texttt{set1}. Wi
 
 \end{optionlist}
 
-\subparagraph{\texttt{authortitle}/\texttt{authoryear}} All bibliography styles of the \texttt{authoryear} and \texttt{authortitle} family as well as all bibliography styles of the \texttt{verbose} family---whose bibliography styles are based on \texttt{authortitle}---support the option \opt{dashed}.
+\subparagraph{\texttt{authortitle}/\texttt{authoryear}} All bibliography styles of the \texttt{authoryear} and \texttt{authortitle} family as well as all bibliography styles of the \texttt{verbose} family---whose bibliography styles are based on \texttt{authortitle}---support the option \opt{dashed} in global scope.
 
 \begin{optionlist}
 
@@ -2558,7 +2558,7 @@ This option controls whether recurrent the same author\slash editor list in the 
 
 \end{optionlist}
 
-\subparagraph{\texttt{authoryear}} Bibliography styles of the \texttt{authoryear} family provide the option \opt{mergedate}
+\subparagraph{\texttt{authoryear}} Bibliography styles of the \texttt{authoryear} family provide the option \opt{mergedate} in global, per-type and per-entry scope.
 
 \begin{optionlist}
 
@@ -2578,7 +2578,7 @@ This option controls whether and how the date specification in the entry is merg
 More in-depth examples of this option can be found in the style examples.
 \end{optionlist}
 
-\subparagraph{<ibid> styles} Citation styles with <ibid.> function, namely \texttt{authortitle-ibid}, \texttt{author\allowbreakhere title-icomp}, \texttt{author\allowbreakhere year-ibid}, \texttt{authoryear-icomp}, \texttt{ver\allowbreakhere bose-ibid}, \texttt{verbose-inote}, \texttt{verbose-trad1}, \texttt{verbose-trad2} and \texttt{verbose-trad3} provide the \opt{ibidpage} option.
+\subparagraph{<ibid> styles} Citation styles with <ibid.> function, namely \texttt{authortitle-ibid}, \texttt{author\allowbreakhere title-icomp}, \texttt{author\allowbreakhere year-ibid}, \texttt{authoryear-icomp}, \texttt{ver\allowbreakhere bose-ibid}, \texttt{verbose-inote}, \texttt{verbose-trad1}, \texttt{verbose-trad2} and \texttt{verbose-trad3} provide the global \opt{ibidpage} option.
 
 \begin{optionlist}
 
@@ -2588,7 +2588,7 @@ Whether \emph{ibidem} without page reference means <same work> or <same work + s
 
 \end{optionlist}
 
-\subparagraph{\texttt{verbose}} All citation styles of the \texttt{verbose} family provide the option \opt{citepages}.
+\subparagraph{\texttt{verbose}} All citation styles of the \texttt{verbose} family provide the global option \opt{citepages}.
 
 \begin{optionlist}
 
@@ -2611,7 +2611,7 @@ Here <p.\,125> is the \bibfield{postnote} argument and <pp.\,100--150> is the va
 
 \end{optionlist}
 
-\subparagraph{\texttt{verbose-trad}} The citation styles of the \texttt{verbose-trad} family support the option \opt{strict}.
+\subparagraph{\texttt{verbose-trad}} The citation styles of the \texttt{verbose-trad} family support the global option \opt{strict}.
 
 \begin{optionlist}
 
@@ -13827,15 +13827,15 @@ dateerauto                        &\+&\+&\_&\_&\_&\_&\_\\
 dateuncertain                     &\+&\+&\_&\_&\_&\_&\_\\
 datezeros                         &\+&\+&\_&\_&\_&\_&\_\\
 defernumbers                      &\+&\+&\_&\_&\_&\_&\_\\
-doi                               &\+&\+&\_&\_&\_&\_&\_\\ % style
-eprint                            &\+&\+&\_&\_&\_&\_&\_\\ % style
+doi                               &\+&\+&\_&\+&\+&\_&\_\\ % style
+eprint                            &\+&\+&\_&\+&\+&\_&\_\\ % style
 $<$namepart$>$inits               &\+&\+&\_&\+&\+&\+&\+\\
 gregorianstart                    &\+&\+&\_&\_&\_&\_&\_\\
 hyperref                          &\+&\+&\_&\_&\_&\_&\_\\
 ibidtracker                       &\+&\+&\_&\+&\+&\_&\_\\
 idemtracker                       &\+&\+&\_&\+&\+&\_&\_\\
 indexing                          &\+&\+&\_&\+&\+&\_&\_\\
-isbn                              &\+&\+&\_&\_&\_&\_&\_\\ % style
+isbn                              &\+&\+&\_&\+&\+&\_&\_\\ % style
 julian                            &\+&\+&\_&\_&\_&\_&\_\\
 labelalpha                        &\+&\+&\_&\+&\+&\_&\_\\
 labelalphanametemplatename        &\_&\_&\+&\_&\+&\+&\+\\
@@ -13882,6 +13882,7 @@ parentracker                      &\+&\+&\_&\_&\_&\_&\_\\
 punctfont                         &\+&\+&\_&\_&\_&\_&\_\\
 refsection                        &\+&\+&\_&\_&\_&\_&\_\\
 refsegment                        &\+&\+&\_&\_&\_&\_&\_\\
+related                           &\+&\+&\_&\+&\+&\_&\_\\ % style
 safeinputenc                      &\+&\+&\_&\_&\_&\_&\_\\
 seconds                           &\+&\+&\_&\_&\_&\_&\_\\
 singletitle                       &\+&\+&\_&\+&\+&\_&\_\\
@@ -13907,7 +13908,7 @@ uniquetitle                       &\+&\+&\_&\+&\+&\_&\_\\
 uniquebaretitle                   &\+&\+&\_&\+&\+&\_&\_\\
 uniquework                        &\+&\+&\_&\+&\+&\_&\_\\
 uniqueprimaryauthor               &\+&\+&\_&\+&\+&\_&\_\\
-url                               &\+&\+&\_&\_&\_&\_&\_\\
+url                               &\+&\+&\_&\+&\+&\_&\_\\ % style
 useprefix                         &\+&\+&\_&\+&\+&\+&\+\\
 use$<$name$>$                     &\+&\+&\_&\+&\+&\_&\_\\
 \end{longtable}

--- a/tex/latex/biblatex/bbx/alphabetic.bbx
+++ b/tex/latex/biblatex/bbx/alphabetic.bbx
@@ -6,7 +6,7 @@
 
 \providebool{bbx:subentry}
 
-\DeclareBibliographyOption[boolean]{subentry}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{subentry}[true]{%
   \setbool{bbx:subentry}{#1}}
 
 \DeclareNameAlias{author}{default}

--- a/tex/latex/biblatex/bbx/authoryear.bbx
+++ b/tex/latex/biblatex/bbx/authoryear.bbx
@@ -9,7 +9,7 @@
      \renewbibmacro*{bbx:savehash}{\savefield{fullhash}{\bbx@lasthash}}}
     {\renewbibmacro*{bbx:savehash}{}}}
 
-\DeclareBibliographyOption[boolean]{mergedate}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{mergedate}[true]{%
   \ifcsdef{bbx@opt@mergedate@#1}
     {\csuse{bbx@opt@mergedate@#1}}
     {\PackageError{biblatex}

--- a/tex/latex/biblatex/bbx/numeric.bbx
+++ b/tex/latex/biblatex/bbx/numeric.bbx
@@ -6,7 +6,7 @@
 
 \providebool{bbx:subentry}
 
-\DeclareBibliographyOption[boolean]{subentry}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{subentry}[true]{%
   \setbool{bbx:subentry}{#1}}
 
 \DeclareNameAlias{author}{default}

--- a/tex/latex/biblatex/bbx/reading.bbx
+++ b/tex/latex/biblatex/bbx/reading.bbx
@@ -102,21 +102,21 @@
 \newbool{bbx:library}
 \newbool{bbx:file}
 
-\DeclareBibliographyOption[boolean]{entryhead}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{entryhead}[true]{%
   \ifcsdef{bbx@item@#1}
     {\letcs\bbx@item{bbx@item@#1}}
     {\PackageError{biblatex}
        {Invalid option 'header=#1'}
        {Valid values: header=true, false, full, name.}}}
-\DeclareBibliographyOption[boolean]{entrykey}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{entrykey}[true]{%
   \setbool{bbx:entrykey}{#1}}
-\DeclareBibliographyOption[boolean]{annotation}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{annotation}[true]{%
   \setbool{bbx:annotation}{#1}}
-\DeclareBibliographyOption[boolean]{abstract}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{abstract}[true]{%
   \setbool{bbx:abstract}{#1}}
-\DeclareBibliographyOption[boolean]{library}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{library}[true]{%
   \setbool{bbx:library}{#1}}
-\DeclareBibliographyOption[boolean]{file}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{file}[true]{%
   \setbool{bbx:file}{#1}}
 
 \ExecuteBibliographyOptions{loadfiles,entryhead,entrykey,annotation,abstract,library,file}

--- a/tex/latex/biblatex/bbx/standard.bbx
+++ b/tex/latex/biblatex/bbx/standard.bbx
@@ -7,15 +7,15 @@
 \newtoggle{bbx:eprint}
 \newtoggle{bbx:related}
 
-\DeclareBibliographyOption[boolean]{isbn}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{isbn}[true]{%
   \settoggle{bbx:isbn}{#1}}
-\DeclareBibliographyOption[boolean]{url}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{url}[true]{%
   \settoggle{bbx:url}{#1}}
-\DeclareBibliographyOption[boolean]{doi}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{doi}[true]{%
   \settoggle{bbx:doi}{#1}}
-\DeclareBibliographyOption[boolean]{eprint}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{eprint}[true]{%
   \settoggle{bbx:eprint}{#1}}
-\DeclareBibliographyOption[boolean]{related}[true]{%
+\DeclareBiblatexOption{global,type,entry}[boolean]{related}[true]{%
   \settoggle{bbx:related}{#1}}
 
 \ExecuteBibliographyOptions{isbn,url,doi,eprint,related}


### PR DESCRIPTION
For now only `dashed` and the citation style options `citepages`,
`ibidpage`, `strict`, `pageref` stay global-only as they rely on
tracking features where it is not entirely clear what the expected
outcome would be if they were controlled on a per-entry basis.

If there are custom styles out there that define those standard option at per-type or per-entry scopes already, this change will cause a clash and an error message. A short search suggests that there are no problematic styles on CTAN, but I haven't tested everything extensively.

See #875.