### PR TITLE
Feature/turkish lbx

### DIFF
--- a/tex/latex/biblatex/lbx/03-localization-keys.tex
+++ b/tex/latex/biblatex/lbx/03-localization-keys.tex
@@ -1,0 +1,719 @@
+%
+% This file presents default localization keys for the module specified by
+% the main document language passed to 'babel'.
+%
+\documentclass{article}
+
+% localization modules
+% - ascii
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage[turkish, shorthands=:!]{babel} % The babel module for Turkish defines = as a shorthand that is aimed to leave some space before it in case it's used in text.
+%\usepackage[brazilian]{babel}
+%\usepackage[catalan]{babel}
+%\usepackage[croatian]{babel}
+%\usepackage[czech]{babel}
+%\usepackage[danish]{babel}
+%\usepackage[dutch]{babel}
+%\usepackage[english]{babel}
+%\usepackage[estonian]{babel}
+%\usepackage[finnish]{babel}
+%\usepackage[french]{babel}
+%\usepackage[galician]{babel}
+%\usepackage[german]{babel}
+%\usepackage[icelandic]{babel}
+%\usepackage[italian]{babel}
+%\usepackage[latvian]{babel}
+%\usepackage[magyar]{babel}
+%\usepackage[norsk]{babel}
+%\usepackage[nynorsk]{babel}
+%\usepackage[polish]{babel}
+%\usepackage[portuguese]{babel}
+%\usepackage[slovak]{babel}
+%\usepackage[slovene]{babel}
+%\usepackage[spanish]{babel}
+%\usepackage[swedish]{babel}
+% - UTF-8
+% -- Russian
+%\usepackage[T1,T2A]{fontenc}
+%\usepackage[utf8]{inputenc}
+%\usepackage[bulgarian]{babel}
+%\usepackage[russian]{babel}
+%\usepackage[ukrainian]{babel}
+% -- Greek
+%\usepackage[T1]{fontenc}
+%\usepackage[utf8]{inputenx}
+%\usepackage[english,greek]{babel}
+
+\usepackage[autostyle]{csquotes}
+% \DeclareQuoteAlias{spanish}{catalan}
+% \DeclareQuoteAlias{croatian}{polish}
+% \DeclareQuoteAlias{croatian}{slovene}
+\usepackage[backend=biber]{biblatex}
+\usepackage[colorlinks]{hyperref}
+
+\DeclareQuoteStyle{turkish}%
+  {\textquotedblleft}
+  {\textquotedblright}
+  [0.05em]
+  {\textquotedblleft}
+  {\textquotedblright}
+
+% list format
+\newcommand*{\ie}{i.\,e.}
+\newcommand*{\eg}{e.\,g.}
+\newcommand{\cmd}[1]{\vrb{\textbackslash #1}}
+\newcommand{\vrb}[1]{\mbox{\ttfamily #1}}
+\newcommand{\acr}[1]{\textsc{#1}}
+\newrobustcmd*{\bibfield}[1]{\mbox{\ttfamily #1}}
+\newrobustcmd*{\bibtype}[1]{\mbox{\ttfamily @#1}}
+\newcommand{\prm}[1]{%
+  \mbox{%
+    \ensuremath\langle
+    \normalfont\textit{#1}%
+    \ensuremath\rangle}}
+\newenvironment*{keylist}
+  {\list{}{%
+     \setlength{\labelwidth}{1.25in}%
+     \setlength{\labelsep}{10pt}%
+     \setlength{\leftmargin}{0pt}%
+     \setlength{\itemsep}{0pt}%
+     \raggedright%
+     \renewcommand*{\makelabel}[1]{\hss\bfseries##1}}}
+  {\endlist}
+\makeatletter
+\def\keyitem#1{%
+  \item[#1]
+  \begingroup
+    \keyitemhook%
+    \blx@bibinit%
+    \midsentence\ifbibstring{#1}{}{\latintext}\biblstring{#1}%
+    \expandafter\lbx@initnamehook\lsmartoftext%
+    \par\nobreak
+    \midsentence\ifbibstring{#1}{}{\latintext}\bibsstring{#1}%
+    \expandafter\lbx@initnamehook\ssmartoftext%
+  \endgroup
+  \par\nobreak}
+\makeatother
+\ifdefstring{\languagename}{greek}{%
+  \AtBeginDocument{%
+    \appto{\keyitemhook}{\greektext}%
+    \latintext}
+  \preto{\UrlFont}{\latintext}
+  \pretocmd{\printbibliography}{\greektext}{}{}}{}
+\AtBeginBibliography{\raggedright}
+\AtBeginDocument{\MakeAutoQuote*{<}{>}}
+
+% user-configurable commands
+\newcommand{\keyitemhook}{}
+\newcommand{\lsmartoftext}{A}
+\newcommand{\ssmartoftext}{B}
+
+\addbibresource{biblatex-examples.bib}
+\nocite{*}
+
+\begin{document}
+\section*{Localization Strings for \vrb{\languagename}}
+
+The localization keys listed in this document are defined by default. Each key is printed with its description from the \vrb{biblatex} manual and strings specified by \vrb{\languagename.lbx} in following format.
+\begin{verbatim}
+<key name>  <long string>
+            <short string>
+\end{verbatim}
+Long and short strings ending with \cmd{smartof}-type commands are respectively given the arguments \cmd{lsmarttext} and \cmd{ssmarttext}, which can be redefined in this document's preamble. Any unspecified keys will appear in boldface and generate warnings in the \vrb{log} file. String definitions or corrections are welcome at:
+\begin{center}
+\url{http://github.com/plk/biblatex/issues}
+\end{center}
+
+\subsection*{Headings}
+
+The following strings are special because they are intended for use in headings and made available globally via macros. For this reason, they should be capitalized for use in headings and they must not include any local commands which are part of \vrb{biblatex}'s author interface.
+
+\begin{keylist}
+\keyitem{bibliography} The term <bibliography>, also available as \cmd{bibname}.
+\keyitem{references} The term <references>, also available as \cmd{refname}.
+\keyitem{shorthands} The term <list of shorthands> or <list of abbreviations>, also available as \cmd{biblistname}.
+\end{keylist}
+
+\subsection*{Roles, Expressed as Functions}
+
+The following keys refer to roles which are expressed as a function (<editor>, <translator>) rather than as an action (<edited by>, <translated by>).
+
+\begin{keylist}
+\keyitem{editor} The term <editor>, referring to the main editor. This is the most generic editorial role.
+\keyitem{editors} The plural form of \texttt{editor}.
+\keyitem{compiler} The term <compiler>, referring to an editor whose task is to compile a work.
+\keyitem{compilers} The plural form of \texttt{compiler}.
+\keyitem{founder} The term <founder>, referring to a founding editor.
+\keyitem{founders} The plural form of \texttt{founder}.
+\keyitem{continuator} An expression like <continuator>, <continuation>, or <continued>, referring to a past editor who continued the work of the founding editor but was subsequently replaced by the current editor.
+\keyitem{continuators} The plural form of \texttt{continuator}.
+\keyitem{redactor} The term <redactor>, referring to a secondary editor.
+\keyitem{redactors} The plural form of \texttt{redactor}.
+\keyitem{reviser} The term <reviser>, referring to a secondary editor.
+\keyitem{revisers} The plural form of \texttt{reviser}.
+\keyitem{collaborator} A term like <collaborator>, <collaboration>, <cooperator>, or <cooperation>, referring to a secondary editor.
+\keyitem{collaborators} The plural form of \texttt{collaborator}.
+\keyitem{translator} The term <translator>.
+\keyitem{translators} The plural form of \texttt{translator}.
+\keyitem{commentator} The term <commentator>, referring to the author of a commentary to a work.
+\keyitem{commentators} The plural form of \texttt{commentators}.
+\keyitem{annotator} The term <annotator>, referring to the author of annotations to a work.
+\keyitem{annotators} The plural form of \texttt{annotators}.
+\keyitem{organizer} The term <organizer>, referring to the organizer of an event or work.
+\keyitem{organizers} The plural form of \texttt{organizer}.
+\end{keylist}
+
+\subsection*{Concatenated Editor Roles, Expressed as Functions}
+
+The following keys are similar in function to \texttt{editor}, \texttt{translator}, etc. They are used to indicate additional roles of the editor, \eg\ <editor and translator>, <editor and foreword>.
+
+\begin{keylist}
+\keyitem{editortr} Used if \bibfield{editor}\slash \bibfield{translator} are identical.
+\keyitem{editorstr} The plural form of \texttt{editortr}.
+\keyitem{editorco} Used if \bibfield{editor}\slash \bibfield{commentator} are identical.
+\keyitem{editorsco} The plural form of \texttt{editorco}.
+\keyitem{editoran} Used if \bibfield{editor}\slash \bibfield{annotator} are identical.
+\keyitem{editorsan} The plural form of \texttt{editoran}.
+\keyitem{editorin} Used if \bibfield{editor}\slash \bibfield{introduction} are identical.
+\keyitem{editorsin} The plural form of \texttt{editorin}.
+\keyitem{editorfo} Used if \bibfield{editor}\slash \bibfield{foreword} are identical.
+\keyitem{editorsfo} The plural form of \texttt{editorfo}.
+\keyitem{editoraf} Used if \bibfield{editor}\slash \bibfield{afterword} are identical.
+\keyitem{editorsaf} The plural form of \texttt{editoraf}.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{translator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{editortrco} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator} are identical.
+\keyitem{editorstrco} The plural form of \texttt{editortrco}.
+\keyitem{editortran} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{annotator} are identical.
+\keyitem{editorstran} The plural form of \texttt{editortran}.
+\keyitem{editortrin} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{introduction} are identical.
+\keyitem{editorstrin} The plural form of \texttt{editortrin}.
+\keyitem{editortrfo} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{foreword} are identical.
+\keyitem{editorstrfo} The plural form of \texttt{editortrfo}.
+\keyitem{editortraf} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{afterword} are identical.
+\keyitem{editorstraf} The plural form of \texttt{editortraf}.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{editorcoin} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{editorscoin} The plural form of \texttt{editorcoin}.
+\keyitem{editorcofo} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{editorscofo} The plural form of \texttt{editorcofo}.
+\keyitem{editorcoaf} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\keyitem{editorscoaf} The plural form of \texttt{editorcoaf}.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{annotator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{editoranin} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{introduction} are identical.
+\keyitem{editorsanin} The plural form of \texttt{editoranin}.
+\keyitem{editoranfo} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{foreword} are identical.
+\keyitem{editorsanfo} The plural form of \texttt{editoranfo}.
+\keyitem{editoranaf} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{afterword} are identical.
+\keyitem{editorsanaf} The plural form of \texttt{editoranaf}.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{editortrcoin} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{editorstrcoin} The plural form of \texttt{editortrcoin}.
+\keyitem{editortrcofo} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{editorstrcofo} The plural form of \texttt{editortrcofo}.
+\keyitem{editortrcoaf} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\keyitem{editorstrcoaf} The plural form of \texttt{editortrcoaf}.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{editortranin} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{editorstranin} The plural form of \texttt{editortranin}.
+\keyitem{editortranfo} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{editorstranfo} The plural form of \texttt{editortranfo}.
+\keyitem{editortranaf} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\keyitem{editorstranaf} The plural form of \texttt{editortranaf}.
+\end{keylist}
+
+\subsection*{Concatenated Translator Roles, Expressed as Functions}
+
+The following keys are similar in function to \texttt{translator}. They are used to indicate additional roles of the translator, e.g. <translator and commentator>, <translator and introduction>.
+
+\begin{keylist}
+\keyitem{translatorco} Used if \bibfield{translator}\slash \bibfield{commentator} are identical.
+\keyitem{translatorsco} The plural form of \texttt{translatorco}.
+\keyitem{translatoran} Used if \bibfield{translator}\slash \bibfield{annotator} are identical.
+\keyitem{translatorsan} The plural form of \texttt{translatoran}.
+\keyitem{translatorin} Used if \bibfield{translator}\slash \bibfield{introduction} are identical.
+\keyitem{translatorsin} The plural form of \texttt{translatorin}.
+\keyitem{translatorfo} Used if \bibfield{translator}\slash \bibfield{foreword} are identical.
+\keyitem{translatorsfo} The plural form of \texttt{translatorfo}.
+\keyitem{translatoraf} Used if \bibfield{translator}\slash \bibfield{afterword} are identical.
+\keyitem{translatorsaf} The plural form of \texttt{translatoraf}.
+\end{keylist}
+%
+Keys for \bibfield{translator}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{translatorcoin} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{translatorscoin} The plural form of \texttt{translatorcoin}.
+\keyitem{translatorcofo} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{translatorscofo} The plural form of \texttt{translatorcofo}.
+\keyitem{translatorcoaf} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\keyitem{translatorscoaf} The plural form of \texttt{translatorcoaf}.
+\end{keylist}
+%
+Keys for \bibfield{translator}\slash \bibfield{annotator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{translatoranin} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{introduction} are identical.
+\keyitem{translatorsanin} The plural form of \texttt{translatoranin}.
+\keyitem{translatoranfo} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{foreword} are identical.
+\keyitem{translatorsanfo} The plural form of \texttt{translatoranfo}.
+\keyitem{translatoranaf} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{afterword} are identical.
+\keyitem{translatorsanaf} The plural form of \texttt{translatoranaf}.
+\end{keylist}
+
+\subsection*{Roles, Expressed as Actions}
+
+The following keys refer to roles which are expressed as an action (<edited by>, <translated by>) rather than as a function (<editor>, <translator>).
+
+\begin{keylist}
+\keyitem{byauthor} The expression <[created] by \prm{name}>.
+\keyitem{byeditor} The expression <edited by \prm{name}>.
+\keyitem{bycompiler} The expression <compiled by \prm{name}>.
+\keyitem{byfounder} The expression <founded by \prm{name}>.
+\keyitem{bycontinuator} The expression <continued by \prm{name}>.
+\keyitem{byredactor} The expression <redacted by \prm{name}>.
+\keyitem{byreviser} The expression <revised by \prm{name}>.
+\keyitem{byreviewer} The expression <reviewed by \prm{name}>.
+\keyitem{bycollaborator} An expression like <in collaboration with \prm{name}> or <in cooperation with \prm{name}>.
+\keyitem{bytranslator} The expression <translated by \prm{name}> or <translated from \prm{language} by \prm{name}>.
+\keyitem{bycommentator} The expression <commented by \prm{name}>.
+\keyitem{byannotator} The expression <annotated by \prm{name}>.
+\keyitem{byorganizer} The expression <[organized] by \prm{name}>.
+\end{keylist}
+
+\subsection*{Concatenated Editor Roles, Expressed as Actions}
+
+The following keys are similar in function to \bibfield{byeditor}, \bibfield{bytranslator}, etc. They are used to indicate additional roles of the editor, e.g. <edited and translated by>, <edited and furnished with an introduction by>, <edited, with a foreword, by>.
+
+\begin{keylist}
+\keyitem{byeditortr} Used if \bibfield{editor}\slash \bibfield{translator} are identical.
+\keyitem{byeditorco} Used if \bibfield{editor}\slash \bibfield{commentator} are identical.
+\keyitem{byeditoran} Used if \bibfield{editor}\slash \bibfield{annotator} are identical.
+\keyitem{byeditorin} Used if \bibfield{editor}\slash \bibfield{introduction} are identical.
+\keyitem{byeditorfo} Used if \bibfield{editor}\slash \bibfield{foreword} are identical.
+\keyitem{byeditoraf} Used if \bibfield{editor}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{translator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{byeditortrco} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator} are identical.
+\keyitem{byeditortran} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{annotator} are identical.
+\keyitem{byeditortrin} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{introduction} are identical.
+\keyitem{byeditortrfo} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{foreword} are identical.
+\keyitem{byeditortraf} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{byeditorcoin} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{byeditorcofo} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{byeditorcoaf} Used if \bibfield{editor}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{annotator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{byeditoranin} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{introduction} are identical.
+\keyitem{byeditoranfo} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{foreword} are identical.
+\keyitem{byeditoranaf} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{byeditortrcoin} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{byeditortrcofo} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{byeditortrcoaf} Used if \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{editor}\slash \bibfield{translator}\slash \bibfield{annotator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{byeditortranin} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{byeditortranfo} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{byeditortranaf} Used if \bibfield{editor}\slash \bibfield{annotator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+
+\subsection*{Concatenated Translator Roles, Expressed as Actions}
+
+The following keys are similar in function to \texttt{bytranslator}. They are used to indicate additional roles of the translator, e.g. <translated and commented by>, <translated and furnished with an introduction by>, <translated, with a foreword, by>.
+
+\begin{keylist}
+\keyitem{bytranslatorco} Used if \bibfield{translator}\slash \bibfield{commentator} are identical.
+\keyitem{bytranslatoran} Used if \bibfield{translator}\slash \bibfield{annotator} are identical.
+\keyitem{bytranslatorin} Used if \bibfield{translator}\slash \bibfield{introduction} are identical.
+\keyitem{bytranslatorfo} Used if \bibfield{translator}\slash \bibfield{foreword} are identical.
+\keyitem{bytranslatoraf} Used if \bibfield{translator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{translator}\slash \bibfield{commentator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{bytranslatorcoin} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{introduction} are identical.
+\keyitem{bytranslatorcofo} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{foreword} are identical.
+\keyitem{bytranslatorcoaf} Used if \bibfield{translator}\slash \bibfield{commentator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+%
+Keys for \bibfield{translator}\slash \bibfield{annotator}\slash \prm{role} combinations:
+
+\begin{keylist}
+\keyitem{bytranslatoranin} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{introduction} are identical.
+\keyitem{bytranslatoranfo} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{foreword} are identical.
+\keyitem{bytranslatoranaf} Used if \bibfield{translator}\slash \bibfield{annotator}\slash \bibfield{afterword} are identical.
+\end{keylist}
+
+\subsection*{Roles, Expressed as Objects}
+
+Roles which are related to supplementary material may also be expressed as objects (<with a commentary by>) rather than as functions (<commentator>) or as actions (<commented by>).
+
+\begin{keylist}
+\keyitem{withcommentator} The expression <with a commentary by \prm{name}>.
+\keyitem{withannotator} The expression <with annotations by \prm{name}>.
+\keyitem{withintroduction} The expression <with an introduction by \prm{name}>.
+\keyitem{withforeword} The expression <with a foreword by \prm{name}>.
+\keyitem{withafterword} The expression <with an afterword by \prm{name}>.
+\end{keylist}
+
+\subsection*{Supplementary Material}
+
+\begin{keylist}
+\keyitem{commentary} The term <commentary>.
+\keyitem{annotations} The term <annotations>.
+\keyitem{introduction} The term <introduction>.
+\keyitem{foreword} The term <foreword>.
+\keyitem{afterword} The term <afterword>.
+\end{keylist}
+
+\subsection*{Publication Details}
+
+\begin{keylist}
+\keyitem{volume} The term <volume>, referring to a book.
+\keyitem{volumes} The plural form of \texttt{volume}.
+\keyitem{involumes} The term <in>, as used in expressions like <in \prm{number of volumes} volumes>.
+\keyitem{jourvol} The term <volume>, referring to a journal.
+\keyitem{jourser} The term <series>, referring to a journal.
+\keyitem{book} The term <book>, referring to a document division.
+\keyitem{part} The term <part>, referring to a part of a book or a periodical.
+\keyitem{issue} The term <issue>, referring to a periodical.
+\keyitem{newseries} The expression <new series>, referring to a journal.
+\keyitem{oldseries} The expression <old series>, referring to a journal.
+\keyitem{edition} The term <edition>.
+\keyitem{in} The term <in>, referring to the title of a work published as part of another one, e.g. <\prm{title of article} in \prm{title of journal}>.
+\keyitem{inseries} The term <in>, as used in expressions like <volume \prm{number} in \prm{name of series}>.
+\keyitem{ofseries} The term <of>, as used in expressions like <volume \prm{number} of \prm{name of series}>.
+\keyitem{number} The term <number>, referring to an issue of a journal.
+\keyitem{chapter} The term <chapter>, referring to a chapter in a book.
+\keyitem{version} The term <version>, referring to a revision number.
+\keyitem{reprint} The term <reprint>.
+\keyitem{reprintof} The expression <reprint of \prm{title}>.
+\keyitem{reprintas} The expression <reprinted as \prm{title}>.
+\keyitem{reprintfrom} The expression <reprinted from \prm{title}>.
+\keyitem{translationof} The expression <translation of \prm{title}>.
+\keyitem{translationas} The expression <translated as \prm{title}>.
+\keyitem{translationfrom} The expression <translated from [the] \prm{language}>.
+\keyitem{reviewof} The expression <review of \prm{title}>.
+\keyitem{origpubas} The expression <originally published as \prm{title}>.
+\keyitem{origpubin} The expression <originally published in \prm{year}>.
+\keyitem{astitle} The term <as>, as used in expressions like <published by \prm{publisher} as \prm{title}>.
+\keyitem{bypublisher} The term <by>, as used in expressions like <published by \prm{publisher}>.
+\end{keylist}
+
+\subsection*{Publication State}
+
+\begin{keylist}
+\keyitem{inpreparation} The expression <in preparation> (the manuscript is being prepared for publication).
+\keyitem{submitted} The expression <submitted> (the manuscript has been submitted to a journal or conference).
+\keyitem{forthcoming} The expression <forthcoming> (the manuscript has been accepted by a press or journal).
+\keyitem{inpress} The expression <in press> (the manuscript is fully copyedited and out of the author's hands; it is in the final stages of the production process).
+\keyitem{prepublished} The expression <pre-published> (the manuscript is published in a preliminary form or location, such as online version in advance of print publication).
+\end{keylist}
+
+\subsection*{Pagination}
+
+\begin{keylist}
+\keyitem{page} The term <page>.
+\keyitem{pages} The plural form of \texttt{page}.
+\keyitem{column} The term <column>, referring to a column on a page.
+\keyitem{columns} The plural form of \texttt{column}.
+\keyitem{section} The term <section>, referring to a document division (usually abbreviated as \S).
+\keyitem{sections} The plural form of \texttt{section} (usually abbreviated as \S\S).
+\keyitem{paragraph} The term <paragraph> (\ie a block of text, not to be confused with \texttt{section}).
+\keyitem{paragraphs} The plural form of \texttt{paragraph}.
+\keyitem{verse} The term <verse> as used when referring to a work which is cited by verse numbers.
+\keyitem{verses} The plural form of \texttt{verse}.
+\keyitem{line} The term <line> as used when referring to a work which is cited by line numbers.
+\keyitem{lines} The plural form of \texttt{line}.
+\keyitem{pagetotal} The term <page> as used in \cmd{mkpageprefix}.
+\keyitem{pagetotals} The plural form of \texttt{pagetotal}.
+\keyitem{columntotal} The term <column>, referring to a column on a page, as used in \cmd{mkpageprefix}.
+\keyitem{columntotals} The plural form of \texttt{columntotal}.
+\keyitem{sectiontotal} The term <section>, referring to a document division (usually abbreviated as \S),  as used in \cmd{mkpageprefix}.
+\keyitem{sectiontotals} The plural form of \texttt{sectiontotal} (usually abbreviated as \S\S).
+\keyitem{paragraphtotal} The term <paragraph> (\ie a block of text, not to be confused with \texttt{section}) as used in \cmd{mkpageprefix}.
+\keyitem{paragraphtotals} The plural form of \texttt{paragraphtotal}.
+\keyitem{versetotal} The term <verse> as used when referring to a work which is cited by verse numbers when used in \cmd{mkpageprefix}.
+\keyitem{versetotals} The plural form of \texttt{versetotal}.
+\keyitem{linetotal} The term <line> as used when referring to a work which is cited by line numbers when used in \cmd{mkpageprefix}.
+\keyitem{linetotals} The plural form of \texttt{linetotal}.
+\end{keylist}
+
+\subsection*{Types}
+
+The following keys are typically used in the \bibfield{type} field of \bibtype{thesis}, \bibtype{report}, \bibtype{misc}, and other entries:
+
+\begin{keylist}
+\keyitem{bathesis} An expression equivalent to the term <Bachelor's thesis>.
+\keyitem{mathesis} An expression equivalent to the term <Master's thesis>.
+\keyitem{phdthesis} The term <PhD thesis>, <PhD dissertation>, <doctoral thesis>, etc.
+\keyitem{candthesis} An expression equivalent to the term <Candidate thesis>. Used for <Candidate> degrees that have no clear equivalent to the Master's or doctoral level.
+\keyitem{techreport} The term <technical report>.
+\keyitem{resreport} The term <research report>.
+\keyitem{software} The term <computer software>.
+\keyitem{datacd} The term <data \textsc{cd}> or <\textsc{cd-rom}>.
+\keyitem{audiocd} The term <audio \textsc{cd}>.
+\end{keylist}
+
+\subsection*{Dates and Times}
+\begin{keylist}
+\keyitem{commonera} The term used to denote the secular era modern term \eg\ <CE>.
+\keyitem{beforecommonera} The term used to denote the secular era pre-modern term \eg\ <BCE>.
+\keyitem{annodomini} The term used to denote the christian era modern term \eg\ <AD>.
+\keyitem{beforechrist} The term used to denote the christian era pre-modern term \eg\ <BC>.
+\keyitem{circa} The string prefix used to denote approximate dates \eg\ <circa>.
+\keyitem{spring} The string <spring>.
+\keyitem{summer} The string <summer>.
+\keyitem{autumn} The string <autumn>.
+\keyitem{winter} The string <winter>.
+\keyitem{am} The string <AM>.
+\keyitem{pm} The string <PM>.
+\end{keylist}
+
+\subsection*{Miscellaneous}
+
+\begin{keylist}
+\keyitem{nodate} The term to use in place of a date when there is no date for an entry \eg\ <n.d.>
+\keyitem{and} The term <and>, as used in a list of authors or editors, for example.
+\keyitem{andothers} The expression <and others> or <et alii>, used to mark the truncation of a name list.
+\keyitem{andmore} Like \texttt{andothers} but used to mark the truncation of a literal list.
+\end{keylist}
+
+\subsection*{Labels}
+
+The following strings are intended for use as labels, \eg\ <Address: \prm{url}> or <Abstract: \prm{abstract}>.
+
+\begin{keylist}
+\keyitem{url} The term <address> in the sense of an internet address.
+\keyitem{urlfrom} An expression like <available from \prm{url}> or <available at \prm{url}>.
+\keyitem{urlseen} An expression like <accessed on \prm{date}>, <retrieved on \prm{date}>, <visited on \prm{date}>, referring to the access date of an online resource.
+\keyitem{file} The term <file>.
+\keyitem{library} The term <library>.
+\keyitem{abstract} The term <abstract>.
+\keyitem{annotation} The term <annotations>.
+\end{keylist}
+
+\subsection*{Citations}
+
+Traditional scholarly expressions used in citations:
+
+\begin{keylist}
+\keyitem{idem} The term equivalent to the Latin <idem> (<the same [person]>).
+\keyitem{idemsf} The feminine singular form of \texttt{idem}.
+\keyitem{idemsm} The masculine singular form of \texttt{idem}.
+\keyitem{idemsn} The neuter singular form of \texttt{idem}.
+\keyitem{idempf} The feminine plural form of \texttt{idem}.
+\keyitem{idempm} The masculine plural form of \texttt{idem}.
+\keyitem{idempn} The neuter plural form of \texttt{idem}.
+\keyitem{idempp} The plural form of \texttt{idem} suitable for a mixed gender list of names.
+\keyitem{ibidem} The term equivalent to the Latin <ibidem> (<in the same place>).
+\keyitem{opcit} The term equivalent to the Latin term <opere citato> (<[in] the work [already] cited>).
+\keyitem{loccit} The term equivalent to the Latin term <loco citato> (<[at] the place [already] cited>).
+\keyitem{confer} The term equivalent to the Latin <confer> (<compare>).
+\keyitem{sequens} The term equivalent to the Latin <sequens> (<[and] the following [page]>), as used to indicate a range of two pages when only the starting page is provided (\eg\ <25\,sq.> or <25\,f.> instead of <25--26>).
+\keyitem{sequentes} The term equivalent to the Latin <sequentes> (<[and] the following [pages]>), as used to indicate an open"=ended range of pages when only the starting page is provided (\eg\ <25\,sqq.> or <25\,ff.>).
+\keyitem{passim} The term equivalent to the Latin <passim> (<throughout>, <here and there>, <scatteredly>).
+\end{keylist}
+%
+Other expressions frequently used in citations:
+
+\begin{keylist}
+\keyitem{see} The term <see>.
+\keyitem{seealso} The expression <see also>.
+\keyitem{seenote} An expression like <see note \prm{footnote}> or <as in \prm{footnote}>, used to refer to a previous footnote in a citation.
+\keyitem{backrefpage} An expression like <see page \prm{page}> or <cited on page \prm{page}>, used to introduce back references in the bibliography.
+\keyitem{backrefpages} The plural form of \texttt{backrefpage}, \eg\ <see pages \prm{pages}> or <cited on pages \prm{pages}>.
+\keyitem{quotedin} An expression like <quoted in \prm{citation}>, used when quoting a passage which was already a quotation in the cited work.
+\keyitem{citedas} An expression like <henceforth cited as \prm{shorthand}>, used to introduce a shorthand in a citation.
+\keyitem{thiscite} The expression used in some verbose citation styles to differentiate between the page range of the cited item (typically an article in a journal, collection, or conference proceedings) and the page number the citation refers to. For example: \enquote{Author, Title, in: Book, pp. 45--61, \texttt{thiscite} p. 52.}
+\end{keylist}
+
+\subsection*{Month Names}
+
+\begin{keylist}
+\keyitem{january} The name <January>.
+\keyitem{february} The name <February>.
+\keyitem{march} The name <March>.
+\keyitem{april} The name <April>.
+\keyitem{may} The name <May>.
+\keyitem{june} The name <June>.
+\keyitem{july} The name <July>.
+\keyitem{august} The name <August>.
+\keyitem{september} The name <September>.
+\keyitem{october} The name <October>.
+\keyitem{november} The name <November>.
+\keyitem{december} The name <December>.
+\end{keylist}
+
+\subsection*{Language Names}
+
+\begin{keylist}
+\keyitem{langamerican} The language <American> or <American English>.
+\keyitem{langbrazilian} The language <Brazilian> or <Brazilian Portuguese>.
+\keyitem{langbulgarian} The language <Bulgarian>.
+\keyitem{langcatalan} The language <Catalan>.
+\keyitem{langcroatian} The language <Croatian>.
+\keyitem{langczech} The language <Czech>.
+\keyitem{langdanish} The language <Danish>.
+\keyitem{langdutch} The language <Dutch>.
+\keyitem{langenglish} The language <English>.
+\keyitem{langestonian} The language <Estonian>.
+\keyitem{langfinnish} The language <Finnish>.
+\keyitem{langfrench} The language <French>.
+\keyitem{langgerman} The language <German>.
+\keyitem{langgreek} The language <Greek>.
+\keyitem{langhungarian} The language <Hungarian>.
+\keyitem{langitalian} The language <Italian>.
+\keyitem{langjapanese} The language <Japanese>.
+\keyitem{langlatin} The language <Latin>.
+\keyitem{langlatvian} The language <Latvian>.
+\keyitem{langnorwegian} The language <Norwegian>.
+\keyitem{langpolish} The language <Polish>.
+\keyitem{langportuguese} The language <Portuguese>.
+\keyitem{langrussian} The language <Russian>.
+\keyitem{langserbian} The language <Serbian>.
+\keyitem{langslovak} The language <Slovak>.
+\keyitem{langslovene} The language <Slovene>.
+\keyitem{langspanish} The language <Spanish>.
+\keyitem{langswedish} The language <Swedish>.
+\keyitem{langukrainian} The language <Ukrainian>.
+\end{keylist}
+%
+The following strings are intended for use in phrases like <translated from [the] English by \prm{translator}>:
+
+\begin{keylist}
+\keyitem{fromamerican} The expression <from [the] American> or <from [the] American English>.
+\keyitem{frombrazilian} The expression <from [the] Brazilian> or <from [the] Brazilian Portuguese>.
+\keyitem{frombulgarian} The expression <from [the] Bulgarian>.
+\keyitem{fromcatalan} The expression <from [the] Catalan>.
+\keyitem{fromcroatian} The expression <from [the] Croatian>.
+\keyitem{fromczech} The expression <from [the] Czech>.
+\keyitem{fromdanish} The expression <from [the] Danish>.
+\keyitem{fromdutch} The expression <from [the] Dutch>.
+\keyitem{fromenglish} The expression <from [the] English>.
+\keyitem{fromestonian} The expression <from [the] Estonian>.
+\keyitem{fromfinnish} The expression <from [the] Finnish>.
+\keyitem{fromfrench} The expression <from [the] French>.
+\keyitem{fromgerman} The expression <from [the] German>.
+\keyitem{fromgreek} The expression <from [the] Greek>.
+\keyitem{fromhungarian} The language <from [the] Hungarian>.
+\keyitem{fromitalian} The expression <from [the] Italian>.
+\keyitem{fromjapanese} The expression <from [the] Japanese>.
+\keyitem{fromlatin} The expression <from [the] Latin>.
+\keyitem{fromlatvian} The expression <from [the] Latvian>.
+\keyitem{fromnorwegian} The expression <from [the] Norwegian>.
+\keyitem{frompolish} The expression <from [the] Polish>.
+\keyitem{fromportuguese} The expression <from [the] Portuguese>.
+\keyitem{fromrussian} The expression <from [the] Russian>.
+\keyitem{fromserbian} The expression <from [the] Serbian>.
+\keyitem{fromslovak} The expression <from [the] Slovak>.
+\keyitem{fromslovene} The expression <from [the] Slovene>.
+\keyitem{fromspanish} The expression <from [the] Spanish>.
+\keyitem{fromswedish} The expression <from [the] Swedish>.
+\keyitem{fromukrainian} The expression <from [the] Ukrainian>.
+\end{keylist}
+
+\subsection*{Country Names}
+
+Country names are localised by using the string \texttt{country} plus the \acr{ISO}-3166 country code as the key. The short version of the translation should be the \acr{ISO}-3166 country code. Note that only a small number of country names is defined by default, mainly to illustrate this scheme. These keys are used in the \bibfield{location} list of \bibtype{patent} entries but they may be useful for other purposes as well.
+
+\begin{keylist}
+\keyitem{countryde} The name <Germany>, abbreviated as \texttt{DE}.
+\keyitem{countryeu} The name <European Union>, abbreviated as \texttt{EU}.
+\keyitem{countryep} Similar to \texttt{countryeu} but abbreviated as \texttt{EP}. This is intended for \bibfield{patent} entries.
+\keyitem{countryfr} The name <France>, abbreviated as \texttt{FR}.
+\keyitem{countryuk} The name <United Kingdom>, abbreviated (according to \acr{ISO}-3166) as \texttt{GB}.
+\keyitem{countryus} The name <United States of America>, abbreviated as \texttt{US}.
+\end{keylist}
+
+\subsection*{Patents and Patent Requests}
+
+Strings related to patents are localised by using the term \texttt{patent} plus the \acr{ISO}-3166 country code as the key. Note that only a small number of patent keys is defined by default, mainly to illustrate this scheme. These keys are used in the \bibfield{type} field of \bibtype{patent} entries.
+
+\begin{keylist}
+\keyitem{patent} The generic term <patent>.
+\keyitem{patentde} The expression <German patent>.
+\keyitem{patenteu} The expression <European patent>.
+\keyitem{patentfr} The expression <French patent>.
+\keyitem{patentuk} The expression <British patent>.
+\keyitem{patentus} The expression <U.S. patent>.
+\end{keylist}
+%
+Patent requests are handled in a similar way, using the string \texttt{patreq} as the base name of the key:
+
+\begin{keylist}
+\keyitem{patreq} The generic term <patent request>.
+\keyitem{patreqde} The expression <German patent request>.
+\keyitem{patreqeu} The expression <European patent request>.
+\keyitem{patreqfr} The expression <French patent request>.
+\keyitem{patrequk} The expression <British patent request>.
+\keyitem{patrequs} The expression <U.S. patent request>.
+\end{keylist}
+
+\subsection*{Dates and Times}
+
+\begin{keylist}
+\keyitem{commonera} The era <CE>
+\keyitem{beforecommonera} The era <BCE>
+\keyitem{annodomini} The era <AD>
+\keyitem{beforechrist} The era <BC>
+\end{keylist}
+
+\begin{keylist}
+\keyitem{circa} The string <circa>
+\end{keylist}
+
+\begin{keylist}
+\keyitem{spring} The string <spring>
+\keyitem{summer} The string <summer>
+\keyitem{autumn} The string <autumn>
+\keyitem{winter} The string <winter>
+\end{keylist}
+
+\begin{keylist}
+\keyitem{am} The string <AM>
+\keyitem{pm} The string <PM>
+\end{keylist}
+
+\printbibliography
+\end{document}

--- a/tex/latex/biblatex/lbx/turkish.lbx
+++ b/tex/latex/biblatex/lbx/turkish.lbx
@@ -1,0 +1,531 @@
+\ProvidesFile{turkish.lbx}
+[\abx@lbxid]
+
+\DeclareRedundantLanguages{turkish}{turkish}
+
+\DeclareBibliographyExtras{%
+  \DeclareCapitalPunctuation{.!?}%
+  \protected\def\bibrangedash{%
+    \textendash\penalty\hyphenpenalty}% breakable dash
+  \let\finalandcomma=\empty
+  \let\finalandsemicolon=\empty
+  \protected\def\mkbibordinal#1{\stripzeros{#1}\adddot}%
+  \protected\def\mkbibmascord{\mkbibordinal}%
+  \protected\def\mkbibfemord{\mkbibordinal}%
+  \protected\def\mkbibneutord{\mkbibordinal}%
+  \protected\def\mkbibdatelong#1#2#3{%
+    \iffieldundef{#3}
+      {}
+      {\thefield{#3}%
+       \iffieldundef{#2}{}{\nobreakspace}}%
+    \iffieldundef{#2}
+      {}
+      {\mkbibmonth{\thefield{#2}}%
+       \iffieldundef{#1}{}{\space}}%
+    \iffieldbibstring{#1}
+      {\bibstring{\thefield{#1}}}
+      {\dateeraprintpre{#1}\stripzeros{\thefield{#1}}}}%
+  \protected\def\mkbibdateshort#1#2#3{%
+    \iffieldundef{#3}
+      {}
+      {\mkdayzeros{\thefield{#3}}%
+       \iffieldundef{#2}{}{/}}%
+    \iffieldundef{#2}
+      {}
+      {\mkmonthzeros{\thefield{#2}}%
+       \iffieldundef{#1}{}{/}}%
+    \iffieldbibstring{#1}
+      {\bibstring{\thefield{#1}}}
+      {\dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}}%
+   \expandafter\protected\expandafter\def\csname mkbibtime24h\endcsname#1#2#3#4{%
+      \iffieldundef{#1}{}
+        {\printtext{\mktimezeros{\thefield{#1}}}\setunit{\bibtimesep}}%
+      \iffieldundef{#2}{}
+        {\printtext{\mktimezeros{\thefield{#2}}}\setunit{\bibtimesep}}%
+      \iffieldundef{#3}{}
+        {\printtext{\mktimezeros{\thefield{#3}}}}%
+      \setunit{}%
+      \iffieldundef{#4}{}
+        {\bibtimezonesep
+         \mkbibtimezone{\thefield{#4}}}}%
+  \expandafter\protected\expandafter\def\csname mkbibtime12h\endcsname#1#2#3#4{%
+      \stripzeros{\mktimehh{\thefield{#1}}}\bibtimesep
+      \forcezerosmdt{\thefield{#2}}%
+      \iffieldundef{#3}{}
+        {\bibtimesep
+         \forcezerosmdt{\thefield{#3}}}%
+       \space
+       \ifnumless{\thefield{#1}}{12}
+         {\bibstring{am}}
+         {\bibstring{pm}}%
+      \iffieldundef{#4}{}
+       {\space\bibtimezonesep
+        \parentext{\mkbibtimezone{\thefield{#4}}}}}%
+  \protected\def\mkbibseasondateshort#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}%
+  \protected\def\mkbibseasondatelong#1#2{%
+    \mkbibseason{\thefield{#2}}%
+    \iffieldundef{#1}{}{\space}%
+    \dateeraprintpre{#1}\mkyearzeros{\thefield{#1}}}%
+}
+
+\DeclareBibliographyStrings{%
+  bibliography     = {{Kaynak\c{c}a}{Kaynak\c{c}a}},
+  references       = {{Kaynaklar}{Kaynaklar}},
+  shorthands       = {{K\i saltmalar dizini}{K\i saltmalar}},
+  editor           = {{edit\"{o}r}{ed\adddot}},
+  editors          = {{edit\"{o}rler}{ed\adddot}},
+  compiler         = {{derleyen}{der\adddot}},
+  compilers        = {{derleyenler}{der\adddot}},
+  redactor         = {{yay\i na haz\i rlayan}{yay\adddot\ haz\adddot}},
+  redactors        = {{yay\i na haz\i rlayanlar}{yay\adddot\ haz\adddot}},
+  reviser          = {{tashih eden}{tashih\adddot}},
+  revisers         = {{tashih edenler}{tashih\adddot}},
+  founder          = {{kurucu}{kur\adddot}},
+  founders         = {{kurucular}{kur\adddot}},
+  continuator      = {{tamamlayan}{tam\adddot}},
+  continuators     = {{tamamlayanlar}{tam\adddot}},
+  collaborator     = {{ortak}{ortak}},
+  collaborators    = {{ortaklar}{ortaklar}},
+  translator       = {{\c{c}eviren}{\c{c}ev\adddot}},
+  translators      = {{\c{c}evirenler}{\c{c}ev\adddot}},
+  commentator      = {{yorumlayan}{yrm\adddot}},
+  commentators     = {{yorumlayanlar}{yrm\adddot}},
+  annotator        = {{a\c{c}\i klayan}{a\c{c}\i k\adddot}},
+  annotators       = {{a\c{c}\i klayanlar}{a\c{c}\i k\adddot}},
+  commentary       = {{yorum}{yrm\adddot}},
+  annotations      = {{a\c{c}\i klamalar}{a\c{c}\i k\adddot}},
+  introduction     = {{giri\c{s}}{gir\adddot}},
+  foreword         = {{\"{o}ns\"{o}z}{\"{o}ns\adddot}},
+  afterword        = {{sons\"{o}z}{sons\adddot}},
+  editortr         = {{edit\"{o}r ve \c{c}eviren}%
+                      {ed\adddot\ ve \c{c}ev\adddot}},
+  editorstr        = {{edit\"{o}rler ve \c{c}evirenler}%
+                      {ed\adddot\ ve \c{c}ev\adddot}},
+  editorco         = {{edit\"{o}r ve yorumlayan}%
+                      {ed\adddot\ ve yrm\adddot}},
+  editorsco        = {{edit\"{o}rler ve yorumlayanlar}%
+                      {ed\adddot\ ve yrm\adddot}},
+  editoran         = {{edit\"{o}r ve a\c{c}\i klayan}%
+                      {ed\adddot\ ve a\c{c}\i k\adddot}},
+  editorsan        = {{edit\"{o}rler ve a\c{c}\i klayanlar}%
+                      {ed\adddot\ ve a\c{c}\i k\adddot}},
+  editorin         = {{edit\"{o}r ve giri\c{s}}%
+                      {ed\adddot\ ve gir\adddot}},
+  editorsin        = {{edit\"{o}rler ve giri\c{s}}%
+                      {ed\adddot\ ve gir\adddot}},
+  editorfo         = {{edit\"{o}r ve \"{o}ns\"{o}z}%
+                      {ed\adddot\ ve \"{o}ns\adddot}},
+  editorsfo        = {{edit\"{o}rler ve \"{o}ns\"{o}z}%
+                      {ed\adddot\ ve \"{o}ns\adddot}},
+  editoraf         = {{edit\"{o}r ve sons\"{o}z}%
+                      {ed\adddot\ ve sons\adddot}},
+  editorsaf        = {{edit\"{o}rler ve sons\"{o}z}%
+                      {ed\adddot\ ve sons\adddot}},
+  editortrco       = {{edit\"{o}r, \c{c}eviren and yorumlayan}%
+                      {ed\adddot, \c{c}ev\adddot\ ve yrm\adddot}},
+  editorstrco      = {{edit\"{o}rler, \c{c}evirenler ve yorumlayanlar}%
+                      {ed\adddot, \c{c}ev\adddot\ ve yrm\adddot}},
+  editortran       = {{edit\"{o}r, \c{c}eviren ve a\c{c}\i klayan}%
+                      {ed\adddot, \c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  editorstran      = {{edit\"{o}rler, \c{c}evirenler ve a\c{c}\i klayanlar}%
+                      {ed\adddot, \c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  editortrin       = {{edit\"{o}r, \c{c}eviren ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot\ ve gir\adddot}},
+  editorstrin      = {{edit\"{o}rler, \c{c}evirenler ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot\ ve gir\adddot}},
+  editortrfo       = {{edit\"{o}r, \c{c}eviren ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  editorstrfo      = {{edit\"{o}rler, \c{c}evirenler ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  editortraf       = {{edit\"{o}r, \c{c}eviren ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot\ ve sons\adddot}},
+  editorstraf      = {{edit\"{o}rler, \c{c}evirenler ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot\ ve sons\adddot}},
+  editorcoin       = {{edit\"{o}r, yorumlayan ve giri\c{s}}%
+                      {ed\adddot, yrm\adddot\ ve gir\adddot}},
+  editorscoin      = {{edit\"{o}rler, yorumlayanlar ve giri\c{s}}%
+                      {ed\adddot, yrm\adddot\ ve gir\adddot}},
+  editorcofo       = {{edit\"{o}r, yorumlayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  editorscofo      = {{edit\"{o}rler, yorumlayanlar ve \"{o}ns\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  editorcoaf       = {{edit\"{o}r, yorumlayan ve sons\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve sons\adddot}},
+  editorscoaf      = {{edit\"{o}rler, yorumlayanlar ve sons\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve sons\adddot}},
+  editoranin       = {{edit\"{o}r, a\c{c}\i klayan ve giri\c{s}}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  editorsanin      = {{edit\"{o}rler, a\c{c}\i klayanlar ve giri\c{s}}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  editoranfo       = {{edit\"{o}r, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  editorsanfo      = {{edit\"{o}rler, a\c{c}\i klayanlar ve \"{o}ns\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  editoranaf       = {{edit\"{o}r, a\c{c}\i klayan ve sons\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  editorsanaf      = {{edit\"{o}rler, a\c{c}\i klayanlar ve sons\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  editortrcoin     = {{edit\"{o}r, \c{c}eviren, yorumlayan ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  editorstrcoin    = {{edit\"{o}rler, \c{c}evirenler, yorumlayanlar ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  editortrcofo     = {{edit\"{o}r, \c{c}eviren, yorumlayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  editorstrcofo    = {{edit\"{o}rler, \c{c}evirenler, yorumlayanlar ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  editortrcoaf     = {{edit\"{o}r, \c{c}eviren, yorumlayan ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  editorstrcoaf    = {{edit\"{o}rler, \c{c}evirenler, yorumlayanlar ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  editortranin     = {{edit\"{o}r, \c{c}eviren, a\c{c}\i klayan ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  editorstranin    = {{edit\"{o}rler, \c{c}evirenler, a\c{c}\i klayanlar ve giri\c{s}}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  editortranfo     = {{edit\"{o}r, \c{c}eviren, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  editorstranfo    = {{edit\"{o}rler, \c{c}evirenler, a\c{c}\i klayanlar ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  editortranaf     = {{edit\"{o}r, \c{c}eviren, a\c{c}\i klayan ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  editorstranaf    = {{edit\"{o}rler, \c{c}evirenler, a\c{c}\i klayanlar ve sons\"{o}z}%
+                      {ed\adddot, \c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  translatorco     = {{\c{c}eviren ve yorumlayan}%
+                      {\c{c}ev\adddot\ ve yrm\adddot}},
+  translatorsco    = {{\c{c}evirenler ve yorumlayanlar}%
+                      {\c{c}ev\adddot\ ve yrm\adddot}},
+  translatoran     = {{\c{c}eviren ve a\c{c}\i klayan}%
+                      {\c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  translatorsan    = {{\c{c}evirenler ve a\c{c}\i klayanlar}%
+                      {\c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  translatorin     = {{\c{c}eviren ve giri\c{s}}%
+                      {\c{c}ev\adddot\ ve gir\adddot}},
+  translatorsin    = {{\c{c}evirenler ve giri\c{s}}%
+                      {\c{c}ev\adddot\ ve gir\adddot}},
+  translatorfo     = {{\c{c}eviren ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  translatorsfo    = {{\c{c}evirenler ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  translatoraf     = {{\c{c}eviren ve sons\"{o}z}%
+                      {\c{c}ev\adddot\ ve sons\adddot}},
+  translatorsaf    = {{\c{c}evirenler ve sons\"{o}z}%
+                      {\c{c}ev\adddot\ ve sons\adddot}},
+  translatorcoin   = {{\c{c}eviren, yorumlayan ve giri\c{s}}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  translatorscoin  = {{\c{c}evirenler, yorumlayanlar ve giri\c{s}}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  translatorcofo   = {{\c{c}eviren, yorumlayan ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  translatorscofo  = {{\c{c}evirenler, yorumlayanlar ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  translatorcoaf   = {{\c{c}eviren, yorumlayan ve sons\"{o}z}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  translatorscoaf  = {{\c{c}evirenler, yorumlayanlar ve sons\"{o}z}%
+                      {\c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  translatoranin   = {{\c{c}eviren, a\c{c}\i klayan ve giri\c{s}}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  translatorsanin  = {{\c{c}evirenler, a\c{c}\i klayanlar ve giri\c{s}}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  translatoranfo   = {{\c{c}eviren, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  translatorsanfo  = {{\c{c}evirenler, a\c{c}\i klayanlar ve \"{o}ns\"{o}z}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  translatoranaf   = {{\c{c}eviren, a\c{c}\i klayan ve sons\"{o}z}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  translatorsanaf  = {{\c{c}evirenler, a\c{c}\i klayanlar ve sons\"{o}z}%
+                      {\c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  organizer        = {{organizat\"{o}r}{org\adddot}},
+  organizers       = {{organizat\"{o}rler}{org\adddot}},
+  byorganizer      = {{organizat\"{o}r}{org\adddot}},
+  byauthor         = {{yazar}{yazar}},
+  byeditor         = {{edit\"{o}r}{ed\adddot}},
+  bycompiler       = {{derleyen}{der\adddot}},
+  byredactor       = {{yay\i na haz\i rlayan}{yay\adddot\ haz\adddot}},
+  byreviser        = {{tashih}{tashih}},
+  byreviewer       = {{de\u{g}erlendiren}{de\u{g}\adddot}},
+  byfounder        = {{kurucu}{kur\adddot}},
+  bycontinuator    = {{tamamlayan}{tam\adddot}},
+  bycollaborator   = {{ortakla\c{s}a yapanlar}{ortak\adddot\ yap\adddot}},
+  bytranslator     = {{\lbx@lfromlang\ \c{c}eviren}{\lbx@sfromlang\ \c{c}ev\adddot}},
+  bycommentator    = {{yorumlayan}{yrm\adddot}},
+  byannotator      = {{a\c{c}\i klayan}{a\c{c}\i k\adddot}},
+  withcommentator  = {{yorumlar\i yla katk\i da bulunan}{yrm\adddot\ kat\adddot\ bul\adddot}},
+  withannotator    = {{a\c{c}\i klamalar\i yla katk\i da bulunan}{a\c{c}\i k\adddot\ kat\adddot\ bul\adddot}},
+  withintroduction = {{giri\c{si yazan}}{gir\adddot\ yaz\adddot}}, 
+  withforeword     = {{\"{o}ns\"{o}z\"{u} yazan}{\"{o}ns\adddot\ yaz\adddot}},% 
+  withafterword    = {{sons\"{o}z\"{u} yazan}{sons\adddot\ yaz\adddot}},
+  byeditortr       = {{edit\"{o}r ve \lbx@lfromlang\ \c{c}eviren}%
+                      {ed\adddot\ ve \lbx@sfromlang\ \c{c}ev\adddot}},
+  byeditorco       = {{edit\"{o}r ve yorumlayan}%
+                      {ed\adddot\ ve yrm\adddot}},
+  byeditoran       = {{edit\"{o}r ve a\c{c}\i klayan}%
+                      {ed\adddot\ ve a\c{c}\i k\adddot}},
+  byeditorin       = {{edit\"{o}r ve giri\c{s}}%
+                      {ed\adddot\ ve gir\adddot}},
+  byeditorfo       = {{edit\"{o}r ve \"{o}ns\"{o}z}%
+                      {ed\adddot\ ve \"{o}ns\adddot}},
+  byeditoraf       = {{edit\"{o}r ve sons\"{o}z}%
+                      {ed\adddot\ ve sons\adddot}},
+  byeditortrco     = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren ve yorumlayan}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot\ ve yrm\adddot}},
+  byeditortran     = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren ve a\c{c}\i klayan}%
+                      {ed\adddot,  \lbx@sfromlang\ \c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  byeditortrin     = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren ve giri\c{s}}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot\ ve gir\adddot}},
+  byeditortrfo     = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  byeditortraf     = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren ve sons\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot\ ve sons\adddot}},
+  byeditorcoin     = {{edit\"{o}r, yorumlayan ve giri\c{s}}%
+                      {ed\adddot, yrm\adddot\ ve gir\adddot}},
+  byeditorcofo     = {{edit\"{o}r, yorumlayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  byeditorcoaf     = {{edit\"{o}r, yorumlayan ve sons\"{o}z}%
+                      {ed\adddot, yrm\adddot\ ve sons\adddot}},
+  byeditoranin     = {{edit\"{o}r, a\c{c}\i klayan ve giri\c{s}}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  byeditoranfo     = {{edit\"{o}r, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  byeditoranaf     = {{edit\"{o}r, a\c{c}\i klayan ve sons\"{o}z}%
+                      {ed\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  byeditortrcoin   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, yorumlayan ve giri\c{s}}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  byeditortrcofo   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, yorumlayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  byeditortrcoaf   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, yorumlayan ve sons\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  byeditortranin   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve giri\c{s}}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  byeditortranfo   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  byeditortranaf   = {{edit\"{o}r, \lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve sons\"{o}z}%
+                      {ed\adddot, \lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  bytranslatorco   = {{\lbx@lfromlang\ \c{c}eviren ve yorumlayan}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot\ ve yrm\adddot}},
+  bytranslatoran   = {{\lbx@lfromlang\ \c{c}eviren ve a\c{c}\i klayan}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot\ ve a\c{c}\i k\adddot}},
+  bytranslatorin   = {{\lbx@lfromlang\ \c{c}eviren ve giri\c{s}}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot\ ve gir\adddot}},
+  bytranslatorfo   = {{\lbx@lfromlang\ \c{c}eviren ve \"{o}ns\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot\ ve \"{o}ns\adddot}},
+  bytranslatoraf   = {{\lbx@lfromlang\ \c{c}eviren ve sons\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot\ ve sons\adddot}},
+  bytranslatorcoin = {{\lbx@lfromlang\ \c{c}eviren, yorumlayan ve giri\c{s}}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve gir\adddot}},
+  bytranslatorcofo = {{\lbx@lfromlang\ \c{c}eviren, yorumlayan ve \"{o}ns\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve \"{o}ns\adddot}},
+  bytranslatorcoaf = {{\lbx@lfromlang\ \c{c}eviren, yorumlayan ve sons\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, yrm\adddot\ ve sons\adddot}},
+  bytranslatoranin = {{\lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve giri\c{s}}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve gir\adddot}},
+  bytranslatoranfo = {{\lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve \"{o}ns\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve \"{o}ns\adddot}},
+  bytranslatoranaf = {{\lbx@lfromlang\ \c{c}eviren, a\c{c}\i klayan ve sons\"{o}z}%
+                      {\lbx@sfromlang\ \c{c}ev\adddot, a\c{c}\i k\adddot\ ve sons\adddot}},
+  and              = {{ve}{ve}},
+  andothers        = {{ve di\u{g}erleri}{ve di\u{g}\adddot}},
+  andmore          = {{ve di\u{g}erleri}{ve di\u{g}\adddot}},
+  volume           = {{cilt}{c\adddot}},
+  volumes          = {{cilt}{c\adddot}},
+  involumes        = {{i\c{c}inde}{i\c{c}inde}},
+  jourvol          = {{cilt}{c\adddot}},
+  jourser          = {{seri}{seri}},
+  book             = {{kitap}{kitap}},
+  part             = {{k\i s\i m}{k\i s\i m}},
+  issue            = {{say\i}{say\i}},
+  newseries        = {{yeni seri}{yeni seri}},
+  oldseries        = {{eski seri}{eski seri}},
+  edition          = {{bask\i}{bs\adddot}},
+  reprint          = {{yeni bask\i s\i}{yeni bask\i s\i}}, 
+  reprintof        = {{yeni bask\i s\i}{yeni bask\i s\i}}, 
+  reprintas        = {{yeni bask\i s\i}{yeni bask\i s\i}},  
+  reprintfrom      = {{yeni bask\i s\i}{yeni bask\i s\i}}, 
+  reviewof         = {{derlenen eser}{der\adddot\ eser}}, 
+  translationof    = {{\c{c}evirilen eser}{\c{c}ev\adddot\ eser}},  
+  translationas    = {{\c{c}evirilen eser}{\c{c}ev\adddot\ eser}}, 
+  translationfrom  = {{\c{c}evirilen eser}{\c{c}ev\adddot\ eser}}, 
+  origpubas        = {{as\i l eser}{as\i l eser}},
+  origpubin        = {{as\i l eser yay\i n tarihi}{as\i l eser yay\i n tarihi}},
+  astitle          = {{yeni ba\c{s}l\i k}{yeni ba\c{s}l\i k}},
+  bypublisher      = {{yay\i n evi}{yay\i n evi}}, 
+  nodate           = {{tarih yok}{t\adddot y\adddot}},
+  page             = {{sayfa}{s\adddot}},
+  pages            = {{sayfalar}{ss\adddot}},
+  column           = {{s\"{u}tun}{s\"{u}t\adddot}},
+  columns          = {{s\"{u}tunlar}{s\"{u}t\adddot}},
+  line             = {{sat\i r}{sat\adddot}},
+  lines            = {{sat\i rlar}{sat\adddot}},
+  verse            = {{m\i sra}{m\i s\adddot}},
+  verses           = {{m\i sralar}{m\i s\adddot}},
+  section          = {{b\"{o}l\"{u}m}{b\"{o}l\adddot}},
+  sections         = {{b\"{o}l\"{u}mler}{b\"{o}l\adddot}},
+  paragraph        = {{paragraf}{par\adddot}},
+  paragraphs       = {{paragraflar}{par\adddot}},
+  pagetotal        = {{toplam sayfa}{s\adddot}},
+  pagetotals       = {{toplam sayfalar}{ss\adddot}},
+  columntotal      = {{toplam s\"{u}tun}{s\"{u}t\adddot}},
+  columntotals     = {{toplam s\"{u}tunlar}{s\"{u}t\adddot}},
+  linetotal        = {{toplam sat\i r}{sat\adddot}},
+  linetotals       = {{toplam sat\i rlar}{sat\adddot}},
+  versetotal       = {{toplam m\i sra}{m\i s\adddot}},
+  versetotals      = {{toplam m\i sralar}{m\i s\adddot}},
+  sectiontotal     = {{toplam b\"{o}l\"{u}m}{b\"{o}l\adddot}},
+  sectiontotals    = {{toplam b\"{o}l\"{u}mler}{b\"{o}l\adddot}},
+  paragraphtotal   = {{toplam paragraf}{par\adddot}},
+  paragraphtotals  = {{toplam paragraflar}{par\adddot}},
+  in               = {{i\c{c}inde}{i\c{c}inde}},
+  inseries         = {{serilerde}{serilerde}},
+  ofseries         = {{serilerde}{serilerde}},
+  number           = {{numara}{no\adddot}},
+  chapter          = {{b\"{o}l\"{u}m}{b\"{o}l\adddot}},
+  bathesis         = {{lisans tezi}{lis\adddot\ tezi}},
+  mathesis         = {{y\"{u}ksek lisans tezi}{y\"{u}k\adddot\ lis\adddot\ tezi}},
+  phdthesis        = {{doktora tezi}{dok\adddot\ tezi}},
+  candthesis       = {{aday tezi}{aday tezi}},
+  resreport        = {{ara\c{s}t\i rma raporu}{ara\c{s}\adddot\ rap\adddot}},
+  techreport       = {{teknik rapor}{tek\adddot\ rap\adddot}},
+  software         = {{bilgisayar yaz\i l\i m\i}{bilg\adddot\ yaz\adddot}},
+  datacd           = {{CD}{CD}},
+  audiocd          = {{ses CD'si}{ses CD'si}},
+  version          = {{versiyon}{ver\adddot}},
+  url              = {{eri\c{s}im adresi}{eri\c{s}im adresi}},
+  urlfrom          = {{eri\c{s}im adresi}{eri\c{s}im adresi}},
+  urlseen          = {{eri\c{s}im tarihi}{eri\c{s}im tarihi}},
+  inpreparation    = {{haz\i rl\i k a\c{s}amas\i nda}{haz\i rl\i k a\c{s}amas\i nda}},
+  submitted        = {{g\"{o}nderilmi\c{s}tir}{g\"{o}nderilmi\c{s}tir}},
+  forthcoming      = {{yak\i nda}{yak\i nda}},
+  inpress          = {{bas\i m a\c{s}amas\i nda}{bas\i m a\c{s}amas\i nda}},
+  prepublished     = {{taslak bas\i m\i}{taslak bas\i m\i}},
+  citedas          = {{at\i f olarak}{at\i f olarak}},
+  thiscite         = {{\"{o}zellikle}{\"{o}z\adddot\ bkz\adddot}},
+  seenote          = {{nota bak\i n\i z}{nota bkz\adddot}},
+  quotedin         = {{al\i nt\i}{al\i nt\i}},
+  idem             = {{ayn\i}{ayn\i}},
+  idemsm           = {{ayn\i}{ayn\i}},
+  idemsf           = {{ayn\i}{ayn\i}},
+  idemsn           = {{ayn\i}{ayn\i}},
+  idempm           = {{ayn\i lar\i}{ayn\i lar\i}},
+  idempf           = {{ayn\i lar\i}{ayn\i lar\i}},
+  idempn           = {{ayn\i lar\i}{ayn\i lar\i}},
+  idempp           = {{ayn\i lar\i}{ayn\i lar\i}},
+  ibidem           = {{ayn{\i} yer}{ayn{\i} yer}},
+  opcit            = {{at\i f yap\i lan \c{c}al\i\c{s}ma}{at\i f yap\adddot\ \c{c}al\adddot}},
+  loccit           = {{at\i f yap\i lan yer}{at\i f yap\adddot\ yer}},
+  confer           = {{kar\c{s}\i la\c{s}t\i r}{kar\c{s}\adddot}},
+  sequens          = {{takip eden}{takip eden}},
+  sequentes        = {{takip eden}{takip eden}},
+  passim           = {{rastgele}{rastgele}},
+  see              = {{bak\i n\i z}{bkz\adddot}},
+  seealso          = {{ayr\i ca bak\i n\i z}{ayr\i ca bkz\adddot}},
+  backrefpage      = {{sayfada g\"{o}sterilmi\c{s}tir}{say\adddot\ g\"{o}s\adddot}},
+  backrefpages     = {{sayfalarda g\"{o}sterilmi\c{s}tir}{say\adddot\ g\"{o}s\adddot}},
+  january          = {{Ocak}{Ocak}},
+  february         = {{\c{S}ubat}{\c{S}ub\adddot}},
+  march            = {{Mart}{Mar\adddot}},
+  april            = {{Nisan}{Nis\adddot}},
+  may              = {{May\i s}{May\adddot}},
+  june             = {{Haziran}{Haz\adddot}},
+  july             = {{Temmuz}{Tem\adddot}},
+  august           = {{A\u{g}ustos}{A\u{g}us\adddot}},
+  september        = {{Eyl\"{u}l}{Eyl\adddot}},
+  october          = {{Ekim}{Ekim}},
+  november         = {{Kas\i m}{Kas\adddot}},
+  december         = {{Aral\i k}{Ara\adddot}},
+  langamerican     = {{Amerikanca}{Amerikanca}},
+  langbrazilian    = {{Brezilyanca}{Brezilyanca}},
+  langbulgarian    = {{Bulgarca}{Bulgarca}},
+  langcatalan      = {{Katalanca}{Katalanca}},
+  langcroatian     = {{H\i rvat\c{c}a}{H\i rvat\c{c}a}},
+  langczech        = {{\c{C}ek\c{c}e}{\c{C}ek\c{c}e}},
+  langdanish       = {{Danimarkanca}{Danimarkanca}},
+  langdutch        = {{Flemenk\c{c}e}{Flemenk\c{c}e}},
+  langenglish      = {{\.{I}ngilizce}{\.{I}ngilizce}},
+  langestonian     = {{Estonca}{Estonca}},
+  langfinnish      = {{Fince}{Fince}},
+  langfrench       = {{Frans\i zca}{Frans\i zca}},
+  langgalician     = {{Galce}{Galce}},
+  langgerman       = {{Almanca}{Almanca}},
+  langgreek        = {{Yunanca}{Yunanca}},
+  langhungarian    = {{Macarca}{Macarca}},
+  langitalian      = {{\.{I}talyanca}{\.{I}talyanca}},
+  langjapanese     = {{Japonca}{Japonca}},
+  langlatin        = {{Latince}{Latince}},
+  langlatvian      = {{Letonca}{Letonca}},
+  langnorwegian    = {{Norve\c{c}\c{c}e}{Norve\c{c}\c{c}e}},
+  langpolish       = {{Polonyaca}{Polonyaca}},
+  langportuguese   = {{Portekizce}{Portekizce}},
+  langrussian      = {{Rus\c{c}a}{Rus\c{c}a}},
+  %langserbian      = {{S\i rp\c{c}a}{S\i rp\c{c}a}},
+  langslovak       = {{Slovak\c{c}a}{Slovak\c{c}a}},
+  langslovene      = {{Slovence}{Slovence}},
+  langspanish      = {{\.{I}spanyolca}{\.{I}spanyolca}},
+  langswedish      = {{\.{I}sve\c{c}\c{c}e}{\.{I}sve\c{c}\c{c}e}},
+  langukrainian    = {{Ukraynaca}{Ukraynaca}},
+  fromamerican     = {{Amerikanca'dan}{Amerikanca'dan}},
+  frombrazilian    = {{Brezilyanca'dan}{Brezilyanca'dan}},
+  frombulgarian    = {{Bulgarca'dan}{Bulgarca'dan}},
+  fromcatalan      = {{Katalanca'dan}{Katalanca'dan}},
+  fromcroatian     = {{H\i rvat\c{c}a'dan}{H\i rvat\c{c}a'dan}},
+  fromczech        = {{\c{C}ek\c{c}e'den}{\c{C}ek\c{c}e'den}},
+  fromdanish       = {{Danimarkanca'dan}{Danimarkanca'dan}},
+  fromdutch        = {{Flemenk\c{c}e'den}{Flemenk\c{c}e'den}},
+  fromenglish      = {{\.{I}ngilizce'den}{\.{I}ngilizce'den}},
+  fromestonian     = {{Estonyaca'dan}{Estonyaca'dan}},
+  fromfinnish      = {{Fince'den}{Fince'den}},
+  fromfrench       = {{Frans\i zca'dan}{Frans\i zca'dan}},
+  fromgalician     = {{Galyaca'dan}{Galyaca'dan}},
+  fromgerman       = {{Almanca'dan}{Almanca'dan}},
+  fromgreek        = {{Yunanca'dan}{Yunanca'dan}},
+  fromhungarian    = {{Macarca'dan}{Macarca'dan}},
+  fromitalian      = {{\.{I}talyanca'dan}{\.{I}talyanca'dan}},
+  fromjapanese     = {{Japonca'dan}{Japonca'dan}},
+  fromlatin        = {{Latince'den}{Latince'den}},
+  fromlatvian      = {{Latvianca'dan}{Latvianca'dan}},
+  fromnorwegian    = {{Norve\c{c}\c{c}e'den}{Norve\c{c}\c{c}e'den}},
+  frompolish       = {{Polonyaca'dan}{Polonyaca'dan}},
+  fromportuguese   = {{Portekizce'den}{Portekizce'den}},
+  fromrussian      = {{Rus\c{c}a'dan}{Rus\c{c}a'dan}},
+  %fromserbian      = {{S\i rp\c{c}a'dan}{S\i rp\c{c}a'dan}},
+  fromslovak       = {{Slovak\c{c}a'dan}{Slovak\c{c}a'dan}},
+  fromslovene      = {{Slovence'den}{Slovence'den}},
+  fromspanish      = {{\.{I}spanyolca'dan}{\.{I}spanyolca'dan}},
+  fromswedish      = {{\.{I}sve\c{c}\c{c}e'den}{\.{I}sve\c{c}\c{c}e'den}},
+  fromukrainian    = {{Ukraynaca'dan}{Ukraynaca'dan}},
+  countryde        = {{Almanya}{DE}},
+  countryeu        = {{Avrupa Birli\u{g}i}{AB}},
+  countryep        = {{Avrupa Birli\u{g}i}{AB}},
+  countryfr        = {{Fransa}{FR}},
+  countryuk        = {{Birle\c{s}ik Krall\i k}{BK}},
+  countryus        = {{Amerika Birle\c{s}ik Devletleri}{ABD}},
+  patent           = {{patent}{pat\adddot}},
+  patentde         = {{Alman patenti}{Alman pat\adddot}},
+  patenteu         = {{Avrupa patenti}{Avrupa pat\adddot}},
+  patentfr         = {{Frans\i z patenti}{Frans\i z pat\adddot}},
+  patentuk         = {{\.{I}ngiliz patenti}{\.{I}ngiliz pat\adddot}},
+  patentus         = {{Amerika patenti}{Amerika pat\adddot}},
+  patreq           = {{patent beklemede}{pat\adddot\ bek\adddot}},
+  patreqde         = {{Alman patenti beklemede}{Alman pat\adddot\ bek\adddot}},
+  patreqeu         = {{Avrupa patenti beklemede}{Avrupa pat\adddot\ bek\adddot}},
+  patreqfr         = {{Frans\i z patenti beklemede}{Frans\i z pat\adddot\ bek\adddot}},
+  patrequk         = {{\.{I}ngiliz patenti beklemede}{\.{I}ngiliz pat\adddot\ bek\adddot}},
+  patrequs         = {{Amerika patenti beklemede}{Amerika pat\adddot\ bek\adddot}},
+  file             = {{dosya}{dosya}},
+  library          = {{k\"{u}t\"{u}phane}{k\"{u}t\"{u}phane}},
+  abstract         = {{\"{o}zet}{\"{o}zet}},
+  annotation       = {{a\c{c}\i klama}{a\c{c}\i klama}},
+  commonera        = {{milattan sonra}{MS}},
+  beforecommonera  = {{milattan \"{o}nce}{M\"{O}}},
+  annodomini       = {{milattan sonra}{MS}},
+  beforechrist     = {{milattan \"{o}nce}{M\"{O}}},
+  circa            = {{yakla\c{s}\i k olarak}{yak\adddot}},
+  spring           = {{\.{I}lkbahar}{\.{I}lkbahar}},
+  summer           = {{Yaz}{Yaz}},
+  autumn           = {{Sonbahar}{Sonbahar}},
+  winter           = {{K\i \c{s}}{K\i \c{s}}},
+  am               = {{\"{o}\u{g}leden \"{o}nce}{\"{O}\"{O}}},
+  pm               = {{\"{o}\u{g}leden sonra}{\"{O}S}},
+}
+
+\endinput


### PR DESCRIPTION
I have the turkish.lbx and 03-localization-keys.tex files ready for merging with the dev branch. 

It's important to note that the following are needed in the localization file for Turkish: 

```
\usepackage[turkish, shorthands=:!]{babel} % The babel module for Turkish defines = as a shorthand that is aimed to leave some space before it in case it's used in text.
```

```
\DeclareQuoteStyle{turkish}%
  {\textquotedblleft}
  {\textquotedblright}
  [0.05em]
  {\textquotedblleft}
  {\textquotedblright}
```