### PR TITLE
Enhance polyglossia support (#460)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -2,6 +2,11 @@
 - biber from version 2.14 has extended, granular XDATA functionality to
   allow referencing from and to parts of fields. This makes XDATA entries into
   more general data sharing containers.
+- `biblatex` now interfaces with `polyglossia` much better and can deal
+  with language variants.
+  Note that `polyglossia` v1.45 (2019/10/27) is required for this
+  to work properly, it is strongly recommended to update `polyglossia`
+  to this or a later (current) version.
 # RELEASE NOTES FOR VERSION 3.13
 - **INCOMPATIBLE CHANGE** Any custom per-entry options in datasources must
   be defined with `\DeclareEntryOption` in order for biber to recognise

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -183,7 +183,7 @@ This package provides advanced bibliographic facilities for use with \latex. The
 
 \subsection{License}
 
-Copyright \textcopyright\ 2006--2012 Philipp Lehman, 2012--2017 Philip Kime, Audrey Boruvka, Joseph Wright, 2018- Philip Kime and Moritz Wemheuer. Permission is granted to copy, distribute and\slash or modify this software under  the terms of the \lppl, version 1.3.\fnurl{http://www.latex-project.org/lppl.txt}
+Copyright \textcopyright\ 2006--2012 Philipp Lehman, 2012--2017 Philip Kime, Audrey Boruvka, Joseph Wright, 2018-- Philip Kime and Moritz Wemheuer. Permission is granted to copy, distribute and\slash or modify this software under  the terms of the \lppl, version~1.3.\fnurl{http://www.latex-project.org/lppl.txt}
 
 \subsection{Feedback}
 \label{int:feb}
@@ -263,14 +263,14 @@ Apart from the above resources, \biblatex also requires the standard \latex pack
 \subsubsection{Recommended Packages}
 \label{int:pre:rec}
 
-The packages listed in this section are not required for \biblatex to function, but they provide recommended additional functions or enhance existing features. The package loading order does not matter.
+The packages listed in this section are not required for \biblatex to function, but they provide recommended additional functions or enhance existing features. The package loading order usually does not matter.
 
 \begin{marglist}
 
 \item[babel/polyglossia]
-The \sty{babel} and \sty{polyglossia} packages provides the core architecture for multilingual typesetting. If you are writing in a language other than American English, using one of these packages is strongly recommended. You should load \sty{babel} or \sty{polyglossia} before \biblatex and then \biblatex will detect \sty{babel} or \sty{polyglossia} automatically.
+The \sty{babel} and \sty{polyglossia} packages provides the core architecture for multilingual typesetting. If you are writing in a language other than American English, using one of these packages is strongly recommended. You should load \sty{babel} or \sty{polyglossia} before \biblatex and then \biblatex will detect \sty{babel} or \sty{polyglossia} automatically. (While \sty{babel} may be loaded after \biblatex if so desired, \sty{polyglossia} must always be loaded before \biblatex.)
 
-Please note that \biblatex can only detect the language (\eg \texttt{english}, \texttt{german}), but not the language variant (\eg \texttt{british}, \texttt{austrian}) and other properties (\eg \texttt{spelling=new} for \texttt{german}) when used with \sty{polyglossia}. To remind you of these shortcomings \biblatex will issue a warning message when it is loaded together with \sty{polyglossia}, the warning message tells you how to silence it should you want to do so.
+\biblatex has only limited support for \sty{polyglossia} versions prior to~v1.45. If \sty{polyglossia} is used, it should be updated to version~1.45 (2019/10/27) or above.
 
 \item[csquotes]
 If this package is available, \biblatex will use its language sensitive quotation facilities to enclose certain titles in quotation marks. If not, \biblatex uses quotes suitable for American English as a fallback. When writing in a language other than American English, loading \sty{csquotes} is strongly recommended.\fnurl{http://ctan.org/pkg/csquotes/}
@@ -2139,7 +2139,7 @@ This option controls whether the citation commands scan ahead for punctuation ma
 
 \optitem[autobib]{language}{\opt{autobib}, \opt{autocite}, \opt{auto}, \prm{language}}
 
-This option controls multilingual support. By default \biblatex automatically picks up the active surrounding language from the \sty{babel}/\sty{polyglossia} package\footnote{Note that \biblatex can only detect the base language (\eg \texttt{english}), but not the language variant (\eg \texttt{british}) or other properties (\eg \texttt{spelling=new} for \texttt{german}) from \sty{polyglossia}. That means that the \biblatex localisation of the base language is used for all variants, even for variants whose <\sty{babel} equivalent> has a localisation of its own. To remind you of these shortcomings a warning will be issued if \biblatex is used with \sty{polyglossia}, the warning explains how it can be disabled.} (and fall back to English if \sty{babel}/\sty{polyglossia} is not available). \opt{autobib} switches the language for each entry in the bibliography using the \bibfield{langid} field and the language environment specified by the \opt{autolang} option. \opt{autocite} switches the language for each citation using the \bibfield{langid} field and the language environment specified by the \opt{autolang} option. \opt{auto} is a shorthand to set both \opt{autobib} and \opt{autocite}. It is also possible to select the package language manually. In this case, the language chosen will override the \bibfield{langid} of entries and you should still choose a language switching environment with the \opt{autolang} option to select how the switch to the manually chosen language is handled. Please refer to \tabref{bib:fld:tab1} for a list of supported languages and the corresponding identifiers.
+This option controls multilingual support. By default \biblatex automatically picks up the active surrounding language from the \sty{babel}/\sty{polyglossia} package\footnote{Note that \biblatex has only limited support for \sty{polyglossia} versions prior to v1.45. If \sty{polyglossia} is used, it should be updated to version~1.45 (2019/10/27) or above.} (and fall back to English if \sty{babel}/\sty{polyglossia} is not available). \opt{autobib} switches the language for each entry in the bibliography using the \bibfield{langid} field and the language environment specified by the \opt{autolang} option. \opt{autocite} switches the language for each citation using the \bibfield{langid} field and the language environment specified by the \opt{autolang} option. \opt{auto} is a shorthand to set both \opt{autobib} and \opt{autocite}. It is also possible to select the package language manually. In this case, the language chosen will override the \bibfield{langid} of entries and you should still choose a language switching environment with the \opt{autolang} option to select how the switch to the manually chosen language is handled. Please refer to \tabref{bib:fld:tab1} for a list of supported languages and the corresponding identifiers.
 
 \boolitem[true]{clearlang}
 
@@ -14140,6 +14140,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{release}{3.14}{2019}
 \item Added new mapping verbs for citation sources\see{aut:ctm:map}
 \item Added documentation for new \biber granular \bibtype{xdata} functionality\see{use:use:xdat}
+\item Enhanced \sty{polyglossia} support
 \end{release}
 \begin{release}{3.13a}{2019-08-31}
 \item Bugfix release

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -52,21 +52,6 @@
       This is a fatal error. I'm aborting now}%
    \endinput}
 
-% polyglossia pretends to be babel, so we need to make sure
-% we are definitely talking to babel here.
-\AtEndPreamble{%
-  \@ifpackageloaded{polyglossia}
-    {}
-    {\@ifpackageloaded{babel}
-       {\@ifpackagelater{babel}{2016/04/23}
-          {}
-          {\PackageError{biblatex}
-             {Outdated 'babel' package}
-             {Upgrade to babel 3.9r (2016/04/23) or later.\MessageBreak
-              I found: '\csuse{ver@babel.sty}'.\MessageBreak
-              This is a fatal error. I'm aborting now}%
-            \endinput}}
-       {}}}
 
 %% Category codes
 
@@ -117,6 +102,9 @@
     \endgroup}}
 
 %% Compatibility
+% this hook is executed once at the beginning of loading the package
+% just a few lines down
+% and again later in an \AtEndPreamble hook
 \def\blx@packageincompatibility{%
   \def\do##1{%
     \@ifpackageloaded{##1}
@@ -166,8 +154,15 @@
 % still gives a weird error.
 \blx@packageincompatibility
 
-% people should not be abusing noerroretextools, so warn if it is not needed
+% this part is only executed now
+\@ifpackageloaded{polyglossia}
+  {\global\cslet{blx@pkgloaded@polyglossia}\@empty}
+  {}
+
+% this part is deferred to \AtEndPreamble
 \def\blx@packageincompatibility@endpreambleonly{%
+  % people should not be abusing noerroretextools,
+  % so warn if it is not needed
   \ifcsdef{blx@noerroretextools}
     {\@ifpackageloaded{etextools}
        {}
@@ -176,7 +171,34 @@
           but 'etextools' is not loaded.\MessageBreak
           Please do not define '\string\blx@noerroretextools'\MessageBreak
           unless you really need it}}}
-    {}}
+    {}%
+  % polyglossia pretends to be babel, so the nested structure helps
+  % to make sure that babel really is babel
+  \@ifpackageloaded{polyglossia}
+    {\ifcsundef{blx@pkgloaded@polyglossia}
+       {\blx@error
+         {'polyglossia' loaded after biblatex}
+         {'polyglossia' must be loaded before biblatex}}
+       {}%
+     \@ifpackagelater{polyglossia}{2019/10/27}
+       {}
+       {\blx@warning@noline
+          {biblatex works best with 'polyglossia' 1.45\MessageBreak
+           or above.\MessageBreak
+           Please update 'polyglossia' to v1.45 (2019/10/27)\MessageBreak
+           or later.\MessageBreak
+           Variant detection will not work properly with\MessageBreak
+           older versions}}}
+    {\@ifpackageloaded{babel}
+       {\@ifpackagelater{babel}{2016/04/23}
+          {}
+          {\blx@error
+             {Outdated 'babel' package}
+             {Upgrade to babel 3.9r (2016/04/23) or later.\MessageBreak
+              I found: '\csuse{ver@babel.sty}'.\MessageBreak
+              This is a fatal error. I'm aborting now}%
+            \endinput}}
+       {}}}
 
 \begingroup
 \catcode`\#=12
@@ -439,15 +461,11 @@
        {}
        {\def\blx@ifhyphenationundef#1#2#3{\xpg@ifdefined{#1}{#3}{#2}}}%
      % This is required for languages which are never explicitly selected
-     % This check because \xpg@bloaded is not defined in
-     % polyglossia <= v1.44.0
+     % \xpg@bloaded is not defined in polyglossia < v1.45
      \ifundef\xpg@bloaded
        {\ifundef\xpg@loaded
           {\let\xpg@bloaded\@empty}
-          {\let\xpg@bloaded\xpg@loaded}%
-        \blx@warning@noline{%
-          'polyglossia' >= v1.45 required.\MessageBreak
-          Please update polyglossia to version v1.45 or above}}
+          {\let\xpg@bloaded\xpg@loaded}}
        {}%
      \global\let\blx@maplang\blx@maplang@polyglossia
      \def\do#1{\blx@langsetup{#1}}%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -428,12 +428,17 @@
 % no longer needed, keep for backwards compatibility
 \let\blx@langstrings\relax
 
+\def\blx@ifhyphenationundef#1{\ifcsundef{l@#1}}
+
 % polyglossia makes heavy use of \AtBeginDocument, so we need to use
 % it too to get in later than polyglossia's setup.
 % This means that load-order is relevant, boo ...
 \AtBeginDocument{%
   \@ifpackageloaded{polyglossia}
-    {% This is required for languages which are never explicitly selected
+    {\ifundef\xpg@ifdefined
+       {}
+       {\def\blx@ifhyphenationundef#1#2#3{\xpg@ifdefined{#1}{#3}{#2}}}%
+     % This is required for languages which are never explicitly selected
      % This check because \xpg@bloaded is not defined in
      % polyglossia <= v1.44.0
      \ifundef\xpg@bloaded
@@ -5451,14 +5456,14 @@
 
 % {<language>}{<exceptions>}
 \newrobustcmd*{\DefineHyphenationExceptions}[2]{%
-  \ifcsundef{l@#1}
+  \blx@ifhyphenationundef{#1}
     {\blx@warn@nohyph{#1}}
     {}%
   \csgappto{blx@hook@hyph@#1}{\blx@hyphexcept{#1}{#2}}}
 \@onlypreamble\DefineHyphenationExceptions
 
 \def\blx@hyphexcept#1#2{%
-  \ifcsundef{l@#1}
+  \blx@ifhyphenationundef{#1}
     {\blx@warn@nohyph{#1}}
     {\begingroup
      \language\csname l@#1\endcsname\relax
@@ -6364,7 +6369,7 @@
 \let\blx@hook@initlang\@empty
 \let\blx@imc@mainlang\@empty
 \def\blx@hyphenreset{%
-  \ifcsundef{l@\blx@languagename}
+  \blx@ifhyphenationundef{\blx@languagename}
     {}
     {\language\csname l@\blx@languagename\endcsname\relax}%
   \ifcsundef{\blx@languagename hyphenmins}
@@ -6399,7 +6404,7 @@
                {\let\abx@field@langid\blx@forcelanguagename}
                {}%
              \let\blx@languagename\abx@field@langid% track global language
-             \ifcsundef{l@\abx@field@langid}
+             \blx@ifhyphenationundef{\abx@field@langid}
                {\blx@warn@nohyph{\abx@field@langid}}
                {\blx@hook@initlang
                 \def\blx@endlang{%
@@ -6436,18 +6441,18 @@
        {\def\blx@beglang{%
           \blx@clearlang
           \begingroup
-         % Need to override all entries, regardless of if there is a langid
-         % if language=<language> option is given
-         \ifboolexpr { test {\ifdef\abx@field@langid }
-                       or
-                       test {\ifdef\blx@forcelanguagename} }
+          % Need to override all entries, regardless of if there is a
+          % langid if language=<language> option is given
+          \ifboolexpr { test {\ifdef\abx@field@langid }
+                        or
+                        test {\ifdef\blx@forcelanguagename} }
             % override local langid if we forced it with
             % language=<language> option
             {\ifdef\blx@forcelanguagename
                {\let\abx@field@langid\blx@forcelanguagename}
                {}%
              \let\blx@languagename\abx@field@langid% track global language
-             \ifcsundef{l@\abx@field@langid}
+             \blx@ifhyphenationundef{\abx@field@langid}
                {\blx@warn@nohyph{\abx@field@langid}}
                {\blx@hook@initlang
                 \def\blx@endlang{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -425,11 +425,13 @@
        \sfcode`\'=\z@}}%
   \let\do\noexpand}
 
+% no longer needed, keep for backwards compatibility
+\let\blx@langstrings\relax
+
 % polyglossia makes heavy use of \AtBeginDocument, so we need to use
 % it too to get in later than polyglossia's setup.
 % This means that load-order is relevant, boo ...
 \AtBeginDocument{%
-  \def\blx@langstrings{}%
   \@ifpackageloaded{polyglossia}
     {% This is required for languages which are never explicitly selected
      % This check because \xpg@bloaded is not defined in
@@ -442,6 +444,7 @@
           'polyglossia' >= v1.45 required.\MessageBreak
           Please update polyglossia to version v1.45 or above}}
        {}%
+     \global\let\blx@maplang\blx@maplang@polyglossia
      \def\do#1{\blx@langsetup{#1}}%
      \expandafter\docsvlist\expandafter{\xpg@bloaded}%
      \ifboolexpr{
@@ -451,17 +454,18 @@
        {\blx@mknoautolang}
        {\blx@mkautolangpoly}%
     }
-    {\@ifpackageloaded{babel}
-      {% This is required for languages which are never explicitly selected
-       \def\do#1{\blx@langsetup{#1}}%
-       \expandafter\docsvlist\expandafter{\bbl@loaded}%
-       \ifboolexpr{
-        not togl {blx@autolangbib}
-        and
-        not togl {blx@autolangcite}}
-         {\blx@mknoautolang}
-         {\blx@mkautolangbabel}}
-      {\blx@mknoautolang}}%
+    {\global\let\blx@maplang\blx@maplang@babel
+     \@ifpackageloaded{babel}
+       {% This is required for languages which are never explicitly selected
+        \def\do#1{\blx@langsetup{#1}}%
+        \expandafter\docsvlist\expandafter{\bbl@loaded}%
+        \ifboolexpr{
+          not togl {blx@autolangbib}
+          and
+          not togl {blx@autolangcite}}
+          {\blx@mknoautolang}
+          {\blx@mkautolangbabel}}
+       {\blx@mknoautolang}}%
   % These already have defaults set to basically do nothing
   % so if the toggles are true, we need to define again since
   % mkautolang* redefines \blx@beglang
@@ -6327,12 +6331,25 @@
 \def\currentlang{\blx@languagename}
 
 % {<language>}{<strings>}
-\def\blx@maplang#1#2{%
+\def\blx@maplang@babel#1#2{%
   \csgappto{extras#1}{%
     \blx@resetpunct
     \csuse{abx@extras@#2}%
     \csuse{abx@strings@#2}}%
   \csgappto{noextras#1}{%
+    \blx@resetpunct
+    \csuse{abx@noextras@#2}}}
+
+\def\blx@maplang@polyglossia#1#2{%
+  \csgappto{blockextras@bbl@#1}{%
+    \blx@resetpunct
+    \csuse{abx@extras@#2}%
+    \csuse{abx@strings@#2}}%
+  \csgappto{inlinextras@bbl@#1}{%
+    \blx@resetpunct
+    \csuse{abx@extras@#2}%
+    \csuse{abx@strings@#2}}%
+  \csgappto{noextras@bbl@#1}{%
     \blx@resetpunct
     \csuse{abx@noextras@#2}}}
 
@@ -6399,7 +6416,6 @@
                 \expandafter{\abx@field@langid}}}
             {}}}
        {}%
-     \def\blx@langstrings{}%
      \def\blx@imc@mainlang{\select@language{\blx@main@language}}%
      \blx@langsetup\blx@main@language}
     {\blx@err@patch{'babel' package}%
@@ -6460,17 +6476,7 @@
                    \csuse{abx@strings@\abx@field@langid}}}}
             {}}}
        {}%
-     % polyglossia needs this - it doesn't get the
-     % strings automatically set for some reason
-     \def\blx@langstrings{%
-       \csuse{abx@extras@\languagename}%
-       \csuse{abx@strings@\languagename}}%
-     \def\blx@imc@mainlang{%
-       \select@language{\blx@main@language}%
-       % These lines are equal to \blx@maplang
-       \blx@resetpunct
-       \csuse{abx@extras@\blx@main@language}%
-       \csuse{abx@strings@\blx@main@language}}%
+     \def\blx@imc@mainlang{\select@language{\blx@main@language}}%
      \blx@langsetup\blx@main@language}
     {\blx@err@patch{'polyglossia' package}%
      \blx@mknoautolang}%
@@ -9129,7 +9135,6 @@
   \blx@safe@actives
   \setkeys{blx@bhd}{#1}%
   \blx@rest@actives
-  \blx@langstrings
   \blx@bibheading\blx@theheading\blx@thetitle
   \endgroup}
 
@@ -9319,7 +9324,6 @@
 
 % {<entrykey>,...}
 \def\blx@bibliography#1{%
-  \blx@langstrings
   \blx@bibheading\blx@theheading\blx@thetitle
   \blx@bibnote\blx@theprenote
   \begingroup
@@ -9669,7 +9673,6 @@
   \else
     \@restonecolfalse
   \fi
-  \blx@langstrings
   \blx@bibheading\blx@theheading\blx@thetitle
   \blx@bibnote\blx@theprenote
   \begingroup
@@ -11410,7 +11413,6 @@
     {}
     {\toggletrue{blx@citation}}%
   \blx@blxinit
-  \blx@langstrings
   \citesetup
   \blx@setsfcodes
   \blx@postpunct@agroup

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -201,69 +201,6 @@
 \AtEndPreamble{%
   \blx@packageincompatibility
   \blx@packageincompatibility@endpreambleonly
-  \def\blx@langstrings{}%
-  % Set up sortlocale defaults and default language if babel/polyglossia is not loaded
-  \ifdefstring\blx@sortlocale{auto}
-    {\ifdef\bbl@main@language% babel or polyglossia is loaded
-      {\edef\blx@sortlocale{\bbl@main@language}}
-      {\def\blx@sortlocale{english}}}
-    {}%
-  \@ifpackageloaded{polyglossia}
-    {% polyglossia support is not great when it comes to language variants,
-     % so we better warn about it.
-     \ifundef\blx@nowarnpolyglossia
-       {\blx@warning@noline{%
-          Package 'polyglossia' detected.\MessageBreak
-          Please note that biblatex's polyglossia\MessageBreak
-          interface has some rough edges.\MessageBreak
-          Language variants are not picked up correctly.\MessageBreak
-          You can disable this warning by defining the macro\MessageBreak
-          '\string\blx@nowarnpolyglossia' in the preamble}}
-       {}%
-     % This is required for languages which are never explicitly selected
-     % This check because \xpg@loaded is not defined in polyglossia <= v1.42.0
-     \ifundef\xpg@loaded
-       {\let\xpg@loaded\@empty
-        \let\xpg@vloaded\@empty
-        \blx@warning@noline{Upgrade package 'polyglossia' to > v1.42.0 recommended}}
-       {}%
-     \def\do#1{\blx@langsetup{#1}}%
-     \expandafter\docsvlist\expandafter{\xpg@loaded}%
-     \expandafter\docsvlist\expandafter{\xpg@vloaded}%
-     \ifboolexpr{
-      not togl {blx@autolangbib}
-      and
-      not togl {blx@autolangcite}}
-       {\blx@mknoautolang}
-       {\blx@mkautolangpoly}}
-    {\@ifpackageloaded{babel}
-      {% This is required for languages which are never explicitly selected
-       \def\do#1{\blx@langsetup{#1}}%
-       \expandafter\docsvlist\expandafter{\bbl@loaded}%
-       \ifboolexpr{
-        not togl {blx@autolangbib}
-        and
-        not togl {blx@autolangcite}}
-         {\blx@mknoautolang}
-         {\blx@mkautolangbabel}}
-      {\blx@mknoautolang}}%
-  % These already have defaults set to basically do nothing
-  % so if the toggles are true, we need to define again since
-  % mkautolang* redefines \blx@beglang
-  % In turn, \blx@beglang defines \blx@endlang and so \blx@beglangcite and
-  % \blx@endlangcite need redefining inside \blx@beglang after \blx@endlang
-  % has been defined.
-  \iftoggle{blx@autolangbib}
-    {\let\blx@beglangbib\blx@beglang}
-    {}%
-  \iftoggle{blx@autolangcite}
-    {\let\blx@beglangcite\blx@beglang}
-    {}%
-  \csuse{abx@extras@\blx@languagename}%
-  \csuse{abx@strings@\blx@languagename}%
-  \undef\blx@mkautolangbabel
-  \undef\blx@mkautolangpoly
-  \undef\blx@mknoautolang
   \ifnum\blx@hyperref=\thr@@
   \else
     \ifnum\blx@hyperref=\z@
@@ -487,6 +424,70 @@
        \sfcode`\`=\z@
        \sfcode`\'=\z@}}%
   \let\do\noexpand}
+
+% polyglossia makes heavy use of \AtBeginDocument, so we need to use
+% it too to get in later than polyglossia's setup.
+% This means that load-order is relevant, boo ...
+\AtBeginDocument{%
+  \def\blx@langstrings{}%
+  \@ifpackageloaded{polyglossia}
+    {% This is required for languages which are never explicitly selected
+     % This check because \xpg@bloaded is not defined in
+     % polyglossia <= v1.44.0
+     \ifundef\xpg@bloaded
+       {\ifundef\xpg@loaded
+          {\let\xpg@bloaded\@empty}
+          {\let\xpg@bloaded\xpg@loaded}%
+        \blx@warning@noline{%
+          'polyglossia' >= v1.45 required.\MessageBreak
+          Please update polyglossia to version v1.45 or above}}
+       {}%
+     \def\do#1{\blx@langsetup{#1}}%
+     \expandafter\docsvlist\expandafter{\xpg@bloaded}%
+     \ifboolexpr{
+      not togl {blx@autolangbib}
+      and
+      not togl {blx@autolangcite}}
+       {\blx@mknoautolang}
+       {\blx@mkautolangpoly}%
+    }
+    {\@ifpackageloaded{babel}
+      {% This is required for languages which are never explicitly selected
+       \def\do#1{\blx@langsetup{#1}}%
+       \expandafter\docsvlist\expandafter{\bbl@loaded}%
+       \ifboolexpr{
+        not togl {blx@autolangbib}
+        and
+        not togl {blx@autolangcite}}
+         {\blx@mknoautolang}
+         {\blx@mkautolangbabel}}
+      {\blx@mknoautolang}}%
+  % These already have defaults set to basically do nothing
+  % so if the toggles are true, we need to define again since
+  % mkautolang* redefines \blx@beglang
+  % In turn, \blx@beglang defines \blx@endlang and so \blx@beglangcite and
+  % \blx@endlangcite need redefining inside \blx@beglang after \blx@endlang
+  % has been defined.
+  \iftoggle{blx@autolangbib}
+    {\let\blx@beglangbib\blx@beglang}
+    {}%
+  \iftoggle{blx@autolangcite}
+    {\let\blx@beglangcite\blx@beglang}
+    {}%
+  \csuse{abx@extras@\blx@languagename}%
+  \csuse{abx@strings@\blx@languagename}%
+  \undef\blx@mkautolangbabel
+  \undef\blx@mkautolangpoly
+  \undef\blx@mknoautolang
+  % pick up the main document language as sortlocale if
+  % auto-detection is desired
+  \ifdefstring\blx@sortlocale{auto}
+    {\ifdef\blx@main@language% babel or polyglossia is loaded
+       {\edef\blx@sortlocale{\blx@main@language}}
+       {\def\blx@sortlocale{english}}}
+     {}%
+}
+
 
 \begingroup
 \@makeother\#
@@ -3994,8 +3995,8 @@
       {\xifinlist\abx@field@langid\blx@cmksc@lang
          {\blx@mksc@ii}
          {\@firstofone}}
-      {\ifdef\bbl@main@language
-        {\xifinlist\bbl@main@language\blx@cmksc@lang
+      {\ifdef\blx@main@language
+        {\xifinlist\blx@main@language\blx@cmksc@lang
           {\blx@mksc@ii}
           {\@firstofone}}
         {\xifinlist\blx@languagename\blx@cmksc@lang
@@ -6364,7 +6365,7 @@
     {\blx@error
       {No default 'babel' language defined}
       {You must define a default language for 'babel'}}
-    {}%
+    {\let\blx@main@language\bbl@main@language}%
   \pretocmd\select@language{\blx@langsetup{#1}}
     {\ifdef\blx@thelangenv
        {\def\blx@beglang{%
@@ -6399,20 +6400,22 @@
             {}}}
        {}%
      \def\blx@langstrings{}%
-     \def\blx@imc@mainlang{\select@language{\bbl@main@language}}%
-     \blx@langsetup\bbl@main@language}
+     \def\blx@imc@mainlang{\select@language{\blx@main@language}}%
+     \blx@langsetup\blx@main@language}
     {\blx@err@patch{'babel' package}%
      \blx@mknoautolang}}
 
 \gdef\blx@mkautolangpoly{%
-  \ifundef\bbl@main@language
-    {\blx@error
-      {No default 'polyglossia' language defined}
-      {You must define a default language for 'polyglossia'}}
-    {}%
+  \ifundef\mainbabelname
+    {\ifundef\bbl@main@language
+       {\blx@error
+          {No default 'polyglossia' language defined}
+          {You must define a default language for 'polyglossia'}}
+       {\let\blx@main@language\bbl@main@language}}
+    {\let\blx@main@language\mainbabelname}%
   \edef\blx@saved@underscore@catcode{\the\catcode`\_}%
   \catcode`\_=11% polyglossia uses "_" as a letter
-  \pretocmd\select@language{\blx@langsetup{#1}}
+  \pretocmd\select@language{\blx@langsetup{\babelname}}
     {\ifdef\blx@thelangenv
        {\def\blx@beglang{%
           \blx@clearlang
@@ -6463,12 +6466,12 @@
        \csuse{abx@extras@\languagename}%
        \csuse{abx@strings@\languagename}}%
      \def\blx@imc@mainlang{%
-       \select@language{\bbl@main@language}%
+       \select@language{\blx@main@language}%
        % These lines are equal to \blx@maplang
        \blx@resetpunct
-       \csuse{abx@extras@\bbl@main@language}%
-       \csuse{abx@strings@\bbl@main@language}}%
-     \blx@langsetup\bbl@main@language}
+       \csuse{abx@extras@\blx@main@language}%
+       \csuse{abx@strings@\blx@main@language}}%
+     \blx@langsetup\blx@main@language}
     {\blx@err@patch{'polyglossia' package}%
      \blx@mknoautolang}%
   \catcode`\_=\blx@saved@underscore@catcode\relax}


### PR DESCRIPTION
See #460.

Make use of new `polyglossia` 1.45 features to deal with language variants as expected.

Ping back to https://github.com/plk/biblatex/issues/845, https://github.com/plk/biblatex/issues/69, https://github.com/plk/biblatex/issues/359.

This effectively reverts https://github.com/plk/biblatex/commit/b2d6d0c0e953edd6134573942fae166c2c6214e5.