### PR TITLE
Compress subentry set references in numeric-comp (#900)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -28,6 +28,17 @@
   `biblatex` no longer falls back to English for unknown languages.
   Warnings will be triggered if undefined language strings or extras
   are used.
+- Added `subentrycomp` option to `numeric-comp` citation style.
+  The option is only relevant with `subentry=true`.
+  With `subentrycomp=true` set citations will be compressed
+  to "1a-c" instead of "1a; 1b; 1c".
+  The option is mainly intended for backwards compatibility,
+  the behaviour of previous `biblatex` versions can be restored
+  with `subentrycomp=false`.
+- Added `\multiciterangedelim`, `\multicitesubentrydelim`,
+  `\multicitesubentryrangedelim`, `\superciterangedelim`,
+  `\supercitesubentrydelim`, and `\supercitesubentryrangedelim` for
+  finer control over (compressed) subentry citations in `numeric-comp`.
 
 # RELEASE NOTES FOR VERSION 3.14
 - biber from version 2.14 has extended, granular XDATA functionality to

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -28,6 +28,9 @@
   `biblatex` no longer falls back to English for unknown languages.
   Warnings will be triggered if undefined language strings or extras
   are used.
+- **INCOMPATIBLE CHANGE** `numeric-comp` compresses subentry set
+  references now.
+  This behaviour can be disabled with `subentrycomp=false`.
 - Added `subentrycomp` option to `numeric-comp` citation style.
   The option is only relevant with `subentry=true`.
   With `subentrycomp=true` set citations will be compressed

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -14195,6 +14195,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{release}{3.15}{20??-??-??}
 \item Added \cmd{mautocite} and \cmd{Mautocite}\see{use:cit:mct}
 \item Added \cmd{NumsCheckSetup} and \cmd{PagesCheckSetup}\see{aut:aux:msc}
+\item \texttt{numeric-comp} compresses \opt{subentry} set references now\see{use:opt:pre:bbx}
 \item Added \opt{subentrycomp} to \texttt{numeric-comp} style\see{use:opt:pre:bbx}
 \item Added \cmd{multiciterangedelim}, \cmd{multicitesubentrydelim},
       \cmd{multicitesubentryrangedelim}, \cmd{superciterangedelim},

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -2563,6 +2563,18 @@ Suppose \texttt{key1} and \texttt{key2} are members of the set \texttt{set1}. Wi
 
 \end{optionlist}
 
+\subparagraph{\texttt{numeric-comp}} The citation style \texttt{numeric-comp}  supports the \opt{subentrycomp} option in global, per-type and per-entry scope.
+
+\boolitem[true]{subentrycomp}
+
+This option determines whether or not citations to set members are compressed similar to non-set citations. The option only has an effect if \opt{subentry} is set to \texttt{true}.
+
+Suppose \texttt{key1}, \texttt{key2} and \texttt{key3} are members of the set \texttt{set1}. With \opt{subentrycomp} set to \texttt{true} the three entries will be compressed to <[1a\multicitesubentryrangedelim c]> in citations. With \opt{subentry} set to \texttt{false} the citation will show in the more verbose form <[1a; 1b; 1c]>.
+
+The option is intended mainly for backwards compatibility, because earlier versions of \biblatex did not compress set member citations.
+
+\end{optionlist}
+
 \subparagraph{\texttt{authortitle}/\texttt{authoryear}} All bibliography styles of the \texttt{authoryear} and \texttt{authortitle} family as well as all bibliography styles of the \texttt{verbose} family---whose bibliography styles are based on \texttt{authortitle}---support the option \opt{dashed} in global scope.
 
 \begin{optionlist}
@@ -4958,8 +4970,26 @@ The delimiter printed before the localisation string <\texttt{andmore}> if a lit
 \csitem{multicitedelim}
 The delimiter printed between citations if multiple entry keys are passed to a single citation command. The default is a semicolon plus an interword space.
 
+\csitem{multiciterangedelim}
+The delimiter printed between two citations if they are compressed to a range. The default is \cmd{bibrangedash}.
+
+\csitem{multicitesubentrydelim}
+The delimiter printed between subentry citations of the same set. This delimiter is only used in citation styles that reduce citations of the same set to a more compact form (\opt{subentry} of \texttt{numeric-comp}). The default is a comma.
+
+\csitem{multicitesubentryrangedelim}
+The delimiter printed between two citations of the same set if they are compressed to a range. The default is \cmd{multiciterangedelim}.
+
 \csitem{supercitedelim}
 Similar to \cmd{multicitedelim}, but used by the \cmd{supercite} command only. The default is a comma.
+
+\csitem{superciterangedelim}
+Analogue of \cmd{multiciterangedelim} for \cmd{supercite}. The default is \cmd{bibrangedash}.
+
+\csitem{supercitesubentrydelim}
+Analogue of \cmd{multicitesubentrydelim} for \cmd{supercite}. The default is \cmd{supercitedelim}.
+
+\csitem{supercitesubentryrangedelim}
+Analogue of \cmd{multicitesubentryrangedelim} for \cmd{supercite}. The default is \cmd{superciterangedelim}.
 
 \csitem{compcitedelim}
 Similar to \cmd{multicitedelim}, but used by certain citation styles when <compressing> multiple citations. The default definition is a comma plus an interword space.
@@ -12017,8 +12047,26 @@ The delimiter to be printed before the localisation string <\texttt{andmore}> if
 \csitem{multicitedelim}
 The delimiter printed between citations if multiple entry keys are passed to a single citation command. This command should be incorporated in the definition of all citation commands, for example in the \prm{sepcode} argument passed to \cmd{DeclareCiteCommand}. See \secref{aut:cbx:cbx} for details. The default is a semicolon plus an interword space.
 
+\csitem{multiciterangedelim}
+The delimiter printed between two citations if they are compressed to a range. The default is \cmd{bibrangedash}.
+
+\csitem{multicitesubentrydelim}
+The delimiter printed between subentry citations of the same set. This delimiter is only used in citation styles that reduce citations of the same set to a more compact form (\opt{subentry} of \texttt{numeric-comp}). The default is a comma.
+
+\csitem{multicitesubentryrangedelim}
+The delimiter printed between two citations of the same set if they are compressed to a range. The default is \cmd{multiciterangedelim}.
+
 \csitem{supercitedelim}
 Similar to \cmd{multinamedelim}, but intended for the \cmd{supercite} command only. The default is a comma.
+
+\csitem{superciterangedelim}
+Analogue of \cmd{multiciterangedelim} for \cmd{supercite}. The default is \cmd{bibrangedash}.
+
+\csitem{supercitesubentrydelim}
+Analogue of \cmd{multicitesubentrydelim} for \cmd{supercite}. The default is \cmd{supercitedelim}.
+
+\csitem{supercitesubentryrangedelim}
+Analogue of \cmd{multicitesubentryrangedelim} for \cmd{supercite}. The default is \cmd{superciterangedelim}.
 
 \csitem{compcitedelim}
 Similar to \cmd{multicitedelim}, but intended for citation styles that <compress> multiple citations, \ie print the author only once if subsequent citations share the same author etc. The default definition is a comma plus an interword space.
@@ -14147,6 +14195,11 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{release}{3.15}{20??-??-??}
 \item Added \cmd{mautocite} and \cmd{Mautocite}\see{use:cit:mct}
 \item Added \cmd{NumsCheckSetup} and \cmd{PagesCheckSetup}\see{aut:aux:msc}
+\item Added \opt{subentrycomp} to \texttt{numeric-comp} style\see{use:opt:pre:bbx}
+\item Added \cmd{multiciterangedelim}, \cmd{multicitesubentrydelim},
+      \cmd{multicitesubentryrangedelim}, \cmd{superciterangedelim},
+      \cmd{supercitesubentrydelim}, \cmd{supercitesubentryrangedelim}%
+      \see{use:fmt:fmt}
 \end{release}
 \begin{release}{3.14}{2019-12-01}
 \item Added new mapping verbs for citation sources\see{aut:ctm:map}

--- a/doc/latex/biblatex/examples/31-style-numeric-comp.tex
+++ b/doc/latex/biblatex/examples/31-style-numeric-comp.tex
@@ -36,7 +36,31 @@ This option is disabled by default, but it has been enabled
 in this example. If disabled, citations referring to a set member
 will point to the entire set, i.e., the above citations would
 come out as
+\begingroup\boolfalse{bbx:subentry}% don't try this at home
 \cite{stdmodel,set,stdmodel,set,companion}.
+\endgroup
+
+\subsection*{The \texttt{subentrycomp} option}
+
+The option \texttt{subentrycomp} controls whether or not citations
+to subentries of the same sets are compressed as well.
+It only becomes relevant if \texttt{subentry} is set to \texttt{true},
+with \texttt{subentry=false} it has no effect.
+If \texttt{subentrycomp} is enabled,
+subentries that belong to the same
+set are shown in a more compact form:
+\cite{glashow,herrmann,aksin,yoon,salam,companion}.
+
+If the option is disabled, subentries of sets are shown as in
+the \texttt{numeric} style:
+\begingroup\togglefalse{cbx:subentrycomp}% don't try this at home
+\cite{glashow,herrmann,aksin,yoon,salam,companion}.
+\endgroup
+
+This option is implemented for backwards compatibility,
+earlier versions of \texttt{biblatex} behaved like
+\texttt{subentrycomp=false}, current versions have
+\texttt{subentrycomp=true} enabled.
 
 \subsection*{Multiple citations}
 

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -95,8 +95,17 @@
 \DeclareDelimFormat{andmoredelim}{\addspace}
 
 \newcommand*{\multicitedelim}{\addsemicolon\space}
+\newcommand*{\multicitesubentrydelim}{\addcomma}
+\newcommand*{\multiciterangedelim}{\bibrangedash}
+\newcommand*{\multicitesubentryrangedelim}{\multiciterangedelim}
+
 \newcommand*{\compcitedelim}{\addcomma\space}
+
 \newcommand*{\supercitedelim}{\addcomma}
+\newcommand*{\supercitesubentrydelim}{\supercitedelim}
+\newcommand*{\superciterangedelim}{\bibrangedash}
+\newcommand*{\supercitesubentryrangedelim}{\superciterangedelim}
+
 \DeclareDelimFormat{prenotedelim}{\addspace}
 \DeclareDelimFormat{postnotedelim}{\addcomma\space}
 \DeclareDelimAlias{multiprenotedelim}{prenotedelim}

--- a/tex/latex/biblatex/cbx/numeric-comp.cbx
+++ b/tex/latex/biblatex/cbx/numeric-comp.cbx
@@ -8,6 +8,7 @@
 \ExecuteBibliographyOptions{labelnumber,sortcites,autocite=inline,
   subentrycomp=true}
 
+\renewcommand*{\multicitedelim}{\addcomma\space}
 \renewcommand*{\iffinalcitedelim}{%
   \ifnumequal{\value{textcitecount}}{\value{textcitetotal}-1}}
 

--- a/tex/latex/biblatex/cbx/numeric-comp.cbx
+++ b/tex/latex/biblatex/cbx/numeric-comp.cbx
@@ -1,30 +1,57 @@
 \ProvidesFile{numeric-comp.cbx}
 [\abx@cbxid]
 
-\ExecuteBibliographyOptions{labelnumber,sortcites,autocite=inline}
+\newtoggle{cbx:subentrycomp}
+\DeclareBiblatexOption{global,type,entry}[boolean]{subentrycomp}[true]{%
+  \settoggle{cbx:subentrycomp}{#1}}
 
-\renewcommand*{\multicitedelim}{\addcomma\space}
+\ExecuteBibliographyOptions{labelnumber,sortcites,autocite=inline,
+  subentrycomp=true}
+
 \renewcommand*{\iffinalcitedelim}{%
   \ifnumequal{\value{textcitecount}}{\value{textcitetotal}-1}}
 
 \providebool{bbx:subentry}
 \newbool{cbx:parens}
 
-\newcounter{cbx@tempcnta}
-\newcounter{cbx@tempcntb}
+\newcounter{cbx@tempcnta}% no. of labelnumbers skipped
+\newcounter{cbx@tempcntb}% 'predicted' labelnumber for current cite
+\newcounter{cbx@tempcntc}% no. of entrysetcounts we skipped
+\newcounter{cbx@tempcntd}% 'predicted' entrysetcount
 
 \DeclareFieldFormat{entrysetcount}{\mknumalph{#1}}
+
+\newcommand*{\cbx@iflabelnumberequalslast}{%
+  \iffieldequals{labelnumber}{\cbx@lastnumber}}
+
+% \iffieldequals is false even if both are empty/undef
+% so we need a special test for that case
+% this test is optimised for performance and laziness
+% rather than prettiness, not that it would matter a lot...
+\newcommand*{\cbx@iflabelprefixequalslast}{%
+  \ifundef\cbx@lastprefix
+    {\iffieldundef{labelprefix}}
+    {\iffieldequals{labelprefix}{\cbx@lastprefix}}}
+
+% \cbx@iflabelnumberequalslast and \cbx@iflabelprefixequalslast
+\newcommand*{\cbx@iflabelnumberandprefixequallast}{%
+  \cbx@iflabelnumberequalslast
+    {\cbx@iflabelprefixequalslast}
+    {\@secondoftwo}}
 
 \newbibmacro*{cite:init}{%
   \global\boolfalse{cbx:parens}%
   \global\undef\cbx@lasthash
   \global\undef\cbx@lastnumber
   \global\undef\cbx@lastprefix
+  \global\undef\cbx@lastentrysetcount
   \setcounter{cbx@tempcnta}{0}%
-  \setcounter{cbx@tempcntb}{-2}}
+  \setcounter{cbx@tempcntb}{-2}%
+  \setcounter{cbx@tempcntc}{0}%
+  \setcounter{cbx@tempcntd}{-1}}
 
 \newbibmacro*{cite:comp}{%
-  \addtocounter{cbx@tempcntb}{1}%
+  \stepcounter{cbx@tempcntb}%
   \iffieldundef{shorthand}
     {\ifbool{bbx:subentry}
        {\iffieldundef{entrysetcount}
@@ -34,24 +61,18 @@
     {\usebibmacro{cite:comp:shand}}}
 
 \newbibmacro*{cite:comp:comp}{%
-  \ifboolexpr{
-    ( test {\iffieldundef{labelprefix}} and test {\ifundef\cbx@lastprefix} )
-    or
-    test {\iffieldequals{labelprefix}{\cbx@lastprefix}}
-  }
+  \cbx@iflabelprefixequalslast
     {\ifnumequal{\thefield{labelnumber}}{\value{cbx@tempcntb}}
        {\savefield{entrykey}{\cbx@lastkey}%
         \savefield{labelnumber}{\cbx@lastnumber}%
-        \addtocounter{cbx@tempcnta}{1}}
+        \stepcounter{cbx@tempcnta}}
        {\ifnumequal{\thefield{labelnumber}}{\value{cbx@tempcntb}-1}
-          {}
-          {\usebibmacro{cite:dump}%
-           \ifnumgreater{\value{cbx@tempcntb}}{-1}
-             {\multicitedelim}
-             {}%
-           \printtext[bibhyperref]{%
-             \printfield{labelprefix}%
-             \printfield{labelnumber}}}}}
+          {% current cite is *exactly* the same a previous source
+           % this can only happen if the same source is cited twice
+           % and sortcites is turned off
+           % print nothing
+          }
+          {\usebibmacro{cite:comp:end}}}}
     {\usebibmacro{cite:comp:end}}%
   \setcounter{cbx@tempcntb}{\thefield{labelnumber}}%
   \savefield{labelprefix}{\cbx@lastprefix}}
@@ -66,15 +87,37 @@
     \printfield{labelnumber}}}
 
 \newbibmacro*{cite:comp:inset}{%
-  \usebibmacro{cite:dump}%
-  \ifnumgreater{\value{cbx@tempcntb}}{-1}
-    {\multicitedelim}
-    {}%
-  \printtext[bibhyperref]{%
-    \printfield{labelprefix}%
-    \printfield{labelnumber}%
-    \printfield{entrysetcount}}%
-  \setcounter{cbx@tempcntb}{-1}}
+  \stepcounter{cbx@tempcntd}%
+  \ifboolexpr{    togl {cbx:subentrycomp}
+              and test {\cbx@iflabelnumberandprefixequallast}}
+    {\ifnumequal{\thefield{entrysetcount}}{\value{cbx@tempcntd}}
+       {\savefield{entrykey}{\cbx@lastkey}%
+        \savefield{entrysetcount}{\cbx@lastentrysetcount}%
+        \stepcounter{cbx@tempcntc}}
+       {\ifnumequal{\thefield{entrysetcount}}{\value{cbx@tempcntd}-1}
+          {% current cite is *exactly* the same a previous source
+           % this can only happen if the same source is cited twice
+           % and sortcites is turned off
+           % print nothing
+          }
+          {\usebibmacro{cite:dump:inset}%
+           \ifnumgreater{\value{cbx@tempcntd}}{-1}
+             {\multicitesubentrydelim}
+             {}%
+           \printtext[bibhyperref]{\printfield{entrysetcount}}}}}
+    {\usebibmacro{cite:dump}%
+     \ifnumgreater{\value{cbx@tempcntb}}{-1}
+       {\multicitedelim}
+       {}%
+     \setcounter{cbx@tempcntd}{-1}%
+     \printtext[bibhyperref]{%
+       \printfield{labelprefix}%
+       \printfield{labelnumber}%
+       \printfield{entrysetcount}}%
+     \savefield{labelprefix}{\cbx@lastprefix}%
+     \savefield{labelnumber}{\cbx@lastnumber}}%
+    \setcounter{cbx@tempcntd}{\thefield{entrysetcount}}%
+    \setcounter{cbx@tempcntb}{-1}}
 
 \newbibmacro*{cite:comp:shand}{%
   \usebibmacro{cite:dump}%
@@ -84,19 +127,34 @@
   \printtext[bibhyperref]{\printfield{shorthand}}%
   \setcounter{cbx@tempcntb}{-1}}
 
