### PR TITLE
Print \intitlepunct with \printunit (#943)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -1,3 +1,27 @@
+# RELEASE NOTES FOR VERSION 3.15
+- Fixed a long-standing issue with `\intitlepunct`.
+  The old definition
+  ```
+  \newbibmacro*{in:}{%
+    \printtext{%
+      \bibstring{in}\intitlepunct}}
+  ```
+  would print `\intitlepunct` directly and not via the punctuation
+  buffer. Since the `\add...` punctuation macros guard against
+  undesired double punctuation, this would usually not show as an
+  issue (except in edge cases https://tex.stackexchange.com/q/175730/,
+  https://github.com/plk/biblatex/issues/943).
+  The new definition uses the punctuation tracker to print
+  `\intitlepunct`.
+  ```
+  \newbibmacro*{in:}{%
+    \bibstring{in}%
+    \printunit{\intitlepunct}}
+  ```
+  `\printunit` is needed instead of `\setunit` to stop subsequent
+  `\setunit`s from overriding `\intitlepunct` in case of missing
+  fields.
+
 # RELEASE NOTES FOR VERSION 3.14
 - biber from version 2.14 has extended, granular XDATA functionality to
   allow referencing from and to parts of fields. This makes XDATA entries into
@@ -7,6 +31,7 @@
   Note that `polyglossia` v1.45 (2019/10/27) is required for this
   to work properly, it is strongly recommended to update `polyglossia`
   to this or a later (current) version.
+
 # RELEASE NOTES FOR VERSION 3.13
 - **INCOMPATIBLE CHANGE** Any custom per-entry options in datasources must
   be defined with `\DeclareEntryOption` in order for biber to recognise

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -2861,8 +2861,8 @@
        \printfield[titlecase]{issuesubtitle}}}}
 
 \newbibmacro*{in:}{%
-  \printtext{%
-    \bibstring{in}\intitlepunct}}
+  \bibstring{in}%
+  \printunit{\intitlepunct}}
 
 \newbibmacro*{date}{\printdate}
 


### PR DESCRIPTION
Going via the punctuation tracker with `\printunit` seems much more appropriate than printing punctuation in `\printtext` if the following text can't be controlled.

Thanks to the hard work of the `\add...` macros undesirable punctuation would be suppressed anyway, but in some edge cases e.g. https://tex.stackexchange.com/q/175730/ and https://github.com/plk/biblatex/issues/943 that is not enough.

---

Of course this is a change to a much-used general macro, so there is a chance this might break something. I am hopeful that people don't actually patch `in:` and if people overwrite the definition, they should be fine either way.