### PR TITLE
Add \mkbibcompletename formatting wrapper (#853)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -37,6 +37,11 @@
 - Add the special fields `volcitevolume` and `volcitepages` for finer control
   over the `\volcite` postnote.
 - Add `\AtVolcite` hook to initialise `\volcite` commands.
+- Add `\mkbibcompletename` as well as `\mkbibcompletename<formatorder>`
+  to format complete names.
+  The commands are analogous to `\mkbibname<namepart>` but apply to
+  the entire name printed in format order `<formatorder>`.
+  By default the predefined macros all expand to `\mkbibcompletename`.
 - Add `multiprenotedelim` and `multipostnotedelim` and make all
  `(pre|post)notedelim`-like commands context sensitive.
 - Add rudimentary support for `labelprefix` with BibTeX backend.

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -5009,6 +5009,18 @@ For backwards compatibility with the legacy \bibtex name parts, the following ar
 \mkbibnameaffix
 \end{ltxexample}
 
+\csitem{mkbibcompletenamefamily}{text}
+This command, which takes one argument, is used to format the complete name in \texttt{family} format order.
+
+\csitem{mkbibcompletenamefamilygiven}{text}
+This command, which takes one argument, is used to format the complete name in \texttt{family-given} format order.
+
+\csitem{mkbibcompletenamegivenfamily}{text}
+This command, which takes one argument, is used to format the complete name in \texttt{given-family} format order.
+
+\cmditem{mkbibcompletename}{text}
+The initial value of all default formatting hooks \cmd{mkbibcompletename<formatorder>}.
+
 \csitem{datecircadelim}\CSdelimMark
 When formatting dates with the global option \opt{datecirca} enabled, the delimiter printed after any localised <circa> term. Defaults to interword space.
 
@@ -11926,17 +11938,29 @@ The delimiter to be printed after the \prm{multiprenote} argument of a citation 
 \csitem{multipostnotedelim}\CSdelimMark
 The delimiter to be printed before the \prm{multipostnote} argument of a citation command.
 
-\cmditem{mkbibnamefamily}{text}
-Formatting hook for the family name, to be used in all formatting directives for name lists.
+\cmditem{mkbibname<namepart>}{text}
+Formatting hook for the name part <namepart>, to be used in all formatting directives for name lists. The default datamodel defines the name parts <family>, <given>, <prefix> and <suffix> and therefore the following macros are automatically defined:
 
-\cmditem{mkbibnamegiven}{text}
-Similar to \cmd{mkbibnamefamily}, but intended for the given name.
+\begin{ltxexample}
+\mkbibnamefamily
+\mkbibnamegiven
+\mkbibnameprefix
+\mkbibnamesuffix
+\end{ltxexample}
 
-\cmditem{mkbibnameprefix}{text}
-Similar to \cmd{mkbibnamefamily}, but intended for the name prefix.
+\cmditem{mkbibcompletename<formatorder>}{text}
+Formatting hook for the complete name in format order <formatorder>. The default styles use the name format orders <family>, <family-given> and <given-family>, therefore the following macros are automatically defined:
 
-\cmditem{mkbibnamesuffix}{text}
-Similar to \cmd{mkbibnamefamily}, but intended for the name suffix.
+\begin{ltxexample}
+\mkbibcompletenamefamily
+\mkbibcompletenamefamilygiven
+\mkbibcompletenamegivenfamily
+\end{ltxexample}
+%
+These formatting hooks should enclose the complete name in the bibliography macro \cmd{name:<formatorder>}. Initially all hooks expand to \cmd{mkbibcompletename}.
+
+\cmditem{mkbibcompletename}{text}
+The initial value of all default formatting hooks \cmd{mkbibcompletename<formatorder>}.
 
 \csitem{datecircadelim}\CSdelimMark
 When formatting dates with the global option \opt{datecirca} enabled, the delimiter printed after any localised <circa> term. Defaults to interword space.
@@ -13996,6 +14020,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added special fields \bibfield{volcitevolume} and \bibfield{volcitepages}%
   \see{aut:cbx:fld}
 \item Added \cmd{AtVolcite} hook\see{aut:fmt:hok}
+\item Added \cmd{mkbibcompletename} and \cmd{mkbibcompletename<formatorder>}\see{use:fmt:fmt}
 \item Made \cmd{postnotedelim} and friends context sensitive\see{use:fmt:fmt}
 \item Added \cmd{multipostnotedelim} and \cmd{multiprenotedelim}\see{use:fmt:fmt}
 \item Added \cmd{thefirstlistitem} and friends\see{aut:aux:dat}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -874,7 +874,7 @@
       {\namepartprefix}
       {\namepartsuffix}}%
   \usebibmacro{name:andothers}}
-  
+
 \DeprecateNameFormatWithReplacement{last-first}{family-given}
 
 
@@ -987,64 +987,92 @@
 % Auxiliary macros for name formatting directives
 % ------------------------------------------------------------------
 
