### PR TITLE
replaced most  occurences; fixes #952

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3180,7 +3180,7 @@
        {\bibstring{#1s}\ppspace}
        {\def\pno{\bibstring{#1}}%
         \def\ppno{\bibstring{#1s}}}}%
-  \blx@mkpageprefix@i[#2]{#3}}
+  \blx@mkpageprefix@i[{#2}]{#3}}
 
 \long\def\blx@mkpageprefix@i[#1]#2{#1{#2}\endgroup}
 
@@ -3243,7 +3243,7 @@
   \@ifnextchar[{\blx@range@aux@i#1}{#1[\@firstofone][\@firstofone]}}
 
 \def\blx@range@aux@i#1[#2]{%
-  \@ifnextchar[{#1[#2]}{#1[#2][\@firstofone]}}
+  \@ifnextchar[{#1[{#2}]}{#1[{#2}][\@firstofone]}}
 
 \def\blx@normrange@i[#1][#2]#3{%
   \let\blx@tempa\@empty
@@ -3597,7 +3597,7 @@
   \blx@cleardelim{#2}%
   \ifblank{#1}
     {\blx@declaredelim{#2}{#3}}
-    {\blx@declaredelim[#1]{#2}{#3}}}
+    {\blx@declaredelim[{#1}]{#2}{#3}}}
 
 \newrobustcmd*{\blx@declaredelim}[3][]{%
   \ifblank{#1}
@@ -4472,7 +4472,7 @@
   \iftoggle{blx@loadfiles}
     {\IfFileExists{#2}
        {\listxadd\blx@list@req@edit{#2}%
-        \blx@imc@printtext[#1]{\input{#2}\unspace}}
+        \blx@imc@printtext[{#1}]{\input{#2}\unspace}}
        {\blx@nounit}}
     {\blx@nounit}}
 
@@ -5717,13 +5717,13 @@
           {\iffieldsequal{#1minute}{#1endminute}
              % 14:13:xx 14:13:xx
              {\toggletrue{blx@seconds}%
-              \printtext[#1time]{%
+              \printtext[{#1time}]{%
                 \csuse{mkbibtime24h}{#1hour}{#1minute}{#1second}{}%
               \bibtimerangesep
               \csuse{mkbibtime24h}{}{}{#1endsecond}{}}}
              % 14:13:xx 14:14:xx
              {\toggletrue{blx@seconds}%
-              \printtext[#1time]{\csuse{mkbibtime24h}{#1hour}{#1minute}{}{}%
+              \printtext[{#1time}]{\csuse{mkbibtime24h}{#1hour}{#1minute}{}{}%
               \bibtimerangesep
               \csuse{mkbibtime24h}{}{#1endminute}{}{}}}}
           % 14:xx:xx 15:xx:xx
@@ -5734,7 +5734,7 @@
   \iffieldundef{#2hour}
     {\blx@nounit}
     {\blx@timepre{#2}{}%
-     \printtext[#2time]{\csuse{mkbibtime#1}{#2hour}{#2minute}{#2second}{#2timezone}%
+     \printtext[{#2time}]{\csuse{mkbibtime#1}{#2hour}{#2minute}{#2second}{#2timezone}%
      \iffieldundef{#2endhour}
        {}
        {\blx@timepre{#2}{end}%
@@ -5768,7 +5768,7 @@
   \blx@if@printtime{#1}{#2}
     {\blx@timepre{#1}{#2}%
      \printtext{\bibdatetimesep}%
-     \printtext[#1time]{%
+     \printtext[{#1time}]{%
        \csuse{mkbibtime\csuse{blx@timeformat@#1time}}
          {#1#2hour}{#1#2minute}{#1#2second}{#1#2timezone}}}
     {}}
@@ -5779,7 +5779,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          % Such a season component can only come from an ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -5810,7 +5810,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          % Such a season component can only come from an ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -5849,7 +5849,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          % Such a season component can only come from an ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -5890,7 +5890,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          % Such a season component can only come from an ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -5950,7 +5950,7 @@
     \blx@metadateinfo{#1}%
     \iffieldundef{#1year}
       {\blx@nounit}
-      {\printtext[#1date]{%
+      {\printtext[{#1date}]{%
          \datecircaprint
          % Such a season component can only come from an  ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -5982,7 +5982,7 @@
     \blx@metadateinfo{#1}%
     \iffieldundef{#1year}
       {\blx@nounit}
-      {\printtext[#1date]{%
+      {\printtext[{#1date}]{%
          \datecircaprint
          % Such a season component can only come from an ISO8601 season which replaces
          % a normal month so if it exists, we know that a normal date print is ruled out
@@ -6042,7 +6042,7 @@
     \def\bibdatetimesep{T}%
     \iffieldundef{#1year}
       {\blx@nounit}
-      {\printtext[#1date]{%
+      {\printtext[{#1date}]{%
          \blx@isodate{#1}{}%
          \ifboolexpr{%
            togl {blx@#1dateusetime}
@@ -6074,7 +6074,7 @@
     \def\bibdatetimesep{T}%
     \iffieldundef{#1year}
       {\blx@nounit}
-      {\printtext[#1date]{%
+      {\printtext[{#1date}]{%
          \blx@isodate[extradate]{#1}{}%
          \ifboolexpr{%
            togl {blx@#1dateusetime}
@@ -6693,7 +6693,7 @@
     {\ifcsundef{KV@blx@opt@pre@#1}
        {\ifblank{#2}
           {\define@key{blx@opt@pre}{#1}{#3}}
-          {\define@key{blx@opt@pre}{#1}[#2]{#3}}}
+          {\define@key{blx@opt@pre}{#1}[{#2}]{#3}}}
        {\blx@err@optdef{#1}{pre/global}}}
     {\blx@err@optdef{#1}{ldt/global}}}
 
@@ -6701,7 +6701,7 @@
   \ifcsundef{KV@blx@opt@#1@#2}
     {\ifblank{#3}
        {\define@key{blx@opt@#1}{#2}{#4}}
-       {\define@key{blx@opt@#1}{#2}[#3]{#4}}}
+       {\define@key{blx@opt@#1}{#2}[{#3}]{#4}}}
     {\blx@err@optdef{#2}{#1}}}
 
 \def\blx@defblxopt@typeopt{\blx@defblxopt@typeentryopt{typ}}
@@ -6722,10 +6722,10 @@
 \forcsvlist{\listadd\blx@optscopes}{global,type,entry}
 
 \long\def\blx@defblxopt@loopscopes@i#1[#2]#3#4{%
-  \csuse{blx@defblxopt@#4opt}{#1}[#2]{#3}}
+  \csuse{blx@defblxopt@#4opt}{#1}[{#2}]{#3}}
 
 \long\def\blx@defblxopt@loopscopes#1[#2]#3{%
-  \forlistloop{\blx@defblxopt@loopscopes@i{#1}[#2]{#3}}{\blx@optscopes}}
+  \forlistloop{\blx@defblxopt@loopscopes@i{#1}[{#2}]{#3}}{\blx@optscopes}}
 
 % {<option scopes>}[<datatype>]{<key>}[<default value>]{<code>}
 \newrobustcmd*{\DeclareBiblatexOption}[1]{%
@@ -8756,7 +8756,7 @@
 
 \def\blx@defbibheading#1[#2]{%
   \csundef{#1}%
-  \expandafter\newcommand\csname#1\endcsname[1][#2]}
+  \expandafter\newcommand\csname#1\endcsname[1][{#2}]}
 
 % {<name>}{<text>}
 \newrobustcmd*{\defbibnote}[1]{%
@@ -9392,7 +9392,7 @@
   \let\newrefsegment\relax
   \ifblank{#2}
     {\csuse{blx@head@#1}}
-    {\csuse{blx@head@#1}[#2]}%
+    {\csuse{blx@head@#1}[{#2}]}%
   \let\newrefsection\blx@newrefsection
   \let\newrefsegment\blx@newrefsegment}
 
@@ -9779,8 +9779,8 @@
 
 \def\refcontext@i[#1]{%
   \@ifnextchar\bgroup
-    {\refcontext@ii[#1]}
-    {\refcontext@ii[#1]{}}}
+    {\refcontext@ii[{#1}]}
+    {\refcontext@ii[{#1}]{}}}
 
 \newcommand*{\refcontext@ii}[2][]{%
   \iftoggle{blx@refcontext}
@@ -11470,7 +11470,7 @@
 \long\def\blx@citexpunct@i#1#2#3#4{%
   \@ifnextchar[%]
     {\blx@citexpunct@ii{#1}{{#2}{#3}{#4}}}
-    {\blx@citexpunct@ii{#1}{{#2}{#3}{#4}}[#1]}}
+    {\blx@citexpunct@ii{#1}{{#2}{#3}{#4}}[{#1}]}}
 \long\def\blx@citexpunct@ii#1#2[#3]#4{%
   \blx@thecheckpunct{\blxcitecmd{#1}#2{#3}{#4}}}
 
@@ -11898,7 +11898,7 @@
     \ifnameundef{#5}
       {\blx@warning@entry{'#5' undefined or not a name list}%
        \abx@missing{#5}}
-      {\printnames[#4]{#5}}}%
+      {\printnames[{#4}]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
@@ -11926,7 +11926,7 @@
     \iflistundef{#5}
       {\blx@warning@entry{'#5' undefined or not a literal list}%
        \abx@missing{#5}}
-      {\printlist[#4]{#5}}}%
+      {\printlist[{#4}]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}
@@ -11955,7 +11955,7 @@
     \iffieldundef{#5}
       {\blx@warning@entry{'#5' undefined or not a field}%
        \abx@missing{#5}}
-      {\printfield[#4]{#5}}}%
+      {\printfield[{#4}]{#5}}}%
   \def\blx@dlimcode{\multicitedelim}%
   \def\blx@postpunct@saved{#6}%
   \ifblank{#2}

--- a/tex/latex/biblatex/blx-mcite.def
+++ b/tex/latex/biblatex/blx-mcite.def
@@ -31,7 +31,7 @@
   \let\blx@mclike@tempb\@empty
   \let\blx@mclike@tempc\@empty
   \blx@xsanitizeafter\blx@mclike@i{#4}%
-  \edef\blx@mclike@tempa{\endgroup\unexpanded{#1[#2][#3]}{\blx@mclike@tempa}}%
+  \edef\blx@mclike@tempa{\endgroup\unexpanded{#1[{#2}][{#3}]}{\blx@mclike@tempa}}%
   \blx@mclike@tempa}
 
 \def\blx@mclike@i#1{%

--- a/tex/latex/biblatex/lbx/english.lbx
+++ b/tex/latex/biblatex/lbx/english.lbx
@@ -570,7 +570,7 @@ canadian,australian,newzealand,USenglish,UKenglish}
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}
@@ -609,7 +609,7 @@ canadian,australian,newzealand,USenglish,UKenglish}
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}
@@ -644,7 +644,7 @@ canadian,australian,newzealand,USenglish,UKenglish}
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}
@@ -685,7 +685,7 @@ canadian,australian,newzealand,USenglish,UKenglish}
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}

--- a/tex/latex/biblatex/lbx/latvian.lbx
+++ b/tex/latex/biblatex/lbx/latvian.lbx
@@ -146,7 +146,7 @@
   % this redefines \mkpageprefix to put the page number as suffix
   \savecommand\blx@mkpageprefix
   \protected\long\def\blx@mkpageprefix#1[#2]#3{%
-    \blx@mkpageprefix@i[#2]{#3}%
+    \blx@mkpageprefix@i[{#2}]{#3}%
     \ifnumeral{#3}
       {\ppspace\bibstring{#1}}
       {\ifnumerals{#3}
@@ -716,7 +716,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}
@@ -754,7 +754,7 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {\blx@nounit}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\ifdateyearsequal{#2}{#2end}

--- a/tex/latex/biblatex/lbx/magyar.lbx
+++ b/tex/latex/biblatex/lbx/magyar.lbx
@@ -111,7 +111,7 @@
   % this redefines \mkpageprefix to put the page number as suffix
   \savecommand\blx@mkpageprefix
   \protected\long\def\blx@mkpageprefix#1[#2]#3{%
-    \blx@mkpageprefix@i[#2]{#3}%
+    \blx@mkpageprefix@i[{#2}]{#3}%
     \ifnumeral{#3}
       {\ppspace\bibstring{#1}}
       {\ifnumerals{#3}
@@ -659,7 +659,7 @@
     \edef\lbx@hu@dayrange{\lbx@hu@dayrange@i{#2}}%
     \iffieldundef{#2year}
       {}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%
@@ -699,7 +699,7 @@
     \edef\lbx@hu@dayrange{\lbx@hu@dayrange@i{#2}}%
     \iffieldundef{#2year}
       {}
-      {\printtext[#2date]{%
+      {\printtext[{#2date}]{%
          \datecircaprint
          \iffieldundef{#2season}
            {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%


### PR DESCRIPTION
I just searched for occurrences of `[#` (outside of the parameter text of `\def`) and replaced those occurrences with properly braced ones like `[{#2}]` or `[{#2date}]`. I did that without too much code digging, it should work out of the box (and a very small test on the example document from https://tex.stackexchange.com/questions/522902 did indeed work) but I can't guarantee that this won't break things.

This should fix #952 .