+\newbibmacro{cite:dump:inset}{%
+  % dump subentry
+  \ifnumgreater{\value{cbx@tempcntc}}{0}
+    {\ifnumgreater{\value{cbx@tempcntc}}{1}
+       {\multicitesubentryrangedelim}
+       {\multicitesubentrydelim}%
+     \bibhyperref[\cbx@lastkey]{%
+       \printtext[entrysetcount]{\cbx@lastentrysetcount}}}
+    {}%
+  \setcounter{cbx@tempcntc}{0}%
+}
+
 \newbibmacro*{cite:dump}{%
+  \usebibmacro{cite:dump:inset}%
+  % dump labelnumber (+labelprefix)
   \ifnumgreater{\value{cbx@tempcnta}}{0}
     {\ifnumgreater{\value{cbx@tempcnta}}{1}
-       {\bibrangedash}
+       {\multiciterangedelim}
        {\multicitedelim}%
      \bibhyperref[\cbx@lastkey]{%
        \ifdef\cbx@lastprefix
          {\printtext[labelprefix]{\cbx@lastprefix}}
          {}%
-       \printtext[labelnumber]{\cbx@lastnumber}}}
+       \printtext[labelnumber]{\cbx@lastnumber}}%
+     \global\undef\cbx@lastprefix}
     {}%
   \setcounter{cbx@tempcnta}{0}%
