### PR TITLE
Fix Swedish translation of `nodate`.

### DIFF
--- a/tex/latex/biblatex/lbx/swedish.lbx
+++ b/tex/latex/biblatex/lbx/swedish.lbx
@@ -336,7 +336,7 @@
   origpubin        = {{ursprungligen publicerad}{ursprungligen publ\adddot}},
   astitle          = {{som}{som}},
   bypublisher      = {{av}{av}},
-  nodate           = {{u\adddot d\adddot}{n\adddot d\adddot}},%FIXME
+  nodate           = {{utan \aa rtal}{u\adddot \aa \adddot}},
   page             = {{sidan}{s\adddot}},
   pages            = {{sidorna}{s\adddot}},
   column           = {{spalt}{sp\adddot}},

--- a/tex/latex/biblatex/lbx/swedish.lbx
+++ b/tex/latex/biblatex/lbx/swedish.lbx
@@ -336,7 +336,7 @@
   origpubin        = {{ursprungligen publicerad}{ursprungligen publ\adddot}},
   astitle          = {{som}{som}},
   bypublisher      = {{av}{av}},
-  nodate           = {{utan \aa rtal}{u\adddot \aa \adddot}},
+  nodate           = {{u\adddot\,\aa \adddot}{u\adddot\,\aa \adddot}},
   page             = {{sidan}{s\adddot}},
   pages            = {{sidorna}{s\adddot}},
   column           = {{spalt}{sp\adddot}},


### PR DESCRIPTION
Below are the links to some university style guides all suggesting this way of writing.

I'm unsure if the `å` is correct (I haven't tested it) since it's written `\aa ` including the trailing space before `\adddot`. This seems to be the how it's written elsewhere though.

Umeå universitet, Harvard - hänvisningar i text
https://www.umu.se/bibliotek/soka-skriva-studera/skriva-referenser/harvard-hanvisningar-i-text/

Karolinska Institutet, Referensguide för APA
https://tools.kib.ki.se/referensguide/apa/#webb-webbsidor

Jönköpings universitet, APA – Referenshantering
https://guides.library.ju.se/c.php?g=668119&p=4842879

Röda korsets högskola, Guide till referenshanteringenligt APA-systemet
https://www.sh.se/download/18.7d9f1b25167c61c5af38f695/1551022923629/APA_referenser_2015.pdf