### PR TITLE
Ensure \write to .aux file happens in all circumstances (#242)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -8373,17 +8373,23 @@
 % {<entrykey>}
 % Get the saved information on which citations were mentioned last run
 \protected\def\abx@aux@cite#1{%
-  \listxadd\blx@lastcites{\detokenize{#1}}}
+  \xifinlist{\detokenize{#1}}\blx@lastcites
+    {}
+    {\listxadd\blx@lastcites{\detokenize{#1}}}}
 
 % {<refcontext>}
 % Get the saved information on which refcontexts were mentioned last run
 \protected\def\abx@aux@refcontext#1{%
-  \listxadd\blx@lastrefcontexts{\detokenize{#1}}}
+  \xifinlist{\detokenize{#1}}\blx@lastrefcontexts
+    {}
+    {\listxadd\blx@lastrefcontexts{\detokenize{#1}}}}
 
 % {<sortingtemplatename>}
 % Get the saved information on which shorthand sorting templates were mentioned last run
 \protected\def\abx@aux@biblist#1{%
-  \listgadd\blx@lastbiblists{#1}}
+  \ifinlist{#1}\blx@lastbiblists
+    {}
+    {\listgadd\blx@lastbiblists{#1}}}
 
 % Here we mustn't change the checksum if we used localnumbers from the
 % .aux file as this means that deferred numbering is
@@ -9468,8 +9474,8 @@
   % so we can compare on next run
   \xifinlist\blx@tempc\blx@biblists
     {}
-    {\listxadd\blx@biblists\blx@tempc
-     \blx@auxwrite\@mainaux{}{\string\abx@aux@biblist{\blx@tempc}}}%
+    {\listxadd\blx@biblists\blx@tempc}%
+  \blx@auxwrite\@mainaux{}{\string\abx@aux@biblist{\blx@tempc}}%
   \setkeys{blx@biblist1}{#1}% Set section only, if present ...
   \blx@rest@actives
   \ifcsvoid{blx@dlist@list@\blx@tempe @\blx@refcontext@context}
@@ -9615,8 +9621,8 @@
      % Add the refcontext to the list of refcontexts so we can compare on next run
      \xifinlist\blx@refcontext@context\blx@refcontexts
        {}
-       {\listxadd\blx@refcontexts\blx@refcontext@context
-        \blx@auxwrite\@mainaux{}{\string\abx@aux@refcontext{\blx@refcontext@context}}}%
+       {\listxadd\blx@refcontexts\blx@refcontext@context}%
+     \blx@auxwrite\@mainaux{}{\string\abx@aux@refcontext{\blx@refcontext@context}}%
      \ifcsundef{blx@sortingtemplate@\blx@refcontext@sortingtemplatename}
        {\blx@err@invopt{sorting=\blx@refcontext@sortingtemplatename}{}}
        {}%
@@ -10228,12 +10234,14 @@
   \blx@bibreq{#1}%
   \ifinlist{#1}\blx@cites
     {}
-    {\listgadd{\blx@cites}{#1}%
-     \blx@auxwrite\@mainaux{}{\string\abx@aux@cite{#1}}}%
+    {\listgadd{\blx@cites}{#1}}%
+  \blx@auxwrite\@mainaux{}{\string\abx@aux@cite{#1}}%
   \ifinlistcs{#1}{blx@segm@\the\c@refsection @\the\c@refsegment}
     {}
     {\listcsgadd{blx@segm@\the\c@refsection @\the\c@refsegment}{#1}}%
-  \blx@auxwrite\@mainaux{}{\string\abx@aux@segm{\the\c@refsection}{\the\c@refsegment}{\detokenize{#1}}}%
+  \blx@auxwrite\@mainaux{}{\string\abx@aux@segm{\the\c@refsection}%
+                                               {\the\c@refsegment}%
+                                               {\detokenize{#1}}}%
   \blx@ifdata{#1}
     {}
     {\ifcsdef{blx@miss@\the\c@refsection}
@@ -10243,7 +10251,9 @@
        {\blx@logreq@active{#2{#1}}}}}
 
 \protected\def\abx@aux@segm#1#2#3{%
-  \listcsxadd{blx@segm@#1@#2}{\detokenize{#3}}}
+  \xifinlistcs{\detokenize{#3}}{blx@segm@#1@#2}
+    {}
+    {\listcsxadd{blx@segm@#1@#2}{\detokenize{#3}}}}
 
 \def\blx@nocitation@all{%
   \ifinlist{*}\blx@nocites


### PR DESCRIPTION
Move the `.aux` `\writes` out of the `\ifinlist` checks to avoid
nasty side effects of several runs of the same code with different
`\@filesw` values to avoid `.aux` writes on the first run.

That implies a change in behaviour:
Those writes now happen for all events that trigger them not only for the first event for a particular entry as before. This is no issue for standard `biblatex` since the use of macros written to the `.aux` is guarded against multiple calls and does not have issues with that. But it could affect code that patches into these (highly internal) macros to do something else. (I'm not aware of any package or style doing this at the moment.)

For #242