### PR TITLE
Switch \nohyphenation to fake language (#772)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -66,6 +66,12 @@
   and `biburlucskip`. The previously hard-coded (stretacheble) space
   `\biburlbigskip` as well as the penalties `biburlbigbreakpenalty` and
   `biburlbreakpenalty` are also configurable now.
+- `\nohyphenation` and `\textnohyphenation` now rely on a (fake)
+  language without hyphenation patterns instead of `\lefthyphenmin`,
+  which means that the command can now be used anywhere in a paragraph,
+  see also https://texfaq.org/FAQ-hyphoff.
+  Note that switching languages with `babel` *within* those commands
+  removes the hyphenation protection.
 
 
 # RELEASE NOTES FOR VERSION 3.12

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -5390,7 +5390,7 @@ An explicit, non-breakable hyphen intended for compound words. In contrast to a 
 
 \csitem{nohyphenation}
 
-A generic switch which suppresses hyphenation locally. Its scope should normally be confined to a group.
+A generic switch which suppresses hyphenation locally. Its scope should normally be confined to a group. The command uses a language without hyphenation patterns to suppress hyphenation. The idea was taken from Peter Wilson's \sty{hyphenat} package. Note that this command should only be used for small portions of text and that its effects are negated if \sty{babel}/\sty{polyglossia} is used to switch the language while it is active.
 
 \cmditem{textnohyphenation}{text}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -2019,8 +2019,13 @@
 \providerobustcmd*{\allowhyphens}{%
   \nobreak\hskip\z@skip}
 
+% Idea from Peter Wilson's hyphenat package
+% https://ctan.org/pkg/hyphenat
+% also https://texfaq.org/FAQ-hyphoff
+\newlanguage\blx@langwohyphens
+
 \providerobustcmd*{\nohyphenation}{%
-  \lefthyphenmin\@m}
+  \language\blx@langwohyphens}
 
 \providerobustcmd*{\textnohyphenation}[1]{%
   \bgroup\nohyphenation#1\egroup}


### PR DESCRIPTION
The solution with `\lefthyphenmin` would only work paragraph-initially (it seems even more complicated than that: https://tex.stackexchange.com/q/323930/35864).

The solution from Peter Wilson's [`hyphenat` package](https://ctan.org/pkg/hyphenat)/https://texfaq.org/FAQ-hyphoff works with a fake language without hyphenation patterns.
The position within the paragraph is not relevant any more, but one shouldn't try to switch languages within `\nohyphenation` now and should probably only use it for short passages of text.
But that seems fair given the only use case is preventing hyphenation in author names (`\def\mkbibnamefamily#1{\textsc{\textnohyphenation{#1}}}` in `french.lbx`).

#772