+\newcommand{\mkbibcompletename}[1]{#1}
+
+\newcommand{\mkbibcompletenamefamily}{\mkbibcompletename}
+
 \newbibmacro*{name:family}[4]{%
   \ifuseprefix
     {\usebibmacro{name:delim}{#3#1}%
      \usebibmacro{name:hook}{#3#1}%
-     \ifdefvoid{#3}
-       {}
-       {\ifcapital
-          {\mkbibnameprefix{\MakeCapital{#3}}\isdot}
-          {\mkbibnameprefix{#3}\isdot}%
-        \ifprefchar{}{\bibnamedelimc}}}
+     \mkbibcompletenamefamily{%
+       \ifdefvoid{#3}
+         {}
+         {\ifcapital
+            {\mkbibnameprefix{\MakeCapital{#3}}\isdot}
+            {\mkbibnameprefix{#3}\isdot}%
+          \ifprefchar{}{\bibnamedelimc}}%
+       \mkbibnamefamily{#1}\isdot}}
     {\usebibmacro{name:delim}{#1}%
-     \usebibmacro{name:hook}{#1}}%
-  \mkbibnamefamily{#1}\isdot}%
+     \usebibmacro{name:hook}{#1}%
+     \mkbibcompletenamefamily{%
+       \mkbibnamefamily{#1}\isdot}}}%
 \newbibmacro*{name:last}[4]{% legacy alias
   \blx@warning@noline{%
     'name:last' is deprecated, please use 'name:family'}%
   \usebibmacro{name:family}{#1}{#2}{#3}{#4}}
 
+\newcommand{\mkbibcompletenamegivenfamily}{\mkbibcompletename}
+
 \newbibmacro*{name:given-family}[4]{%
   \usebibmacro{name:delim}{#2#3#1}%
   \usebibmacro{name:hook}{#2#3#1}%
-  \ifdefvoid{#2}{}{\mkbibnamegiven{#2}\isdot\bibnamedelimd}%
-  \ifdefvoid{#3}{}{%
-    \mkbibnameprefix{#3}\isdot
-    \ifprefchar
+  \mkbibcompletenamegivenfamily{%
+    \ifdefvoid{#2}
       {}
-      {\ifuseprefix{\bibnamedelimc}{\bibnamedelimd}}}%
-  \mkbibnamefamily{#1}\isdot
-  \ifdefvoid{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}}
+      {\mkbibnamegiven{#2}\isdot\bibnamedelimd}%
+    \ifdefvoid{#3}
+      {}
+      {\mkbibnameprefix{#3}\isdot
+       \ifprefchar
+         {}
+         {\ifuseprefix{\bibnamedelimc}{\bibnamedelimd}}}%
+    \mkbibnamefamily{#1}\isdot
+    \ifdefvoid{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}}}
 \newbibmacro*{name:first-last}[4]{% legacy alias
   \blx@warning@noline{%
     'name:first-last' is deprecated, please use 'name:given-family'}%
   \usebibmacro{name:given-family}{#1}{#2}{#3}{#4}}
 
+\newcommand{\mkbibcompletenamefamilygiven}{\mkbibcompletename}
+
 \newbibmacro*{name:family-given}[4]{%
   \ifuseprefix
     {\usebibmacro{name:delim}{#3#1}%
      \usebibmacro{name:hook}{#3#1}%
-     \ifdefvoid{#3}{}{%
-       \ifcapital
-         {\mkbibnameprefix{\MakeCapital{#3}}\isdot}
-         {\mkbibnameprefix{#3}\isdot}%
-       \ifprefchar{}{\bibnamedelimc}}%
-     \mkbibnamefamily{#1}\isdot
-     \ifdefvoid{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
-     \ifdefvoid{#2}{}{\revsdnamepunct\bibnamedelimd\mkbibnamegiven{#2}\isdot}}
+     \mkbibcompletenamefamilygiven{%
+       \ifdefvoid{#3}
+         {}
+         {\ifcapital
+            {\mkbibnameprefix{\MakeCapital{#3}}\isdot}
+            {\mkbibnameprefix{#3}\isdot}%
+          \ifprefchar{}{\bibnamedelimc}}%
+       \mkbibnamefamily{#1}\isdot
+       \ifdefvoid{#4}
+         {}
+         {\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
+       \ifdefvoid{#2}
+         {}
+         {\revsdnamepunct\bibnamedelimd\mkbibnamegiven{#2}\isdot}}}
     {\usebibmacro{name:delim}{#1}%
      \usebibmacro{name:hook}{#1}%
-     \mkbibnamefamily{#1}\isdot
-     \ifdefvoid{#4}{}{\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
-     \ifboolexpe{%
-       test {\ifdefvoid{#2}}
-       and
-       test {\ifdefvoid{#3}}}
-       {}
-       {\revsdnamepunct}%
-     \ifdefvoid{#2}{}{\bibnamedelimd\mkbibnamegiven{#2}\isdot}%
-     \ifdefvoid{#3}{}{\bibnamedelimd\mkbibnameprefix{#3}\isdot}}}
+     \mkbibcompletenamefamilygiven{%
+       \mkbibnamefamily{#1}\isdot
+       \ifdefvoid{#4}
+         {}
+         {\bibnamedelimd\mkbibnamesuffix{#4}\isdot}%
+       \ifboolexpe{%
+         test {\ifdefvoid{#2}}
+         and
+         test {\ifdefvoid{#3}}}
+         {}
+         {\revsdnamepunct}%
+       \ifdefvoid{#2}
+         {}
+         {\bibnamedelimd\mkbibnamegiven{#2}\isdot}%
+       \ifdefvoid{#3}
+         {}
+         {\bibnamedelimd\mkbibnameprefix{#3}\isdot}}}}
 \newbibmacro*{name:last-first}[4]{% legacy alias
   \blx@warning@noline{%
     'name:last-first' is deprecated, please use 'name:family-given'}%


### PR DESCRIPTION
`\mkbibcompletename` is actually a meta-command.
The name formats use `\mkbibcompletename<formatorder>`.

As mentioned in #853 the arguments of these macros are more complex, so underlining or case changing macros might be a bit tricky here. Most other font operations will be fine, though.