### PR TITLE
Rework abbreviations in German.lbx (#997)

### DIFF
--- a/tex/latex/biblatex/lbx/german.lbx
+++ b/tex/latex/biblatex/lbx/german.lbx
@@ -122,141 +122,141 @@
   foreword         = {{Vorwort}{Vorw\adddot}},
   afterword        = {{Nachwort}{Nachw\adddot}},
   editortr         = {{Herausgeber und \"Ubersetzer}%
-                      {Hrsg\adddot\ und \"Ubers\adddot}},
+                      {Hrsg\adddotspace und \"Ubers\adddot}},
   editorstr        = {{Herausgeber und \"Ubersetzer}%
-                      {Hrsg\adddot\ und \"Ubers\adddot}},
+                      {Hrsg\adddotspace und \"Ubers\adddot}},
   editorco         = {{Herausgeber und Kommentator}%
-                      {Hrsg\adddot\ und Komm\adddot}},
+                      {Hrsg\adddotspace und Komm\adddot}},
   editorsco        = {{Herausgeber und Kommentatoren}%
-                      {Hrsg\adddot\ und Komm\adddot}},
+                      {Hrsg\adddotspace und Komm\adddot}},
   editoran         = {{Herausgeber und Kommentator}%
-                      {Hrsg\adddot\ und Komm\adddot}},
+                      {Hrsg\adddotspace und Komm\adddot}},
   editorsan        = {{Herausgeber und Kommentatoren}%
-                      {Hrsg\adddot\ und Komm\adddot}},
+                      {Hrsg\adddotspace und Komm\adddot}},
   editorin         = {{Herausgabe und Einleitung}%
-                      {Hrsg\adddot\ und Einl\adddot}},
+                      {Hrsg\adddotspace und Einl\adddot}},
   editorsin        = {{Herausgeber und Einleitung}%
-                      {Hrsg\adddot\ und Einl\adddot}},
+                      {Hrsg\adddotspace und Einl\adddot}},
   editorfo         = {{Herausgeber und Vorwort}%
-                      {Hrsg\adddot\ und Vorw\adddot}},
+                      {Hrsg\adddotspace und Vorw\adddot}},
   editorsfo        = {{Herausgabe und Vorwort}%
-                      {Hrsg\adddot\ und Vorw\adddot}},
+                      {Hrsg\adddotspace und Vorw\adddot}},
   editoraf         = {{Herausgabe und Nachwort}%
-                      {Hrsg\adddot\ und Nachw\adddot}},
+                      {Hrsg\adddotspace und Nachw\adddot}},
   editorsaf        = {{Herausgabe und Nachwort}%
-                      {Hrsg\adddot\ und Nachw\adddot}},
+                      {Hrsg\adddotspace und Nachw\adddot}},
   editortrco       = {{Herausgeber, \"Ubersetzer und Kommentator}%
-                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Komm\adddot}},
   editorstrco      = {{Herausgeber, \"Ubersetzer und Kommentatoren}%
-                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Komm\adddot}},
   editortran       = {{Herausgeber, \"Ubersetzer und Kommentator}%
-                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Komm\adddot}},
   editorstran      = {{Herausgeber, \"Ubersetzer und Kommentatoren}%
-                      {Hrsg., \"Ubers\adddot\ und Komm\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Komm\adddot}},
   editortrin       = {{Herausgabe, \"Ubersetzung und Einleitung}%
-                      {Hrsg., \"Ubers\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Einl\adddot}},
   editorstrin      = {{Herausgabe, \"Ubersetzung und Einleitung}%
-                      {Hrsg., \"Ubers\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Einl\adddot}},
   editortrfo       = {{Herausgabe, \"Ubersetzung und Vorwort}%
-                      {Hrsg., \"Ubers\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Vorw\adddot}},
   editorstrfo      = {{Herausgabe, \"Ubersetzung und Vorwort}%
-                      {Hrsg., \"Ubers\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Vorw\adddot}},
   editortraf       = {{Herausgabe, \"Ubersetzung und Nachwort}%
-                      {Hrsg., \"Ubers\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Nachw\adddot}},
   editorstraf      = {{Herausgabe, \"Ubersetzung und Nachwort}%
-                      {Hrsg., \"Ubers\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers\adddotspace und Nachw\adddot}},
   editorcoin       = {{Herausgabe, Kommentar und Einleitung}%
-                      {Hrsg., Komm\adddot\ und Einl\adddot}},
+                      {Hrsg., Komm\adddotspace und Einl\adddot}},
   editorscoin      = {{Herausgabe, Kommentar und Einleitung}%
-                      {Hrsg., Komm\adddot\ und Einl\adddot}},
+                      {Hrsg., Komm\adddotspace und Einl\adddot}},
   editorcofo       = {{Herausgabe, Kommentar und Vorwort}%
-                      {Hrsg., Komm\adddot\ und Vorw\adddot}},
+                      {Hrsg., Komm\adddotspace und Vorw\adddot}},
   editorscofo      = {{Herausgabe, Kommentar und Vorwort}%
-                      {Hrsg., Komm\adddot\ und Vorw\adddot}},
+                      {Hrsg., Komm\adddotspace und Vorw\adddot}},
   editorcoaf       = {{Herausgabe, Kommentar und Nachwort}%
-                      {Hrsg., Komm\adddot\ und Nachw\adddot}},
+                      {Hrsg., Komm\adddotspace und Nachw\adddot}},
   editorscoaf      = {{Herausgabe, Kommentar und Nachwort}%
-                      {Hrsg., Komm\adddot\ und Nachw\adddot}},
+                      {Hrsg., Komm\adddotspace und Nachw\adddot}},
   editoranin       = {{Herausgabe, Erl\"auterungen und Einleitung}%
-                      {Hrsg., Erl\"aut\adddot\ und Einl\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Einl\adddot}},
   editorsanin      = {{Herausgabe, Erl\"auterungen und Einleitung}%
-                      {Hrsg., Erl\"aut\adddot\ und Einl\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Einl\adddot}},
   editoranfo       = {{Herausgabe, Erl\"auterungen und Vorwort}%
-                      {Hrsg., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Vorw\adddot}},
   editorsanfo      = {{Herausgabe, Erl\"auterungen und Vorwort}%
-                      {Hrsg., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Vorw\adddot}},
   editoranaf       = {{Herausgabe, Erl\"auterungen und Nachwort}%
-                      {Hrsg., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Nachw\adddot}},
   editorsanaf      = {{Herausgabe, Erl\"auterungen und Nachwort}%
-                      {Hrsg., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {Hrsg., Erl\"aut\adddotspace und Nachw\adddot}},
   editortrcoin     = {{Herausgabe, \"Ubersetzung, Kommentar und Einleitung}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Einl\adddot}},
   editorstrcoin    = {{Herausgabe, \"Ubersetzung, Kommentar und Einleitung}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Einl\adddot}},
   editortrcofo     = {{Herausgabe, \"Ubersetzung, Kommentar und Vorwort}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Vorw\adddot}},
   editorstrcofo    = {{Herausgabe, \"Ubersetzung, Kommentar und Vorwort}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Vorw\adddot}},
   editortrcoaf     = {{Herausgabe, \"Ubersetzung, Kommentar und Nachwort}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Nachw\adddot}},
   editorstrcoaf    = {{Herausgabe, \"Ubersetzung, Kommentar und Nachwort}%
-                      {Hrsg., \"Ubers., Komm\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers., Komm\adddotspace und Nachw\adddot}},
   editortranin     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Einleitung}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Einl\adddot}},
   editorstranin    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Einleitung}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Einl\adddot}},
   editortranfo     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Vorwort}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Vorw\adddot}},
   editorstranfo    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Vorwort}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Vorw\adddot}},
   editortranaf     = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Nachwort}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Nachw\adddot}},
   editorstranaf    = {{Herausgabe, \"Ubersetzung, Erl\"auterungen und Nachwort}%
-                      {Hrsg., \"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {Hrsg., \"Ubers., Erl\"aut\adddotspace und Nachw\adddot}},
   translatorco     = {{\"Ubersetzung und Kommentar}%
-                      {\"Ubers\adddot\ und Komm\adddot}},
+                      {\"Ubers\adddotspace und Komm\adddot}},
   translatorsco    = {{\"Ubersetzung und Kommentar}%
-                      {\"Ubers\adddot\ und Komm\adddot}},
+                      {\"Ubers\adddotspace und Komm\adddot}},
   translatoran     = {{\"Ubersetzung und Erl\"auterungen}%
-                      {\"Ubers\adddot\ und Erl\"aut\adddot}},
+                      {\"Ubers\adddotspace und Erl\"aut\adddot}},
   translatorsan    = {{\"Ubersetzung und Erl\"auterungen}%
-                      {\"Ubers\adddot\ und Erl\"aut\adddot}},
+                      {\"Ubers\adddotspace und Erl\"aut\adddot}},
   translatorin     = {{\"Ubersetzung und Einleitung}%
-                      {\"Ubers\adddot\ und Einl\adddot}},
+                      {\"Ubers\adddotspace und Einl\adddot}},
   translatorsin    = {{\"Ubersetzung und Einleitung}%
-                      {\"Ubers\adddot\ und Einl\adddot}},
+                      {\"Ubers\adddotspace und Einl\adddot}},
   translatorfo     = {{\"Ubersetzung und Vorwort}%
-                      {\"Ubers\adddot\ und Vorw\adddot}},
+                      {\"Ubers\adddotspace und Vorw\adddot}},
   translatorsfo    = {{\"Ubersetzung und Vorwort}%
-                      {\"Ubers\adddot\ und Vorw\adddot}},
+                      {\"Ubers\adddotspace und Vorw\adddot}},
   translatoraf     = {{\"Ubersetzung und Nachwort}%
-                      {\"Ubers\adddot\ und Nachw\adddot}},
+                      {\"Ubers\adddotspace und Nachw\adddot}},
   translatorsaf    = {{\"Ubersetzung und Nachwort}%
-                      {\"Ubers\adddot\ und Nachw\adddot}},
+                      {\"Ubers\adddotspace und Nachw\adddot}},
   translatorcoin   = {{\"Ubersetzung, Kommentar und Einleitung}%
-                      {\"Ubers., Komm\adddot\ und Einl\adddot}},
+                      {\"Ubers., Komm\adddotspace und Einl\adddot}},
   translatorscoin  = {{\"Ubersetzung, Kommentar und Einleitung}%
-                      {\"Ubers., Komm\adddot\ und Einl\adddot}},
+                      {\"Ubers., Komm\adddotspace und Einl\adddot}},
   translatorcofo   = {{\"Ubersetzung, Kommentar und Vorwort}%
-                      {\"Ubers., Komm\adddot\ und Vorw\adddot}},
+                      {\"Ubers., Komm\adddotspace und Vorw\adddot}},
   translatorscofo  = {{\"Ubersetzung, Kommentar und Vorwort}%
-                      {\"Ubers., Komm\adddot\ und Vorw\adddot}},
+                      {\"Ubers., Komm\adddotspace und Vorw\adddot}},
   translatorcoaf   = {{\"Ubersetzung, Kommentar und Nachwort}%
-                      {\"Ubers., Komm\adddot\ und Nachw\adddot}},
+                      {\"Ubers., Komm\adddotspace und Nachw\adddot}},
   translatorscoaf  = {{\"Ubersetzung, Kommentar und Nachwort}%
-                      {\"Ubers., Komm\adddot\ und Nachw\adddot}},
+                      {\"Ubers., Komm\adddotspace und Nachw\adddot}},
   translatoranin   = {{\"Ubersetzung, Erl\"auterungen und Einleitung}%
-                      {\"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Einl\adddot}},
   translatorsanin  = {{\"Ubersetzung, Erl\"auterungen und Einleitung}%
-                      {\"Ubers., Erl\"aut\adddot\ und Einl\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Einl\adddot}},
   translatoranfo   = {{\"Ubersetzung, Erl\"auterungen und Vorwort}%
-                      {\"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Vorw\adddot}},
   translatorsanfo  = {{\"Ubersetzung, Erl\"auterungen und Vorwort}%
-                      {\"Ubers., Erl\"aut\adddot\ und Vorw\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Vorw\adddot}},
   translatoranaf   = {{\"Ubersetzung, Erl\"auterungen und Nachwort}%
-                      {\"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Nachw\adddot}},
   translatorsanaf  = {{\"Ubersetzung, Erl\"auterungen und Nachwort}%
-                      {\"Ubers., Erl\"aut\adddot\ und Nachw\adddot}},
+                      {\"Ubers., Erl\"aut\adddotspace und Nachw\adddot}},
 % organizer        = {{}{}},% FIXME: missing
 % organizers       = {{}{}},% FIXME: missing
 % byorganizer      = {{}{}},% FIXME: missing
@@ -269,82 +269,82 @@
   byfounder        = {{begr\"undet von}{begr\adddotspace von}},
   bycontinuator    = {{fortgef\"uhrt von}{fortgef\adddotspace von}},
   bycollaborator   = {{unter Mitarbeit von}{unter Mitarb\adddotspace von}},
-  bytranslator     = {{\lbx@lfromlang \"ubersetzt von}{\lbx@sfromlang \"ubers\adddot\ von}},
-  bycommentator    = {{kommentiert von}{komm\adddot\ von}},
-  byannotator      = {{erl\"autert von}{erl\"aut\adddot\ von}},
-  withcommentator  = {{mit einem Kommentar von}{mit einem Komm\adddot\ von}},
-  withannotator    = {{mit Erl\"auterungen von}{mit Erl\"aut\adddot\ von}},
-  withintroduction = {{mit einer Einleitung von}{mit einer Einl\adddot\ von}},
-  withforeword     = {{mit einem Vorwort von}{mit einem Vorw\adddot\ von}},
-  withafterword    = {{mit einem Nachwort von}{mit einem Nachw\adddot\ von}},
+  bytranslator     = {{\lbx@lfromlang \"ubersetzt von}{\lbx@sfromlang \"ubers\adddotspace von}},
+  bycommentator    = {{kommentiert von}{komm\adddotspace von}},
+  byannotator      = {{erl\"autert von}{erl\"aut\adddotspace von}},
+  withcommentator  = {{mit einem Kommentar von}{mit einem Komm\adddotspace von}},
+  withannotator    = {{mit Erl\"auterungen von}{mit Erl\"aut\adddotspace von}},
+  withintroduction = {{mit einer Einleitung von}{mit einer Einl\adddotspace von}},
+  withforeword     = {{mit einem Vorwort von}{mit einem Vorw\adddotspace von}},
+  withafterword    = {{mit einem Nachwort von}{mit einem Nachw\adddotspace von}},
   byeditortr       = {{herausgegeben und \lbx@lfromlang \"ubersetzt von}%
-                      {hrsg\adddotspace und \lbx@sfromlang \"ubers\adddot\ von}},
+                      {hrsg\adddotspace und \lbx@sfromlang \"ubers\adddotspace von}},
   byeditorco       = {{herausgegeben und kommentiert von}%
-                      {hrsg\adddotspace und komm\adddot\ von}},
+                      {hrsg\adddotspace und komm\adddotspace von}},
   byeditoran       = {{herausgegeben und erl\"autert von}%
-                      {hrsg\adddotspace und erl\"aut\adddot\ von}},
+                      {hrsg\adddotspace und erl\"aut\adddotspace von}},
   byeditorin       = {{herausgegeben und mit einer Einleitung versehen von}%
-                      {hrsg\adddotspace und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditorfo       = {{herausgegeben und mit einem Vorwort versehen von}%
-                      {hrsg\adddotspace und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditoraf       = {{herausgegeben und mit einem Nachwort versehen von}%
-                      {hrsg\adddotspace und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   byeditortrco     = {{herausgegeben, \lbx@lfromlang \"ubersetzt und kommentiert von}%
-                      {hrsg., \lbx@sfromlang \"ubers\adddot\ und komm\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers\adddotspace und komm\adddotspace von}},
   byeditortran     = {{herausgegeben, \lbx@lfromlang \"ubersetzt und erl\"autert von}%
-                      {hrsg., \lbx@sfromlang \"ubers\adddot\ und erl\"aut\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers\adddotspace und erl\"aut\adddotspace von}},
   byeditortrin     = {{herausgegeben, \lbx@lfromlang \"ubersetzt und mit einer Einleitung versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditortrfo     = {{herausgegeben, \lbx@lfromlang \"ubersetzt und mit einem Vorwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditortraf     = {{herausgegeben, \lbx@lfromlang \"ubersetzt und mit einem Nachwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   byeditorcoin     = {{herausgegeben, kommentiert und mit einer Einleitung versehen von}%
-                      {hrsg., komm\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg., komm\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditorcofo     = {{herausgegeben, kommentiert und mit einem Vorwort versehen von}%
-                      {hrsg., komm\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg., komm\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditorcoaf     = {{herausgegeben, kommentiert und mit einem Nachwort versehen von}%
-                      {hrsg., komm\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg., komm\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   byeditoranin     = {{herausgegeben, erl\"autert und mit einer Einleitung versehen von}%
-                      {hrsg., erl\"aut\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg., erl\"aut\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditoranfo     = {{herausgegeben, erl\"autert und mit einem Vorwort versehen von}%
-                      {hrsg., erl\"aut\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg., erl\"aut\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditoranaf     = {{herausgegeben, erl\"autert und mit einem Nachwort versehen von}%
-                      {hrsg., erl\"aut\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg., erl\"aut\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   byeditortrcoin   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, kommentiert und mit einer Einleitung versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., komm\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., komm\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditortrcofo   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, kommentiert und mit einem Vorwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., komm\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., komm\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditortrcoaf   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, kommentiert und mit einem Nachwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., komm\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., komm\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   byeditortranin   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, erl\"autert und mit einer Einleitung versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   byeditortranfo   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, erl\"autert und mit einem Vorwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   byeditortranaf   = {{herausgegeben, \lbx@lfromlang \"ubersetzt, erl\"autert und mit einem Nachwort versehen von}%
-                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {hrsg., \lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   bytranslatorco   = {{\lbx@lfromlang \"ubersetzt und kommentiert von}%
-                      {\lbx@sfromlang \"ubers\adddot\ und komm\adddot\ von}},
+                      {\lbx@sfromlang \"ubers\adddotspace und komm\adddotspace von}},
   bytranslatoran   = {{\lbx@lfromlang \"ubersetzt und erl\"autert von}%
-                      {\lbx@sfromlang \"ubers\adddot\ und erl\"aut\adddot\ von}},
+                      {\lbx@sfromlang \"ubers\adddotspace und erl\"aut\adddotspace von}},
   bytranslatorin   = {{\lbx@lfromlang \"ubersetzt und mit einer Einleitung versehen von}%
-                      {\lbx@sfromlang \"ubers\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   bytranslatorfo   = {{\lbx@lfromlang \"ubersetzt und mit einem Vorwort versehen von}%
-                      {\lbx@sfromlang \"ubers\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   bytranslatoraf   = {{\lbx@lfromlang \"ubersetzt und mit einem Nachwort versehen von}%
-                      {\lbx@sfromlang \"ubers\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   bytranslatorcoin = {{\lbx@lfromlang \"ubersetzt, kommentiert und mit einer Einleitung versehen von}%
-                      {\lbx@sfromlang \"ubers., komm\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., komm\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   bytranslatorcofo = {{\lbx@lfromlang \"ubersetzt, kommentiert und mit einem Vorwort versehen von}%
-                      {\lbx@sfromlang \"ubers., komm\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., komm\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   bytranslatorcoaf = {{\lbx@lfromlang \"ubersetzt, kommentiert und mit einem Nachwort versehen von}%
-                      {\lbx@sfromlang \"ubers., komm\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., komm\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   bytranslatoranin = {{\lbx@lfromlang \"ubersetzt, erl\"autert und mit einer Einleitung versehen von}%
-                      {\lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einer Einl\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einer Einl\adddotspace vers\adddotspace von}},
   bytranslatoranfo = {{\lbx@lfromlang \"ubersetzt, erl\"autert und mit einem Vorwort versehen von}%
-                      {\lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einem Vorw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einem Vorw\adddotspace vers\adddotspace von}},
   bytranslatoranaf = {{\lbx@lfromlang \"ubersetzt, erl\"autert und mit einem Nachwort versehen von}%
-                      {\lbx@sfromlang \"ubers., erl\"aut\adddot\ und mit einem Nachw\adddot\ vers\adddot\ von}},
+                      {\lbx@sfromlang \"ubers., erl\"aut\adddotspace und mit einem Nachw\adddotspace vers\adddotspace von}},
   and              = {{und}{und}},
   andothers        = {{u.\,a\adddot}{u.\,a\adddot}},
   andmore          = {{u.\,a\adddot}{u.\,a\adddot}},
@@ -371,7 +371,7 @@
   origpubin        = {{zuerst publiziert in}{zuerst publ\adddotspace in}},
   astitle          = {{unter dem Titel}{unter dem Titel}},
   bypublisher      = {{von}{von}},
-  nodate           = {{ohne\space Datum}{{}o\adddot D\adddot}},
+  nodate           = {{ohne\space Datum}{{}o.\,D\adddot}},
   page             = {{Seite}{S\adddot}},
   pages            = {{Seiten}{S\adddot}},
   column           = {{Spalte}{Sp\adddot}},
@@ -421,7 +421,7 @@
   prepublished     = {{Vorver\"offentlichung}{Vorver\"offentlichung}},
   citedas          = {{im folgenden zitiert als}{im folgenden zit\adddotspace als}},
   thiscite         = {{hier}{hier}},
-  seenote          = {{siehe Anmerkung}{s\adddotspace Anm\adddot}},
+  seenote          = {{siehe Anmerkung}{s.~Anm\adddot}},
   quotedin         = {{zitiert nach}{zit\adddotspace nach}},
   idem             = {{derselbe}{ders\adddot}},
   idemsf           = {{dieselbe}{dies\adddot}},
@@ -439,7 +439,7 @@
   sequentes        = {{ff\adddot}{ff\adddot}},
   passim           = {{passim}{pass\adddot}},
   see              = {{siehe}{siehe}},
-  seealso          = {{siehe auch}{s.\,auch}},
+  seealso          = {{siehe auch}{s.~auch}},
   backrefpage      = {{siehe Seite}{siehe S\adddot}},
   backrefpages     = {{siehe Seiten}{siehe S\adddot}},
   january          = {{Januar}{Jan\adddot}},
@@ -526,29 +526,29 @@
   countryus        = {{USA}{US}},
   patent           = {{Patent}{Pat\adddot}},
   patentde         = {{deutsches Patent}{dt\adddotspace Pat\adddot}},
-  patenteu         = {{europ\"aisches Patent}{europ\adddot\ Pat\adddot}},
-  patentfr         = {{franz\"osisches Patent}{frz\adddot\ Pat\adddot}},
-  patentuk         = {{britisches Patent}{brit\adddot\ Pat\adddot}},
+  patenteu         = {{europ\"aisches Patent}{europ\adddotspace Pat\adddot}},
+  patentfr         = {{franz\"osisches Patent}{frz\adddotspace Pat\adddot}},
+  patentuk         = {{britisches Patent}{brit\adddotspace Pat\adddot}},
   patentus         = {{US-Patent}{US-Pat\adddot}},
   patreq           = {{Patentanmeldung}{Patentanmeld\adddot}},
   patreqde         = {{deutsche Patentanmeldung}{dt\adddotspace Patentanmeld\adddot}},
-  patreqeu         = {{europ\"aische Patentanmeldung}{europ\adddot\ Patentanmeld\adddot}},
-  patreqfr         = {{franz\"osische Patentanmeldung}{frz\adddot\ Patentanmeld\adddot}},
-  patrequk         = {{britische Patentanmeldung}{brit\adddot\ Patentanmeld\adddot}},
+  patreqeu         = {{europ\"aische Patentanmeldung}{europ\adddotspace Patentanmeld\adddot}},
+  patreqfr         = {{franz\"osische Patentanmeldung}{frz\adddotspace Patentanmeld\adddot}},
+  patrequk         = {{britische Patentanmeldung}{brit\adddotspace Patentanmeld\adddot}},
   patrequs         = {{US-Patentanmeldung}{US-Patentanmeld\adddot}},
   file             = {{Datei}{Datei}},
   library          = {{Bibliothek}{Bibliothek}},
   abstract         = {{Zusammenfassung}{Zusammenfassung}},
   annotation       = {{Anmerkungen}{Anmerkungen}},
-  commonera        = {{unserer Zeitrechnung}{u\adddotspace Z\adddot}},
-  beforecommonera  = {{vor unserer Zeitrechnung}{v\adddotspace u\adddotspace Z\adddot}},
-  annodomini       = {{n\adddotspace Chr\adddot}{n\adddotspace Chr\adddot}},
-  beforechrist     = {{v\adddotspace Chr\adddot}{v\adddotspace Chr\adddot}},
+  commonera        = {{u.\,Z\adddot}{u.\,Z\adddot}},
+  beforecommonera  = {{v.\,u.\,Z\adddot}{v.\,u.\,Z\adddot}},
+  annodomini       = {{n.\,Chr\adddot}{n.\,Chr\adddot}},
+  beforechrist     = {{v.\,Chr\adddot}{v.\,Chr\adddot}},
   circa            = {{circa}{ca\adddot}},
-  spring           = {{Fr\"uhling}{Fr\adddot}},
-  summer           = {{Sommer}{So\adddot}},
-  autumn           = {{Herbst}{He\adddot}},
-  winter           = {{Winter}{Wi\adddot}},
+  spring           = {{Fr\"uhling}{Frühling}},
+  summer           = {{Sommer}{Sommer}},
+  autumn           = {{Herbst}{Herbst}},
+  winter           = {{Winter}{Winter}},
   am               = {{vorm\adddot}{vorm\adddot}},
   pm               = {{nachm\adddot}{nachm\adddot}},
 }


### PR DESCRIPTION
As discussed in #997
* common multi-letter abbreviations use `\,`
* "s." (siehe) uses `~`
* other abbreviations use `\adddotspace`