### PR TITLE
Add file hooks

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -53,6 +53,20 @@
   redefined them may have to adapt.
 - `biblatex` now tests if a requested Biber (re)run happened by
   comparing the MD5 hashes of the new and old `.bbl` files.
+- Added file hooks `\blx@filehook@preload@<filename>`,
+  `\blx@filehook@postload@<filename>`
+  and `\blx@filehook@failure@<filename>`
+  to execute hooks before or after a file is loaded
+  or if the loading fails.
+  `\blx@lbxfilehook@simple@preload@<filename>`,
+  `\blx@lbxfilehook@simple@postload@<filename>`
+  and `\blx@lbxfilehook@simple@failure@<filename>`
+  as well as
+  `\blx@lbxfilehook@once@preload@<filename>`,
+  `\blx@lbxfilehook@once@postload@<filename>`
+  and `\blx@lbxfilehook@once@failure@<filename>`
+  are the equivalents for `.lbx` loading, where
+  files may be loaded several times in some situations.
 
 # RELEASE NOTES FOR VERSION 3.14
 - biber from version 2.14 has extended, granular XDATA functionality to

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -12843,6 +12843,68 @@ Appends \prm{code} to an internal hook executed every time an entrykey is proces
 
 \end{ltxsyntax}
 
+\subsubsection{File hooks}
+\label{aut:fmt:hok:fil}
+\biblatex has rudimentary support for injecting arbitrary code before and after a file is loaded via file hooks. For files that are loaded using \biblatex's file interface---that includes all bibliography and citation styles---the following three hooks are available
+
+\begin{ltxsyntax}
+\cmditem{blx@filehook@preload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected before it is loaded.
+
+\cmditem{blx@filehook@postload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected after it is loaded.
+
+\cmditem{blx@filehook@failure@$<$filename with extension$>$}
+
+This hook is executed if \file{$<$filename with extension$>$} can not be found.
+\end{ltxsyntax}
+
+\biblatex generally only loads files once even if they were requested multiple times,
+so the hooks will only be executed once.
+Naturally, the file hooks need to be populated before the files are loaded, so the safest would be to populate them before \biblatex is loaded.
+It is advisable to only append code to avoid overwriting previous hook contents.
+Since the name of the file hook include the dot and the file extension they will usually have to be defined with a command like \cmd{csappto} from \sty{etoolbox}.
+
+The \file{.lbx} files are special and may have to be loaded several times in some situations.
+Their file hooks are
+
+\begin{ltxsyntax}
+\cmditem{blx@lbxfilehook@once@preload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected before it is loaded in a situation where the \file{.lbx} files are loaded only once.
+
+\cmditem{blx@lbxfilehook@once@postload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected after it is loaded in a situation where the \file{.lbx} files are loaded only once.
+
+\cmditem{blx@lbxfilehook@once@failure@$<$filename with extension$>$}
+
+This hook is executed if \file{$<$filename with extension$>$} can not be found in a situation where the \file{.lbx} files are loaded only once.
+
+\cmditem{blx@lbxfilehook@simple@preload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected before it is loaded in a situation where the \file{.lbx} files may be loaded multiple times.
+
+\cmditem{blx@lbxfilehook@simple@postload@$<$filename with extension$>$}
+
+If \file{$<$filename with extension$>$} is found, this hook is exected after it is loaded in a situation where the \file{.lbx} files may be loaded multiple times.
+
+\cmditem{blx@lbxfilehook@simple@failure@$<$filename with extension$>$}
+
+This hook is executed if \file{$<$filename with extension$>$} can not be found in a situation where the \file{.lbx} files may be loaded multiple times.
+\end{ltxsyntax}
+
+The following code sets up \sty{beamer} to print the bibliography labels instead of its bibliography icons when \file{numeric.bbx} after is loaded
+\begin{ltxexample}
+\csappto{blx@filehook@postload@numeric.bbx}{%
+  \mode<presentation>{%
+    \setbeamertemplate{bibliography item}{%
+      \insertbiblabel}}}
+\end{ltxexample}
+
+
 \subsection{Hints and Caveats}
 \label{aut:cav}
 
@@ -14235,6 +14297,7 @@ This revision history is a list of changes relevant to users of this package. Ch
       \cmd{supercitesubentrydelim}, \cmd{supercitesubentryrangedelim}%
       \see{use:fmt:fmt}
 \item Added \opt{block} option to \cmd{printbibliography} and friends\see{use:bib:bib}
+\item Added file hooks\see{aut:fmt:hok:fil}
 \end{release}
 \begin{release}{3.14}{2019-12-01}
 \item Added new mapping verbs for citation sources\see{aut:ctm:map}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -1137,10 +1137,15 @@
     {\blx@info@noline{Trying to load #2..}%
      \IfFileExists{#1}
        {\blx@info@noline{... file '#1' found}%
-        #3\@@input\@filef@und#4#5%
+        \csuse{blx@filehook@preload@#1}%
+        #3\@@input\@filef@und#4%
+        \csuse{blx@filehook@postload@#1}%
+        #5%
         \listxadd\blx@list@req@stat{#1}%
         \@addtofilelist{#1}}
-       {\blx@info@noline{... file '#1' not found}#6}%
+       {\blx@info@noline{... file '#1' not found}%
+        \csuse{blx@filehook@failure@#1}%
+        #6}%
      \global\cslet{blx@file@#1}\@empty}
     {#5}}
 
@@ -5630,13 +5635,18 @@
   \blx@info@noline{Trying to load #2..}%
   \IfFileExists{#1}
     {\blx@info@noline{... file '#1' found}%
-     #3\@@input\@filef@und#4#5%
+     \csuse{blx@lbxfilehook@simple@preload@#1}%
+     #3\@@input\@filef@und#4%
+     \csuse{blx@lbxfilehook@simple@postload@#1}%
+     #5%
      \ifcsundef{blx@file@lbx@simple@#1}
        {\listxadd\blx@list@req@stat{#1}%
         \@addtofilelist{#1}%
         \global\cslet{blx@file@lbx@simple@#1}\@empty}
        {}}
-    {\blx@info@noline{... file '#1' not found}#6}}
+    {\blx@info@noline{... file '#1' not found}%
+     \csuse{blx@lbxfilehook@simple@failure@#1}%
+     #6}}
 
 % {<file>}{<message>}{<preload>}{<postload>}{<success>}{<failure>}
 \protected\long\def\blx@lbx@input@handler@once#1#2#3#4#5#6{%
@@ -5644,12 +5654,17 @@
     {\blx@info@noline{Trying to load #2..}%
      \IfFileExists{#1}
        {\blx@info@noline{... file '#1' found}%
-        #3\@@input\@filef@und#4#5%
+        \csuse{blx@lbxfilehook@once@preload@#1}%
+        #3\@@input\@filef@und#4%
+        \csuse{blx@lbxfilehook@once@postload@#1}%
+        #5%
         \ifcsundef{blx@file@lbx@simple@#1}
           {\listxadd\blx@list@req@stat{#1}%
            \@addtofilelist{#1}}
           {}}
-       {\blx@info@noline{... file '#1' not found}#6}%
+       {\blx@info@noline{... file '#1' not found}%
+        \csuse{blx@lbxfilehook@once@failure@#1}%
+        #6}%
      \global\cslet{blx@file@lbx@once@#1}\@empty
      \global\cslet{blx@file@lbx@simple@#1}\@empty}
     {#5}}


### PR DESCRIPTION
See https://github.com/josephwright/beamer/issues/581.

Add file hooks so packages/document classes can directly apply changes to arbitrary files before or after they are loaded.

Things are a bit tricky for `.lbx` files, since they can be loaded multiple times. So they have their own interface. I'm not completely happy with that, but it was the best I could come up with. Suggestions for a smoother solution would be highly appreciated.