### PR TITLE
Add Serbian localization

### DIFF
--- a/tex/latex/biblatex/lbx/serbian.lbx
+++ b/tex/latex/biblatex/lbx/serbian.lbx
@@ -1,0 +1,437 @@
+\ProvidesFile{serbian.lbx}
+[\abx@lbxid]
+
+% Translator's notes:
+%
+% This file is generated from a template and YAML localization string
+% collection by a script
+% You can said files at https://gitlab.com/andrejr/biblatex-serbian.
+% Please don't modify this file by hand -- contribute your changes upstream and
+% then send a pull request with the generated file to the official biblatex
+% repo (https://github.com/plk/biblatex).
+%
+% This is done so we could generate both `serbian.lbx` (Latin) and
+% `serbianc.lbx` (Cyrillic) from the same set of localization strings.
+
+
+\DeclareRedundantLanguages{serbian}{serbian}
+
+\DeclareBibliographyExtras{%
+  \protected\def\bibrangedash{\textendash\penalty\hyphenpenalty}%
+  \protected\def\mkbibordinal#1{\stripzeros{#1}\adddot}%
+  \protected\def\mkbibmascord{\mkbibordinal}%
+  \protected\def\mkbibfemord{\mkbibordinal}%
+  \protected\def\mkbibneutord{\mkbibordinal}%
+  \protected\def\bibtimesep{.}%
+  %\savecommand\mkbibordedition
+  %\savecommand\mkbibordseries
+  \def\mkbibordedition{\mkbibordinal}%
+  \def\mkbibordseries{\mkbibfemord}%
+  \protected\def\mkbibdatelong#1#2#3{%
+    % day field
+    \iffieldundef{#3}{}{\mkbibordinal{\thefield{#3}}% if day exists, display
+      \iffieldundef{#2}{}{\nobreakspace}}% space before month if month exists
+    % month field
+    \iffieldundef{#2}{}{\mkbibmonth{\thefield{#2}}%
+      \iffieldundef{#1}{}{\space}}% space before year if year exists
+    % year field
+    \iffieldbibstring{#1}% year
+    {\bibstring{\thefield{#1}}}%
+    {\dateeraprintpre{#1}\mkbibordinal{\thefield{#1}}}}%
+  \protected\def\mkbibdateshort#1#2#3{%
+    \iffieldundef{#3}{}{\mkbibordinal{\thefield{#3}}%
+      \iffieldundef{#2}{}{\addnbspace}}%
+    \iffieldundef{#2}{}{\mkbibordinal{\thefield{#2}}%
+      \iffieldundef{#1}{}{\addnbspace}}%
+    \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}%
+    {\dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}}%
+  \expandafter\protected\expandafter\def\csname mkbibtime24h%
+  \endcsname#1#2#3#4{%
+    \iffieldundef{#1}{}%
+    {\printtext{\mktimezeros{\thefield{#1}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#2}{}%
+    {\printtext{\mktimezeros{\thefield{#2}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#3}{}%
+    {\printtext{\mktimezeros{\thefield{#3}}}}%
+    \setunit{}%
+    \iffieldundef{#4}{}%
+    {\bibtimezonesep%
+      \mkbibtimezone{\thefield{#4}}}}%
+  \expandafter\protected\expandafter\def\csname mkbibtime12h%
+  \endcsname#1#2#3#4{%
+    \stripzeros{\mktimehh{\thefield{#1}}}\bibtimesep%
+    \forcezerosmdt{\thefield{#2}}%
+    \iffieldundef{#3}{}
+    {\bibtimesep%
+      \forcezerosmdt{\thefield{#3}}}%
+    \space
+    \ifnumless{\thefield{#1}}{12}
+    {\bibstring{am}}
+    {\bibstring{pm}}%
+    \iffieldundef{#4}{}
+    {\space\bibtimezonesep%
+      \parentext{\mkbibtimezone{\thefield{#4}}}}}%
+  \protected\def\mkbibseasondateshort#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}%
+  \protected\def\mkbibseasondatelong#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}%
+}
+
+\DeclareBibliographyStrings{%
+    abstract = {{apstrakt}{apstrakt}},
+    afterword = {{pogovor}{pogovor}},
+    am = {{AM}{AM}},
+    and = {{i}{i}},
+    andmore = {{i drugi}{i\addabbrvspace dr\adddot}},
+    andothers = {{i drugi}{i\addabbrvspace dr\adddot}},
+    annodomini = {{posle Hrista}{p\adddotspace Hr\adddot}},
+    annotation = {{bele\v ska}{bel\adddot}},
+    annotations = {{bele\v ske}{bel\adddot}},
+    annotator = {{autor bele\v zaka}{aut\adddot\ bel\adddot}},
+    annotators = {{autori bele\v zaka}{aut\adddot\ bel\adddot}},
+    april = {{april}{apr\adddot}},
+    astitle = {{pod naslovom}{pod naslovom}},
+    audiocd = {{audio CD}{audio CD}},
+    august = {{avgust}{avg\adddot}},
+    autumn = {{jesen}{jesen}},
+    backrefpage = {{citirano na stranici}{cit\adddot\ na str\adddot}},
+    backrefpages = {{citirano na stranicama}{cit\adddot\ na str\adddot}},
+    bathesis = {{ba\v celor rad}{BA\addabbrvspace rad}},
+    beforechrist = {{pre Hrista}{pr\adddotspace Hr\adddot}},
+    beforecommonera = {{pre nove ere}{pre\addabbrvspace n\adddotspace e\adddot}},
+    bibliography = {{Bibliografija}{Bibliografija}},
+    book = {{knjiga}{knj\adddot}},
+    byannotator = {{autor bele\v zaka}{autor bele\v zaka}},
+    byauthor = {{autor}{autor}},
+    bycollaborator = {{u saradnji sa}{u saradnji sa}},
+    bycommentator = {{komentar}{komentar}},
+    bycompiler = {{odabir}{odabir}},
+    bycontinuator = {{autor nastavka}{autor nastavka}},
+    byeditor = {{urednik}{urednik}},
+    byeditoraf = {{obrada i pogovor}{obrada i pogovor}},
+    byeditoran = {{obrada i bele\v ske}{obrada i bele\v ske}},
+    byeditoranaf = {{obrada, bele\v ske i pogovor}{obrada, bele\v ske i pogovor}},
+    byeditoranfo = {{obrada, bele\v ske i predgovor}{obrada, bele\v ske i predgovor}},
+    byeditoranin = {{obrada, bele\v ske i uvod}{obrada, bele\v ske i uvod}},
+    byeditorco = {{obrada  i komentar}{obrada  i komentar}},
+    byeditorcoaf = {{obrada, komentar i pogovor}{obrada, komentar i pogovor}},
+    byeditorcofo = {{obrada, komentar i predgovor}{obrada, komentar i predgovor}},
+    byeditorcoin = {{obrada, komentar i uvod}{obrada, komentar i uvod}},
+    byeditorfo = {{obrada i predgovor}{obrada i predgovor}},
+    byeditorin = {{obrada i uvod}{obrada i uvod}},
+    byeditortr = {{obrada i prevod}{obrada i prevod}},
+    byeditortraf = {{obrada, prevod i pogovor}{obrada, prevod i pogovor}},
+    byeditortran = {{obrada, prevod i bele\v ske}{obrada, prevod i bele\v ske}},
+    byeditortranaf = {{obrada, prevod, bele\v ske i pogovor}{obrada, prevod, bele\v ske i pogovor}},
+    byeditortranfo = {{obrada, prevod, bele\v ske i predgovor}{obrada, prevod, bele\v ske i predgovor}},
+    byeditortranin = {{obrada, prevod, bele\v ske i uvod}{obrada, prevod, bele\v ske i uvod}},
+    byeditortrco = {{obrada, prevod i komentar}{obrada, prevod i komentar}},
+    byeditortrcoaf = {{obrada, prevod, komentar i pogovor}{obrada, prevod, komentar i pogovor}},
+    byeditortrcofo = {{obrada, prevod, komentar i predgovor}{obrada, prevod, komentar i predgovor}},
+    byeditortrcoin = {{obrada, prevod, komentar i uvod}{obrada, prevod, komentar i uvod}},
+    byeditortrfo = {{obrada, prevod i predgovor}{obrada, prevod i predgovor}},
+    byeditortrin = {{obrada, prevod i uvod}{obrada, prevod i uvod}},
+    byfounder = {{osniva\v c}{osniva\v c}},
+    byorganizer = {{organizator}{organizator}},
+    bypublisher = {{izdava\v c}{izdava\v c}},
+    byredactor = {{redaktor}{redaktor}},
+    byreviewer = {{recenzent}{recenzent}},
+    byreviser = {{korektor}{korektor}},
+    bytranslator = {{prevod}{prevod}},
+    bytranslatoraf = {{prevod i pogovor}{prevod i pogovor}},
+    bytranslatoran = {{prevod i bele\v ske}{prevod i bele\v ske}},
+    bytranslatoranaf = {{prevod, bele\v ske i pogovor}{prevod, bele\v ske i pogovor}},
+    bytranslatoranfo = {{prevod, bele\v ske i predgovor}{prevod, bele\v ske i predgovor}},
+    bytranslatoranin = {{prevod, bele\v ske i uvod}{prevod, bele\v ske i uvod}},
+    bytranslatorco = {{prevod i komentar}{prevod i komentar}},
+    bytranslatorcoaf = {{prevod, komentar i pogovor}{prevod, komentar i pogovor}},
+    bytranslatorcofo = {{prevod, komentar i predgovor}{prevod, komentar i predgovor}},
+    bytranslatorcoin = {{prevod, komentar i uvod}{prevod, komentar i uvod}},
+    bytranslatorfo = {{prevod i predgovor}{prevod i predgovor}},
+    bytranslatorin = {{prevod i uvod}{prevod i uvod}},
+    candthesis = {{kandidatski rad}{kandidatski rad}},
+    chapter = {{glava}{glava}},
+    circa = {{cirka}{cca}},
+    citedas = {{citirano kao}{cit\adddotspace kao}},
+    collaborator = {{saradnik}{sar\adddot}},
+    collaborators = {{saradnici}{sar\adddot}},
+    column = {{stupac}{stupac}},
+    columns = {{stupci}{stupci}},
+    columntotal = {{stupac}{stupac}},
+    columntotals = {{stupci}{stupci}},
+    commentary = {{komentar}{kom\adddot}},
+    commentator = {{komentator}{kom\adddot}},
+    commentators = {{komentatori}{kom\adddot}},
+    commonera = {{nove ere}{n.\addnbspace e\adddot}},
+    compiler = {{prire\dj iva\v c}{prire\dj iva\v c}},
+    compilers = {{priredili}{priredili}},
+    confer = {{cf\adddot}{cf\adddot}},
+    continuator = {{nastavlja\v c}{nast\adddot}},
+    continuators = {{nastavlja\v ci}{nast\adddot}},
+    countryde = {{Nema\v cka}{DE}},
+    countryep = {{Evropska unija}{EP}},
+    countryeu = {{Evropska unija}{EU}},
+    countryfr = {{Francuska}{FR}},
+    countryuk = {{Velika Britanija}{GB}},
+    countryus = {{Sjedinjene Ameri\v cke Dr\v zave}{SAD}},
+    datacd = {{CD-ROM}{CD-ROM}},
+    december = {{decembar}{dec\adddot}},
+    edition = {{izdanje}{izdanje}},
+    editor = {{urednik}{ur\adddot}},
+    editoraf = {{urednik i autor pogovora}{urednik i autor pogovora}},
+    editoran = {{urednik i autor bele\v zaka}{urednik i autor bele\v zaka}},
+    editoranaf = {{urednik, autor bele\v zaka i autor pogovora}{urednik, autor bele\v zaka i autor pogovora}},
+    editoranfo = {{urednik, autor bele\v zaka i autor predgovora}{urednik, autor bele\v zaka i autor predgovora}},
+    editoranin = {{urednik, autor bele\v zaka i autor uvoda}{urednik, autor bele\v zaka i autor uvoda}},
+    editorco = {{urednik i komentator}{urednik i komentator}},
+    editorcoaf = {{urednik, komentator i autor pogovora}{urednik, komentator i autor pogovora}},
+    editorcofo = {{urednik, komentator i autor predgovora}{urednik, komentator i autor predgovora}},
+    editorcoin = {{urednik, komentator i autor uvoda}{urednik, komentator i autor uvoda}},
+    editorfo = {{urednik i autor predgovora}{urednik i autor predgovora}},
+    editorin = {{urednik i autor uvoda}{urednik i autor uvoda}},
+    editors = {{urednici}{urednici}},
+    editorsaf = {{urednici i pisci pogovora}{urednici i pisci pogovora}},
+    editorsan = {{urednici i autori bele\v zaka}{urednici i autori bele\v zaka}},
+    editorsanaf = {{urednici, autori bele\v zaka i autori pogovora}{urednici, autori bele\v zaka i autori pogovora}},
+    editorsanfo = {{urednici, autori bele\v zaka i autori predgovora}{urednici, autori bele\v zaka i autori predgovora}},
+    editorsanin = {{urednici, autori bele\v zaka i autori uvoda}{urednici, autori bele\v zaka i autori uvoda}},
+    editorsco = {{urednici i komentatori}{urednici i komentatori}},
+    editorscoaf = {{urednici, komentatori i pisci pogovora}{urednici, komentatori i pisci pogovora}},
+    editorscofo = {{urednici, komentatori i autori predgovora}{urednici, komentatori i autori predgovora}},
+    editorscoin = {{urednici, komentatori i autori uvoda}{urednici, komentatori i autori uvoda}},
+    editorsfo = {{urednici i pisci predgovora}{urednici i pisci predgovora}},
+    editorsin = {{urednici i autori uvoda}{urednici i autori uvoda}},
+    editorstr = {{urednici i prevodioci}{urednici i prevodioci}},
+    editorstraf = {{urednici, prevodioci i autori pogovora}{urednici, prevodioci i autori pogovora}},
+    editorstran = {{urednici, prevodioci i autori bele\v zaka}{urednici, prevodioci i autori bele\v zaka}},
+    editorstranaf = {{urednici, prevodioci, autori bele\v zaka i pisci pogovora}{urednici, prevodioci, autori bele\v zaka i pisci pogovora}},
+    editorstranfo = {{urednici, prevodioci, autori bele\v zaka i autori predgovora}{urednici, prevodioci, autori bele\v zaka i autori predgovora}},
+    editorstranin = {{urednici, prevodioci, autori bele\v zaka i autori uvoda}{urednici, prevodioci, autori bele\v zaka i autori uvoda}},
+    editorstrco = {{urednici, prevodioci i komentatori}{urednici, prevodioci i komentatori}},
+    editorstrcoaf = {{urednici, prevodioci, komentatori i pisci pogovora}{urednici, prevodioci, komentatori i pisci pogovora}},
+    editorstrcofo = {{urednici, prevodioci, komentatori i autori predgovora}{urednici, prevodioci, komentatori i autori predgovora}},
+    editorstrcoin = {{urednici, prevodioci, komentatori i autori uvoda}{urednici, prevodioci, komentatori i autori uvoda}},
+    editorstrfo = {{urednici, prevodioci i autori predgovora}{urednici, prevodioci i autori predgovora}},
+    editorstrin = {{urednici, prevodioci i autori uvoda}{urednici, prevodioci i autori uvoda}},
+    editortr = {{urednik i prevodilac}{urednik i prevodilac}},
+    editortraf = {{urednik, prevodilac i autor pogovora}{urednik, prevodilac i autor pogovora}},
+    editortran = {{urednik, prevodilac i autor bele\v zaka}{urednik, prevodilac i autor bele\v zaka}},
+    editortranaf = {{urednik, prevodilac, autor bele\v zaka i autor pogovora}{urednik, prevodilac, autor bele\v zaka i autor pogovora}},
+    editortranfo = {{urednik, prevodilac, autor bele\v zaka i autor predgovora}{urednik, prevodilac, autor bele\v zaka i autor predgovora}},
+    editortranin = {{urednik, prevodilac, autor bele\v zaka i autor uvoda}{urednik, prevodilac, autor bele\v zaka i autor uvoda}},
+    editortrco = {{urednik, prevodilac i komentator}{urednik, prevodilac i komentator}},
+    editortrcoaf = {{urednik, prevodilac, komentator i autor pogovora}{urednik, prevodilac, komentator i autor pogovora}},
+    editortrcofo = {{urednik, prevodilac, komentator i autor predgovora}{urednik, prevodilac, komentator i autor predgovora}},
+    editortrcoin = {{urednik, prevodilac, komentator i autor uvoda}{urednik, prevodilac, komentator i autor uvoda}},
+    editortrfo = {{urednik, prevodilac i autor predgovora}{urednik, prevodilac i autor predgovora}},
+    editortrin = {{urednik, prevodilac i autor uvoda}{urednik, prevodilac i autor uvoda}},
+    february = {{februar}{feb\adddot}},
+    file = {{datoteka}{datoteka}},
+    foreword = {{predgovor}{predgovor}},
+    forthcoming = {{dolaze\'ce}{dolaze\'ce}},
+    founder = {{osniva\v c}{osn\adddot}},
+    founders = {{osniva\v ci}{osn\adddot}},
+    fromamerican = {{sa ameri\v ckog}{sa ameri\v ckog}},
+    frombrazilian = {{sa brazilskog}{sa brazilskog}},
+    frombulgarian = {{sa bugarskog}{sa bugarskog}},
+    fromcatalan = {{sa katalonskog}{sa katalonskog}},
+    fromcroatian = {{sa hrvatskog}{sa hrvatskog}},
+    fromczech = {{sa \v ce\v skog}{sa \v ce\v skog}},
+    fromdanish = {{sa danskog}{sa danskog}},
+    fromdutch = {{sa holandskog}{sa holandskog}},
+    fromenglish = {{sa engleskog}{sa engleskog}},
+    fromestonian = {{sa estonskog}{sa estonskog}},
+    fromfinnish = {{sa finskog}{sa finskog}},
+    fromfrench = {{sa francuskog}{sa francuskog}},
+    fromgalician = {{sa galicijskog}{sa galicijskog}},
+    fromgerman = {{sa nema\v ckog}{sa nema\v ckog}},
+    fromgreek = {{sa gr\v ckog}{sa gr\v ckog}},
+    fromhungarian = {{sa ma\dj arskog}{sa ma\dj arskog}},
+    fromitalian = {{sa italijanskog}{sa italijanskog}},
+    fromjapanese = {{sa japanskog}{sa japanskog}},
+    fromlatin = {{sa latinskog}{sa latinskog}},
+    fromlatvian = {{sa letonskog}{sa letonskog}},
+    fromnorwegian = {{sa norve\v skog}{sa norve\v skog}},
+    frompolish = {{sa poljskog}{sa poljskog}},
+    fromportuguese = {{sa portugalskog}{sa portugalskog}},
+    fromrussian = {{sa ruskog}{sa ruskog}},
+    fromslovak = {{sa slova\v ckog}{sa slova\v ckog}},
+    fromslovene = {{sa slovena\v ckog}{sa slovena\v ckog}},
+    fromspanish = {{sa \v spanskog}{sa \v spanskog}},
+    fromswedish = {{sa \v svedskog}{sa \v svedskog}},
+    fromukrainian = {{sa ukrajinskog}{sa ukrajinskog}},
+    ibidem = {{ibidem}{ibid\adddot}},
+    idem = {{idem}{idem}},
+    idempf = {{eaedem}{eaedem}},
+    idempm = {{eidem}{eidem}},
+    idempn = {{eadem}{eadem}},
+    idempp = {{eidem}{eidem}},
+    idemsf = {{eadem}{eadem}},
+    idemsm = {{idem}{idem}},
+    idemsn = {{idem}{idem}},
+    in = {{u}{u}},
+    inpreparation = {{u pripremi}{u pripremi}},
+    inpress = {{u \v stampi}{u \v stampi}},
+    inseries = {{u}{u}},
+    introduction = {{uvod}{uv\adddot}},
+    involumes = {{u}{u}},
+    issue = {{izdanje}{izdanje}},
+    january = {{januar}{jan\adddot}},
+    jourser = {{serija}{ser\adddot}},
+    jourvol = {{sveska}{sv\adddot}},
+    july = {{jul}{jul}},
+    june = {{jun}{jun}},
+    langamerican = {{ameri\v cki}{ameri\v cki}},
+    langbrazilian = {{brazilski}{brazilski}},
+    langbulgarian = {{bugarski}{bugarski}},
+    langcatalan = {{katalanski}{katalanski}},
+    langcroatian = {{hrvatski}{hrvatski}},
+    langczech = {{\v ce\v ski}{\v ce\v ski}},
+    langdanish = {{danski}{danski}},
+    langdutch = {{holandski}{holandski}},
+    langenglish = {{engleski}{engleski}},
+    langestonian = {{estonski}{estonski}},
+    langfinnish = {{finski}{finski}},
+    langfrench = {{francuski}{francuski}},
+    langgalician = {{galicijski}{galicijski}},
+    langgerman = {{nema\v cki}{nema\v cki}},
+    langgreek = {{gr\v cki}{gr\v cki}},
+    langhungarian = {{ma\dj arski}{ma\dj arski}},
+    langitalian = {{italijanski}{italijanski}},
+    langjapanese = {{japanski}{japanski}},
+    langlatin = {{latinski}{latinski}},
+    langlatvian = {{letonski}{letonski}},
+    langnorwegian = {{norve\v ski}{norve\v ski}},
+    langpolish = {{poljski}{poljski}},
+    langportuguese = {{portugalski}{portugalski}},
+    langrussian = {{ruski}{ruski}},
+    langslovak = {{slova\v cki}{slova\v cki}},
+    langslovene = {{slovena\v cki}{slovena\v cki}},
+    langspanish = {{\v spanski}{\v spanski}},
+    langswedish = {{\v svedski}{\v svedski}},
+    langukrainian = {{ukrajinski}{ukrajinski}},
+    library = {{biblioteka}{biblioteka}},
+    line = {{red}{r\adddot}},
+    lines = {{redovi}{r\adddot}},
+    linetotal = {{red}{r\adddot}},
+    linetotals = {{redovi}{r\adddot}},
+    loccit = {{loc\adddotspace cit\adddot}{loc\adddotspace cit\adddot}},
+    march = {{mart}{mar\adddot}},
+    mathesis = {{master rad}{master rad}},
+    may = {{maj}{maj}},
+    newseries = {{nova serija}{nova serija}},
+    nodate = {{bez datuma}{bez datuma}},
+    november = {{novembar}{nov\adddot}},
+    number = {{broj}{br\adddot}},
+    october = {{oktobar}{okt\adddot}},
+    ofseries = {{serija}{ser\adddot}},
+    oldseries = {{stara serija}{stara serija}},
+    opcit = {{op\adddotspace cit\adddot}{op\adddotspace cit\adddot}},
+    organizer = {{organizator}{org\adddot}},
+    organizers = {{organizatori}{org\adddot}},
+    origpubas = {{originalno izdato kao}{originalno izdato kao}},
+    origpubin = {{originalno izdato}{originalno izdato}},
+    page = {{strana}{str\adddot}},
+    pages = {{strane}{str\adddot}},
+    pagetotal = {{strana}{str\adddot}},
+    pagetotals = {{strane}{str\adddot}},
+    paragraph = {{pasus}{pas\adddot}},
+    paragraphs = {{pasusi}{pas\adddot}},
+    paragraphtotal = {{pasus}{pas\adddot}},
+    paragraphtotals = {{pasusi}{pas\adddot}},
+    part = {{deo}{deo}},
+    passim = {{passim}{pass\adddot}},
+    patent = {{patent}{pat\adddot}},
+    patentde = {{nema\v cki patent}{nem\adddot\ pat\adddot}},
+    patenteu = {{evropski patent}{evr\adddot\ pat\adddot}},
+    patentfr = {{francuski patent}{franc\adddot\ pat\adddot}},
+    patentuk = {{britanski patent}{brit\adddot\ pat\adddot}},
+    patentus = {{SAD patent}{SAD pat\adddot}},
+    patreq = {{zahtev za patent}{zahtev za patent}},
+    patreqde = {{nema\v cki zahtev za patent}{nema\v cki zahtev za patent}},
+    patreqeu = {{evropski zahtev za patent}{evropski zahtev za patent}},
+    patreqfr = {{francuski zahtev za patent}{francuski zahtev za patent}},
+    patrequk = {{britanski zahtev za patent}{britanski zahtev za patent}},
+    patrequs = {{SAD zahtev za patent}{SAD zahtev za patent}},
+    phdthesis = {{doktorska teza}{doktorska teza}},
+    pm = {{PM}{PM}},
+    prepublished = {{preliminarno izdanje}{preliminarno izdanje}},
+    quotedin = {{citirano u}{cit\adddotspace u}},
+    redactor = {{redaktor}{red\adddot}},
+    redactors = {{redaktori}{red\adddot}},
+    references = {{Literatura}{Literatura}},
+    reprint = {{reprint}{reprint}},
+    reprintas = {{ponovo izdato kao kao}{ponovo izdato kao kao}},
+    reprintfrom = {{reprint iz}{reprint iz}},
+    reprintof = {{reprint}{reprint}},
+    resreport = {{istra\v ziva\v cki izve\v staj}{istra\v ziva\v cki izve\v staj}},
+    reviewof = {{recenzija}{recenzija}},
+    reviser = {{korektor}{korektor}},
+    revisers = {{korektori}{korektori}},
+    section = {{sekcija}{sek\adddot}},
+    sections = {{sekcije}{sek\adddot}},
+    sectiontotal = {{sekcija}{sek\adddot}},
+    sectiontotals = {{sekcije}{sek\adddot}},
+    see = {{vidi}{vidi}},
+    seealso = {{vidi\addabbrvspace i}{vidi}},
+    seenote = {{vidi fusnotu}{vidi fusnotu}},
+    september = {{septembar}{sept\adddot}},
+    sequens = {{sq\adddot}{sq\adddot}},
+    sequentes = {{sqq\adddot}{sqq\adddot}},
+    shorthands = {{Spisak skra\'cenica}{Skra\'cenice}},
+    software = {{ra\v cunarski softver}{ra\v c\adddot\ softver}},
+    spring = {{prole\'ce}{prole\'ce}},
+    submitted = {{poslato}{poslato}},
+    summer = {{leto}{leto}},
+    techreport = {{tehni\v cki izve\v staj}{tehn\adddotspace izv\adddot}},
+    thiscite = {{posebno}{posebno}},
+    translationas = {{prevedeno kao}{prevedeno kao}},
+    translationfrom = {{prevedeno sa}{prevedeno sa}},
+    translationof = {{prevod}{prevod}},
+    translator = {{prevodilac}{prevodilac}},
+    translatoraf = {{prevodilac i autor pogovora}{prevodilac i autor pogovora}},
+    translatoran = {{prevodilac i anotator}{prevodilac i anotator}},
+    translatoranaf = {{prevodilac, autor anotacija i autor pogovora}{prevodilac, autor anotacija i autor pogovora}},
+    translatoranfo = {{prevodilac, autor anotacija i autor predgovora}{prevodilac, autor anotacija i autor predgovora}},
+    translatoranin = {{prevodilac, autor anotacija i autor uvoda}{prevodilac, autor anotacija i autor uvoda}},
+    translatorco = {{prevodilac i komentator}{prevodilac i komentator}},
+    translatorcoaf = {{prevodilac, komentar i autor pogovora}{prevodilac, komentar i autor pogovora}},
+    translatorcofo = {{prevodilac, komentar i autor predgovora}{prevodilac, komentar i autor predgovora}},
+    translatorcoin = {{prevodilac, komentar i autor uvoda}{prevodilac, komentar i autor uvoda}},
+    translatorfo = {{prevodilac i autor predgovora}{prevodilac i autor predgovora}},
+    translatorin = {{prevodilac i autor uvoda}{prevodilac i autor uvoda}},
+    translators = {{prevodioci}{prevodioci}},
+    translatorsaf = {{prevodilac i autor pogovora}{prevodilac i autor pogovora}},
+    translatorsan = {{prevodioci i autori bele\v ski}{prevodioci i autori bele\v ski}},
+    translatorsanaf = {{prevodilac, autor anotacija i autor pogovora}{prevodilac, autor anotacija i autor pogovora}},
+    translatorsanfo = {{prevodilac, autor anotacija i autor predgovora}{prevodilac, autor anotacija i autor predgovora}},
+    translatorsanin = {{prevodilac, autor anotacija i autor uvoda}{prevodilac, autor anotacija i autor uvoda}},
+    translatorsco = {{prevodioci i komentatori}{prevodioci i komentatori}},
+    translatorscoaf = {{prevodilac, komentar i autor pogovora}{prevodilac, komentar i autor pogovora}},
+    translatorscofo = {{prevodilac, komentar i autor predgovora}{prevodilac, komentar i autor predgovora}},
+    translatorscoin = {{prevodilac, komentar i autor uvoda}{prevodilac, komentar i autor uvoda}},
+    translatorsfo = {{prevodilac i autor predgovora}{prevodilac i autor predgovora}},
+    translatorsin = {{prevodilac i autor uvoda}{prevodilac i autor uvoda}},
+    url = {{adresa}{adresa}},
+    urlfrom = {{dostupno na}{dostupno na}},
+    urlseen = {{pose\'ceno}{pose\'ceno}},
+    verse = {{strofa}{str\adddot}},
+    verses = {{strofe}{str\adddot}},
+    versetotal = {{strofa}{str\adddot}},
+    versetotals = {{strofe}{str\adddot}},
+    version = {{verzija}{verzija}},
+    volume = {{sveska}{sv\adddot}},
+    volumes = {{sveske}{sv\adddot}},
+    winter = {{zima}{zima}},
+    withafterword = {{sa pogovorom}{sa pogovorom}},
+    withannotator = {{sa bele\v skama}{sa bele\v skama}},
+    withcommentator = {{sa komentarom}{sa komentarom}},
+    withforeword = {{sa predgovorom}{sa predgovorom}},
+    withintroduction = {{sa uvodom}{sa uvodom}},
+}
+
+\endinput

--- a/tex/latex/biblatex/lbx/serbianc.lbx
+++ b/tex/latex/biblatex/lbx/serbianc.lbx
@@ -1,0 +1,446 @@
+\ProvidesFile{serbianc.lbx}
+[\abx@lbxid]
+
+% Translator's notes:
+%
+% This file is generated from a template and YAML localization string
+% collection by a script
+% You can said files at https://gitlab.com/andrejr/biblatex-serbian.
+% Please don't modify this file by hand -- contribute your changes upstream and
+% then send a pull request with the generated file to the official biblatex
+% repo (https://github.com/plk/biblatex).
+%
+% This is done so we could generate both `serbian.lbx` (Latin) and
+% `serbianc.lbx` (Cyrillic) from the same set of localization strings.
+
+\lbx@ifutfinput
+  {}
+  {\PackageError{biblatex}
+     {Serbian Cyrillic biblatex localization requires UTF-8 support}
+     {The 'serbianc.lbx' file requires UTF-8 encoding but you
+      seem\MessageBreak to be using a different encoding.
+      This is a fatal error. I will\MessageBreak abort loading
+      serbianc.lbx now.}%
+   \endinput}
+
+\DeclareRedundantLanguages{serbianc}{serbianc}
+
+\DeclareBibliographyExtras{%
+  \protected\def\bibrangedash{\textendash\penalty\hyphenpenalty}%
+  \protected\def\mkbibordinal#1{\stripzeros{#1}\adddot}%
+  \protected\def\mkbibmascord{\mkbibordinal}%
+  \protected\def\mkbibfemord{\mkbibordinal}%
+  \protected\def\mkbibneutord{\mkbibordinal}%
+  \protected\def\bibtimesep{.}%
+  %\savecommand\mkbibordedition
+  %\savecommand\mkbibordseries
+  \def\mkbibordedition{\mkbibordinal}%
+  \def\mkbibordseries{\mkbibfemord}%
+  \protected\def\mkbibdatelong#1#2#3{%
+    % day field
+    \iffieldundef{#3}{}{\mkbibordinal{\thefield{#3}}% if day exists, display
+      \iffieldundef{#2}{}{\nobreakspace}}% space before month if month exists
+    % month field
+    \iffieldundef{#2}{}{\mkbibmonth{\thefield{#2}}%
+      \iffieldundef{#1}{}{\space}}% space before year if year exists
+    % year field
+    \iffieldbibstring{#1}% year
+    {\bibstring{\thefield{#1}}}%
+    {\dateeraprintpre{#1}\mkbibordinal{\thefield{#1}}}}%
+  \protected\def\mkbibdateshort#1#2#3{%
+    \iffieldundef{#3}{}{\mkbibordinal{\thefield{#3}}%
+      \iffieldundef{#2}{}{\addnbspace}}%
+    \iffieldundef{#2}{}{\mkbibordinal{\thefield{#2}}%
+      \iffieldundef{#1}{}{\addnbspace}}%
+    \iffieldbibstring{#1}{\bibstring{\thefield{#1}}}%
+    {\dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}}%
+  \expandafter\protected\expandafter\def\csname mkbibtime24h%
+  \endcsname#1#2#3#4{%
+    \iffieldundef{#1}{}%
+    {\printtext{\mktimezeros{\thefield{#1}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#2}{}%
+    {\printtext{\mktimezeros{\thefield{#2}}}\setunit{\bibtimesep}}%
+    \iffieldundef{#3}{}%
+    {\printtext{\mktimezeros{\thefield{#3}}}}%
+    \setunit{}%
+    \iffieldundef{#4}{}%
+    {\bibtimezonesep%
+      \mkbibtimezone{\thefield{#4}}}}%
+  \expandafter\protected\expandafter\def\csname mkbibtime12h%
+  \endcsname#1#2#3#4{%
+    \stripzeros{\mktimehh{\thefield{#1}}}\bibtimesep%
+    \forcezerosmdt{\thefield{#2}}%
+    \iffieldundef{#3}{}
+    {\bibtimesep%
+      \forcezerosmdt{\thefield{#3}}}%
+    \space
+    \ifnumless{\thefield{#1}}{12}
+    {\bibstring{am}}
+    {\bibstring{pm}}%
+    \iffieldundef{#4}{}
+    {\space\bibtimezonesep%
+      \parentext{\mkbibtimezone{\thefield{#4}}}}}%
+  \protected\def\mkbibseasondateshort#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}%
+  \protected\def\mkbibseasondatelong#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}\adddot}%
+}
+
+\DeclareBibliographyStrings{%
+    abstract = {{апстракт}{апстракт}},
+    afterword = {{поговор}{поговор}},
+    am = {{AM}{AM}},
+    and = {{и}{и}},
+    andmore = {{и други}{и\addabbrvspace др\adddot}},
+    andothers = {{и други}{и\addabbrvspace др\adddot}},
+    annodomini = {{после Христа}{п\adddotspace Хр\adddot}},
+    annotation = {{белешка}{бел\adddot}},
+    annotations = {{белешке}{бел\adddot}},
+    annotator = {{аутор бележака}{аут\adddot\ бел\adddot}},
+    annotators = {{аутори бележака}{аут\adddot\ бел\adddot}},
+    april = {{април}{апр\adddot}},
+    astitle = {{под насловом}{под насловом}},
+    audiocd = {{аудио ЦД}{аудио ЦД}},
+    august = {{август}{авг\adddot}},
+    autumn = {{јесен}{јесен}},
+    backrefpage = {{цитирано на страници}{цит\adddot\ на стр\adddot}},
+    backrefpages = {{цитирано на страницама}{цит\adddot\ на стр\adddot}},
+    bathesis = {{бачелор рад}{БА\addabbrvspace рад}},
+    beforechrist = {{пре Христа}{пр\adddotspace Хр\adddot}},
+    beforecommonera = {{пре нове ере}{пре\addabbrvspace н\adddotspace е\adddot}},
+    bibliography = {{Библиографија}{Библиографија}},
+    book = {{књига}{књ\adddot}},
+    byannotator = {{аутор бележака}{аутор бележака}},
+    byauthor = {{аутор}{аутор}},
+    bycollaborator = {{у сарадњи са}{у сарадњи са}},
+    bycommentator = {{коментар}{коментар}},
+    bycompiler = {{одабир}{одабир}},
+    bycontinuator = {{аутор наставка}{аутор наставка}},
+    byeditor = {{уредник}{уредник}},
+    byeditoraf = {{обрада и поговор}{обрада и поговор}},
+    byeditoran = {{обрада и белешке}{обрада и белешке}},
+    byeditoranaf = {{обрада, белешке и поговор}{обрада, белешке и поговор}},
+    byeditoranfo = {{обрада, белешке и предговор}{обрада, белешке и предговор}},
+    byeditoranin = {{обрада, белешке и увод}{обрада, белешке и увод}},
+    byeditorco = {{обрада  и коментар}{обрада  и коментар}},
+    byeditorcoaf = {{обрада, коментар и поговор}{обрада, коментар и поговор}},
+    byeditorcofo = {{обрада, коментар и предговор}{обрада, коментар и предговор}},
+    byeditorcoin = {{обрада, коментар и увод}{обрада, коментар и увод}},
+    byeditorfo = {{обрада и предговор}{обрада и предговор}},
+    byeditorin = {{обрада и увод}{обрада и увод}},
+    byeditortr = {{обрада и превод}{обрада и превод}},
+    byeditortraf = {{обрада, превод и поговор}{обрада, превод и поговор}},
+    byeditortran = {{обрада, превод и белешке}{обрада, превод и белешке}},
+    byeditortranaf = {{обрада, превод, белешке и поговор}{обрада, превод, белешке и поговор}},
+    byeditortranfo = {{обрада, превод, белешке и предговор}{обрада, превод, белешке и предговор}},
+    byeditortranin = {{обрада, превод, белешке и увод}{обрада, превод, белешке и увод}},
+    byeditortrco = {{обрада, превод и коментар}{обрада, превод и коментар}},
+    byeditortrcoaf = {{обрада, превод, коментар и поговор}{обрада, превод, коментар и поговор}},
+    byeditortrcofo = {{обрада, превод, коментар и предговор}{обрада, превод, коментар и предговор}},
+    byeditortrcoin = {{обрада, превод, коментар и увод}{обрада, превод, коментар и увод}},
+    byeditortrfo = {{обрада, превод и предговор}{обрада, превод и предговор}},
+    byeditortrin = {{обрада, превод и увод}{обрада, превод и увод}},
+    byfounder = {{оснивач}{оснивач}},
+    byorganizer = {{организатор}{организатор}},
+    bypublisher = {{издавач}{издавач}},
+    byredactor = {{редактор}{редактор}},
+    byreviewer = {{рецензент}{рецензент}},
+    byreviser = {{коректор}{коректор}},
+    bytranslator = {{превод}{превод}},
+    bytranslatoraf = {{превод и поговор}{превод и поговор}},
+    bytranslatoran = {{превод и белешке}{превод и белешке}},
+    bytranslatoranaf = {{превод, белешке и поговор}{превод, белешке и поговор}},
+    bytranslatoranfo = {{превод, белешке и предговор}{превод, белешке и предговор}},
+    bytranslatoranin = {{превод, белешке и увод}{превод, белешке и увод}},
+    bytranslatorco = {{превод и коментар}{превод и коментар}},
+    bytranslatorcoaf = {{превод, коментар и поговор}{превод, коментар и поговор}},
+    bytranslatorcofo = {{превод, коментар и предговор}{превод, коментар и предговор}},
+    bytranslatorcoin = {{превод, коментар и увод}{превод, коментар и увод}},
+    bytranslatorfo = {{превод и предговор}{превод и предговор}},
+    bytranslatorin = {{превод и увод}{превод и увод}},
+    candthesis = {{кандидатски рад}{кандидатски рад}},
+    chapter = {{глава}{глава}},
+    circa = {{цирка}{cca}},
+    citedas = {{цитирано као}{цит\adddotspace као}},
+    collaborator = {{сарадник}{сар\adddot}},
+    collaborators = {{сарадници}{сар\adddot}},
+    column = {{ступац}{ступац}},
+    columns = {{ступци}{ступци}},
+    columntotal = {{ступац}{ступац}},
+    columntotals = {{ступци}{ступци}},
+    commentary = {{коментар}{ком\adddot}},
+    commentator = {{коментатор}{ком\adddot}},
+    commentators = {{коментатори}{ком\adddot}},
+    commonera = {{нове ере}{н.\addnbspace е\adddot}},
+    compiler = {{приређивач}{приређивач}},
+    compilers = {{приредили}{приредили}},
+    confer = {{cf\adddot}{cf\adddot}},
+    continuator = {{настављач}{наст\adddot}},
+    continuators = {{настављачи}{наст\adddot}},
+    countryde = {{Немачка}{ДЕ}},
+    countryep = {{Европска унија}{ЕП}},
+    countryeu = {{Европска унија}{ЕУ}},
+    countryfr = {{Француска}{ФР}},
+    countryuk = {{Велика Британија}{ГБ}},
+    countryus = {{Сједињене Америчке Државе}{САД}},
+    datacd = {{CD-ROM}{CD-ROM}},
+    december = {{децембар}{дец\adddot}},
+    edition = {{издање}{издање}},
+    editor = {{уредник}{ур\adddot}},
+    editoraf = {{уредник и аутор поговора}{уредник и аутор поговора}},
+    editoran = {{уредник и аутор бележака}{уредник и аутор бележака}},
+    editoranaf = {{уредник, аутор бележака и аутор поговора}{уредник, аутор бележака и аутор поговора}},
+    editoranfo = {{уредник, аутор бележака и аутор предговора}{уредник, аутор бележака и аутор предговора}},
+    editoranin = {{уредник, аутор бележака и аутор увода}{уредник, аутор бележака и аутор увода}},
+    editorco = {{уредник и коментатор}{уредник и коментатор}},
+    editorcoaf = {{уредник, коментатор и аутор поговора}{уредник, коментатор и аутор поговора}},
+    editorcofo = {{уредник, коментатор и аутор предговора}{уредник, коментатор и аутор предговора}},
+    editorcoin = {{уредник, коментатор и аутор увода}{уредник, коментатор и аутор увода}},
+    editorfo = {{уредник и аутор предговора}{уредник и аутор предговора}},
+    editorin = {{уредник и аутор увода}{уредник и аутор увода}},
+    editors = {{уредници}{уредници}},
+    editorsaf = {{уредници и писци поговора}{уредници и писци поговора}},
+    editorsan = {{уредници и аутори бележака}{уредници и аутори бележака}},
+    editorsanaf = {{уредници, аутори бележака и аутори поговора}{уредници, аутори бележака и аутори поговора}},
+    editorsanfo = {{уредници, аутори бележака и аутори предговора}{уредници, аутори бележака и аутори предговора}},
+    editorsanin = {{уредници, аутори бележака и аутори увода}{уредници, аутори бележака и аутори увода}},
+    editorsco = {{уредници и коментатори}{уредници и коментатори}},
+    editorscoaf = {{уредници, коментатори и писци поговора}{уредници, коментатори и писци поговора}},
+    editorscofo = {{уредници, коментатори и аутори предговора}{уредници, коментатори и аутори предговора}},
+    editorscoin = {{уредници, коментатори и аутори увода}{уредници, коментатори и аутори увода}},
+    editorsfo = {{уредници и писци предговора}{уредници и писци предговора}},
+    editorsin = {{уредници и аутори увода}{уредници и аутори увода}},
+    editorstr = {{уредници и преводиоци}{уредници и преводиоци}},
+    editorstraf = {{уредници, преводиоци и аутори поговора}{уредници, преводиоци и аутори поговора}},
+    editorstran = {{уредници, преводиоци и аутори бележака}{уредници, преводиоци и аутори бележака}},
+    editorstranaf = {{уредници, преводиоци, аутори бележака и писци поговора}{уредници, преводиоци, аутори бележака и писци поговора}},
+    editorstranfo = {{уредници, преводиоци, аутори бележака и аутори предговора}{уредници, преводиоци, аутори бележака и аутори предговора}},
+    editorstranin = {{уредници, преводиоци, аутори бележака и аутори увода}{уредници, преводиоци, аутори бележака и аутори увода}},
+    editorstrco = {{уредници, преводиоци и коментатори}{уредници, преводиоци и коментатори}},
+    editorstrcoaf = {{уредници, преводиоци, коментатори и писци поговора}{уредници, преводиоци, коментатори и писци поговора}},
+    editorstrcofo = {{уредници, преводиоци, коментатори и аутори предговора}{уредници, преводиоци, коментатори и аутори предговора}},
+    editorstrcoin = {{уредници, преводиоци, коментатори и аутори увода}{уредници, преводиоци, коментатори и аутори увода}},
+    editorstrfo = {{уредници, преводиоци и аутори предговора}{уредници, преводиоци и аутори предговора}},
+    editorstrin = {{уредници, преводиоци и аутори увода}{уредници, преводиоци и аутори увода}},
+    editortr = {{уредник и преводилац}{уредник и преводилац}},
+    editortraf = {{уредник, преводилац и аутор поговора}{уредник, преводилац и аутор поговора}},
+    editortran = {{уредник, преводилац и аутор бележака}{уредник, преводилац и аутор бележака}},
+    editortranaf = {{уредник, преводилац, аутор бележака и аутор поговора}{уредник, преводилац, аутор бележака и аутор поговора}},
+    editortranfo = {{уредник, преводилац, аутор бележака и аутор предговора}{уредник, преводилац, аутор бележака и аутор предговора}},
+    editortranin = {{уредник, преводилац, аутор бележака и аутор увода}{уредник, преводилац, аутор бележака и аутор увода}},
+    editortrco = {{уредник, преводилац и коментатор}{уредник, преводилац и коментатор}},
+    editortrcoaf = {{уредник, преводилац, коментатор и аутор поговора}{уредник, преводилац, коментатор и аутор поговора}},
+    editortrcofo = {{уредник, преводилац, коментатор и аутор предговора}{уредник, преводилац, коментатор и аутор предговора}},
+    editortrcoin = {{уредник, преводилац, коментатор и аутор увода}{уредник, преводилац, коментатор и аутор увода}},
+    editortrfo = {{уредник, преводилац и аутор предговора}{уредник, преводилац и аутор предговора}},
+    editortrin = {{уредник, преводилац и аутор увода}{уредник, преводилац и аутор увода}},
+    february = {{фебруар}{феб\adddot}},
+    file = {{датотека}{датотека}},
+    foreword = {{предговор}{предговор}},
+    forthcoming = {{долазеће}{долазеће}},
+    founder = {{оснивач}{осн\adddot}},
+    founders = {{оснивачи}{осн\adddot}},
+    fromamerican = {{са америчког}{са америчког}},
+    frombrazilian = {{са бразилског}{са бразилског}},
+    frombulgarian = {{са бугарског}{са бугарског}},
+    fromcatalan = {{са каталонског}{са каталонског}},
+    fromcroatian = {{са хрватског}{са хрватског}},
+    fromczech = {{са чешког}{са чешког}},
+    fromdanish = {{са данског}{са данског}},
+    fromdutch = {{са холандског}{са холандског}},
+    fromenglish = {{са енглеског}{са енглеског}},
+    fromestonian = {{са естонског}{са естонског}},
+    fromfinnish = {{са финског}{са финског}},
+    fromfrench = {{са француског}{са француског}},
+    fromgalician = {{са галицијског}{са галицијског}},
+    fromgerman = {{са немачког}{са немачког}},
+    fromgreek = {{са грчког}{са грчког}},
+    fromhungarian = {{са мађарског}{са мађарског}},
+    fromitalian = {{са италијанског}{са италијанског}},
+    fromjapanese = {{са јапанског}{са јапанског}},
+    fromlatin = {{са латинског}{са латинског}},
+    fromlatvian = {{са летонског}{са летонског}},
+    fromnorwegian = {{са норвешког}{са норвешког}},
+    frompolish = {{са пољског}{са пољског}},
+    fromportuguese = {{са португалског}{са португалског}},
+    fromrussian = {{са руског}{са руског}},
+    fromslovak = {{са словачког}{са словачког}},
+    fromslovene = {{са словеначког}{са словеначког}},
+    fromspanish = {{са шпанског}{са шпанског}},
+    fromswedish = {{са шведског}{са шведског}},
+    fromukrainian = {{са украјинског}{са украјинског}},
+    ibidem = {{ibidem}{ibid\adddot}},
+    idem = {{idem}{idem}},
+    idempf = {{eaedem}{eaedem}},
+    idempm = {{eidem}{eidem}},
+    idempn = {{eadem}{eadem}},
+    idempp = {{eidem}{eidem}},
+    idemsf = {{eadem}{eadem}},
+    idemsm = {{idem}{idem}},
+    idemsn = {{idem}{idem}},
+    in = {{у}{у}},
+    inpreparation = {{у припреми}{у припреми}},
+    inpress = {{у штампи}{у штампи}},
+    inseries = {{у}{у}},
+    introduction = {{увод}{ув\adddot}},
+    involumes = {{у}{у}},
+    issue = {{издање}{издање}},
+    january = {{јануар}{јан\adddot}},
+    jourser = {{серија}{сер\adddot}},
+    jourvol = {{свеска}{св\adddot}},
+    july = {{јул}{јул}},
+    june = {{јун}{јун}},
+    langamerican = {{амерички}{амерички}},
+    langbrazilian = {{бразилски}{бразилски}},
+    langbulgarian = {{бугарски}{бугарски}},
+    langcatalan = {{каталански}{каталански}},
+    langcroatian = {{хрватски}{хрватски}},
+    langczech = {{чешки}{чешки}},
+    langdanish = {{дански}{дански}},
+    langdutch = {{холандски}{холандски}},
+    langenglish = {{енглески}{енглески}},
+    langestonian = {{естонски}{естонски}},
+    langfinnish = {{фински}{фински}},
+    langfrench = {{француски}{француски}},
+    langgalician = {{галицијски}{галицијски}},
+    langgerman = {{немачки}{немачки}},
+    langgreek = {{грчки}{грчки}},
+    langhungarian = {{мађарски}{мађарски}},
+    langitalian = {{италијански}{италијански}},
+    langjapanese = {{јапански}{јапански}},
+    langlatin = {{латински}{латински}},
+    langlatvian = {{летонски}{летонски}},
+    langnorwegian = {{норвешки}{норвешки}},
+    langpolish = {{пољски}{пољски}},
+    langportuguese = {{португалски}{португалски}},
+    langrussian = {{руски}{руски}},
+    langslovak = {{словачки}{словачки}},
+    langslovene = {{словеначки}{словеначки}},
+    langspanish = {{шпански}{шпански}},
+    langswedish = {{шведски}{шведски}},
+    langukrainian = {{украјински}{украјински}},
+    library = {{библиотека}{библиотека}},
+    line = {{ред}{р\adddot}},
+    lines = {{редови}{р\adddot}},
+    linetotal = {{ред}{р\adddot}},
+    linetotals = {{редови}{р\adddot}},
+    loccit = {{loc\adddotspace cit\adddot}{loc\adddotspace cit\adddot}},
+    march = {{март}{мар\adddot}},
+    mathesis = {{мастер рад}{мастер рад}},
+    may = {{мај}{мај}},
+    newseries = {{нова серија}{нова серија}},
+    nodate = {{без датума}{без датума}},
+    november = {{новембар}{нов\adddot}},
+    number = {{број}{бр\adddot}},
+    october = {{октобар}{окт\adddot}},
+    ofseries = {{серија}{сер\adddot}},
+    oldseries = {{стара серија}{стара серија}},
+    opcit = {{op\adddotspace cit\adddot}{op\adddotspace cit\adddot}},
+    organizer = {{организатор}{орг\adddot}},
+    organizers = {{организатори}{орг\adddot}},
+    origpubas = {{оригинално издато као}{оригинално издато као}},
+    origpubin = {{оригинално издато}{оригинално издато}},
+    page = {{страна}{стр\adddot}},
+    pages = {{стране}{стр\adddot}},
+    pagetotal = {{страна}{стр\adddot}},
+    pagetotals = {{стране}{стр\adddot}},
+    paragraph = {{пасус}{пас\adddot}},
+    paragraphs = {{пасуси}{пас\adddot}},
+    paragraphtotal = {{пасус}{пас\adddot}},
+    paragraphtotals = {{пасуси}{пас\adddot}},
+    part = {{део}{део}},
+    passim = {{passim}{pass\adddot}},
+    patent = {{патент}{пат\adddot}},
+    patentde = {{немачки патент}{нем\adddot\ пат\adddot}},
+    patenteu = {{европски патент}{евр\adddot\ пат\adddot}},
+    patentfr = {{француски патент}{франц\adddot\ пат\adddot}},
+    patentuk = {{британски патент}{брит\adddot\ пат\adddot}},
+    patentus = {{САД патент}{САД пат\adddot}},
+    patreq = {{захтев за патент}{захтев за патент}},
+    patreqde = {{немачки захтев за патент}{немачки захтев за патент}},
+    patreqeu = {{европски захтев за патент}{европски захтев за патент}},
+    patreqfr = {{француски захтев за патент}{француски захтев за патент}},
+    patrequk = {{британски захтев за патент}{британски захтев за патент}},
+    patrequs = {{САД захтев за патент}{САД захтев за патент}},
+    phdthesis = {{докторска теза}{докторска теза}},
+    pm = {{PM}{PM}},
+    prepublished = {{прелиминарно издање}{прелиминарно издање}},
+    quotedin = {{цитирано у}{цит\adddotspace у}},
+    redactor = {{редактор}{ред\adddot}},
+    redactors = {{редактори}{ред\adddot}},
+    references = {{Литература}{Литература}},
+    reprint = {{репринт}{репринт}},
+    reprintas = {{поново издато као као}{поново издато као као}},
+    reprintfrom = {{репринт из}{репринт из}},
+    reprintof = {{репринт}{репринт}},
+    resreport = {{истраживачки извештај}{истраживачки извештај}},
+    reviewof = {{рецензија}{рецензија}},
+    reviser = {{коректор}{коректор}},
+    revisers = {{коректори}{коректори}},
+    section = {{секција}{сек\adddot}},
+    sections = {{секције}{сек\adddot}},
+    sectiontotal = {{секција}{сек\adddot}},
+    sectiontotals = {{секције}{сек\adddot}},
+    see = {{види}{види}},
+    seealso = {{види\addabbrvspace и}{види}},
+    seenote = {{види фусноту}{види фусноту}},
+    september = {{септембар}{септ\adddot}},
+    sequens = {{sq\adddot}{sq\adddot}},
+    sequentes = {{sqq\adddot}{sqq\adddot}},
+    shorthands = {{Списак скраћеница}{Скраћенице}},
+    software = {{рачунарски софтвер}{рач\adddot\ софтвер}},
+    spring = {{пролеће}{пролеће}},
+    submitted = {{послато}{послато}},
+    summer = {{лето}{лето}},
+    techreport = {{технички извештај}{техн\adddotspace изв\adddot}},
+    thiscite = {{посебно}{посебно}},
+    translationas = {{преведено као}{преведено као}},
+    translationfrom = {{преведено са}{преведено са}},
+    translationof = {{превод}{превод}},
+    translator = {{преводилац}{преводилац}},
+    translatoraf = {{преводилац и аутор поговора}{преводилац и аутор поговора}},
+    translatoran = {{преводилац и анотатор}{преводилац и анотатор}},
+    translatoranaf = {{преводилац, аутор анотација и аутор поговора}{преводилац, аутор анотација и аутор поговора}},
+    translatoranfo = {{преводилац, аутор анотација и аутор предговора}{преводилац, аутор анотација и аутор предговора}},
+    translatoranin = {{преводилац, аутор анотација и аутор увода}{преводилац, аутор анотација и аутор увода}},
+    translatorco = {{преводилац и коментатор}{преводилац и коментатор}},
+    translatorcoaf = {{преводилац, коментар и аутор поговора}{преводилац, коментар и аутор поговора}},
+    translatorcofo = {{преводилац, коментар и аутор предговора}{преводилац, коментар и аутор предговора}},
+    translatorcoin = {{преводилац, коментар и аутор увода}{преводилац, коментар и аутор увода}},
+    translatorfo = {{преводилац и аутор предговора}{преводилац и аутор предговора}},
+    translatorin = {{преводилац и аутор увода}{преводилац и аутор увода}},
+    translators = {{преводиоци}{преводиоци}},
+    translatorsaf = {{преводилац и аутор поговора}{преводилац и аутор поговора}},
+    translatorsan = {{преводиоци и аутори белешки}{преводиоци и аутори белешки}},
+    translatorsanaf = {{преводилац, аутор анотација и аутор поговора}{преводилац, аутор анотација и аутор поговора}},
+    translatorsanfo = {{преводилац, аутор анотација и аутор предговора}{преводилац, аутор анотација и аутор предговора}},
+    translatorsanin = {{преводилац, аутор анотација и аутор увода}{преводилац, аутор анотација и аутор увода}},
+    translatorsco = {{преводиоци и коментатори}{преводиоци и коментатори}},
+    translatorscoaf = {{преводилац, коментар и аутор поговора}{преводилац, коментар и аутор поговора}},
+    translatorscofo = {{преводилац, коментар и аутор предговора}{преводилац, коментар и аутор предговора}},
+    translatorscoin = {{преводилац, коментар и аутор увода}{преводилац, коментар и аутор увода}},
+    translatorsfo = {{преводилац и аутор предговора}{преводилац и аутор предговора}},
+    translatorsin = {{преводилац и аутор увода}{преводилац и аутор увода}},
+    url = {{адреса}{адреса}},
+    urlfrom = {{доступно на}{доступно на}},
+    urlseen = {{посећено}{посећено}},
+    verse = {{строфа}{стр\adddot}},
+    verses = {{строфе}{стр\adddot}},
+    versetotal = {{строфа}{стр\adddot}},
+    versetotals = {{строфе}{стр\adddot}},
+    version = {{верзија}{верзија}},
+    volume = {{свеска}{св\adddot}},
+    volumes = {{свеске}{св\adddot}},
+    winter = {{зима}{зима}},
+    withafterword = {{са поговором}{са поговором}},
+    withannotator = {{са белешкама}{са белешкама}},
+    withcommentator = {{са коментаром}{са коментаром}},
+    withforeword = {{са предговором}{са предговором}},
+    withintroduction = {{са уводом}{са уводом}},
+}
+
+\endinput


### PR DESCRIPTION
As announced in #937, here's a Serbian (Cyrillic and Latin) localization for Biblatex.

The files are generated from a common template and YAML string collection by a script.
All of these files can be found at <https://gitlab.com/andrejr/biblatex-serbian>.

Please don't modify these files directly as they are generated - contribute your changes upstream and then send a pull request with the generated file to this repo.

This is done so we could generate both `serbian.lbx` (Latin) and `serbianc.lbx` (Cyrillic) from the same set of localization strings and with the same date format, ordinal format, and other extras.