-  \global\undef\cbx@lastprefix}
+}
 
 \newbibmacro*{textcite}{%
   \iffieldequals{namehash}{\cbx@lasthash}
@@ -169,6 +227,9 @@
 \DeclareCiteCommand{\supercite}[\mkbibsuperscript]
   {\usebibmacro{cite:init}%
    \let\multicitedelim=\supercitedelim
+   \let\multicitesubentrydelim=\supercitesubentrydelim
+   \let\multiciterangedelim=\superciterangedelim
+   \let\multicitesubentryrangedelim=\supercitesubentryrangedelim
    \iffieldundef{prenote}
      {}
      {\BibliographyWarning{Ignoring prenote argument}}%


### PR DESCRIPTION
See #900. Compress subentry set references in `numeric-comp` citation style. Also add a few more configurable delimiters.

This makes the definitions slightly more complex, but I think this is worth it - it makes sense to compress `subentry` citations in a comp style.

Consider
```latex
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=numeric-comp, subentry, backend=biber]{biblatex}

\addbibresource{biblatex-examples.bib}

\begin{document}
\cite{set,stdmodel}

\cite{set,sigfridsson,worman}

\cite{herrmann,aksin,yoon}

\cite{herrmann,aksin}

\cite{herrmann,yoon}

\printbibliography
\end{document}
```

---

Technically this is a breaking change, the previous behaviour can be easily restored with the option
```latex
subentrycomp=false,
```
i.e.
```latex
\documentclass[british]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=numeric-comp, subentry, subentrycomp=false, backend=biber]{biblatex}

\addbibresource{biblatex-examples.bib}

\begin{document}
\cite{set,stdmodel}

\cite{set,sigfridsson,worman}

\cite{herrmann,aksin,yoon}

\cite{herrmann,aksin}

\cite{herrmann,yoon}

\printbibliography
\end{document}
```