### PR TITLE
Add `doi` field for `@online` type

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -527,7 +527,7 @@ A fallback type for entries which do not fit into any other category. Use the fi
 
 An online resource. \bibfield{author}, \bibfield{editor}, and \bibfield{year} are omissible in terms of \secref{bib:use:key}. This entry type is intended for sources such as web sites which are intrinsically online resources. Note that all entry types support the \bibfield{url} field. For example, when adding an article from an online journal, it may be preferable to use the \bibtype{article} type and its \bibfield{url} field.
 
-\reqitem{author/editor, title, year/date, eprint/url}
+\reqitem{author/editor, title, year/date, doi/eprint/url}
 \optitem{subtitle, titleaddon, language, version, note, organization, month, addendum, pubstate, eprintclass, eprinttype, urldate}
 
 \typeitem{patent}

--- a/tex/latex/biblatex/bbx/standard.bbx
+++ b/tex/latex/biblatex/bbx/standard.bbx
@@ -446,6 +446,10 @@
   \newunit\newblock
   \usebibmacro{date}%
   \newunit\newblock
+  \iftoggle{bbx:doi}
+    {\printfield{doi}}
+    {}%
+  \newunit\newblock
   \iftoggle{bbx:eprint}
     {\usebibmacro{eprint}}
     {}%

--- a/tex/latex/biblatex/blx-dm.def
+++ b/tex/latex/biblatex/blx-dm.def
@@ -1087,6 +1087,7 @@
 \DeclareDatamodelEntryfields[online]{
   addendum,
   author,
+  doi,
   editor,
   editortype,
   eprint,
@@ -1472,6 +1473,7 @@
     \constraintfield{title}
     \constraintfieldsor{
       \constraintfield{url}
+      \constraintfield{doi}
       \constraintfield{eprint}
     }
   }


### PR DESCRIPTION
It seems useful to have a `doi` also for `@online` entries. Especially since the already support the more general `eprint`.

See c53c1f5b29b14e6a5c9d005ddebcdcf5b8b52270, 4c18e0fce96c76f27c21ef898ea918c500faf9af, b66a1d53a825c6631bcbb17475a252b071b84b99.