### PR TITLE
Write bibstrings and extras to \captions... (#1011)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -108,7 +108,7 @@
   accepts the values `expl3`, `latex2e` and `auto` (which selects
   `expl3` if the `expl3` version not older than 2020-04-06, this
   is the default).
-  
+
   The `expl3` implementation of the case changer is slightly more
   robust than the home-grown `latex2e` code.
 - The option `bibtexcaseprotection` can be used to turn off the
@@ -143,16 +143,6 @@
   The new default is to write to `\captions<language>`
   (i.e. `langhook=captions`).
   The previous behaviour can be restored with `langhook=extras`.
-  
-  There is no `\captions...`-equivalent for `\noextras...`,
-  so with `langhook=captions` `\UndeclareBibliographyExtras`
-  and `\UndefineBibliographyExtras{<language>}` are ignored.
-  For all standard uses of these commands that is not an issue,
-  since everything these commands reset is already reset by the grouping
-  implied by the language switching commands.
-  If there have global assignments in the bibliography extras,
-  then the missing `\noextras...` would be an issue.
-  In that case the solution is to go back to `langhook=extras`.
 - `biblatex` now tests if a requested backend (re)run happened by
   comparing the MD5 hashes of the new and old `.bbl` files.
 - Added file hooks `\blx@filehook@preload@<filename>`,

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -133,6 +133,26 @@
   `biblatex` no longer falls back to English for unknown languages.
   Warnings will be triggered if undefined language strings or extras
   are used.
+- **INCOMPATIBLE CHANGE**
+  Bibliography strings and bibliography extras can now be written
+  either to `\captions<language>` or to `\extras<language>`
+  (this is controlled with the `langhook` option).
+  Previously, they were written to `\extras<language>`, but upon
+  reflection `\captions<language>` appears to be a more sensible
+  place for these definitions.
+  The new default is to write to `\captions<language>`
+  (i.e. `langhook=captions`).
+  The previous behaviour can be restored with `langhook=extras`.
+  
+  There is no `\captions...`-equivalent for `\noextras...`,
+  so with `langhook=captions` `\UndeclareBibliographyExtras`
+  and `\UndefineBibliographyExtras{<language>}` are ignored.
+  For all standard uses of these commands that is not an issue,
+  since everything these commands reset is already reset by the grouping
+  implied by the language switching commands.
+  If there have global assignments in the bibliography extras,
+  then the missing `\noextras...` would be an issue.
+  In that case the solution is to go back to `langhook=extras`.
 - `biblatex` now tests if a requested backend (re)run happened by
   comparing the MD5 hashes of the new and old `.bbl` files.
 - Added file hooks `\blx@filehook@preload@<filename>`,

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -2185,12 +2185,16 @@ Enclose the entry in a \env{hyphenrules} environment. This will load hyphenation
 Enclose the entry in an \env{otherlanguage} environment. This will load hyphenation patterns for the specified language, enable all extra definitions which \sty{babel}/\sty{polyglossia} and \biblatex provide for the respective language, and translate key terms such as <editor> and <volume>. The extra definitions include localisations of the date format, of ordinals, and similar things.
 
 \item[other*]
-Enclose the entry in an \env{otherlanguage*} environment. Please note that \biblatex treats \env{otherlanguage*} like \env{otherlanguage} but other packages may make a distinction in this case.
+Enclose the entry in an \env{otherlanguage*} environment. Please note that \biblatex treats \env{otherlanguage*} like \env{otherlanguage} if \opt{langhook} is set to \opt{extras}.
 
 \item[langname]
 \sty{polyglossia} only. Enclose the entry in a \env{$<$languagename$>$} environment. The benefit of this option value for \sty{polyglossia} users is that it takes note of the \bibfield{langidopts} field so that you can add per-language options to an entry (like selecting a language variant). When using \sty{babel}, this option does the same as the \opt{other} option value.
 
 \end{valuelist}
+
+\optitem[captions]{langhook}{\opt{captions}, \opt{extras}}
+
+This option controls whether bibliography strings and extras are written to \cmd{captions$<$language$>$} or \cmd{extras$<$language$>$}. The exact effect of this option depend on the language package (\sty{babel}/\sty{polyglossia}). Broadly speaking, the language switching environments provided by those packages (except \env{hyphenrules}) either switch language captions and extras or only language extras. Hence, if this option is set to \opt{extras}, all language switches will affect \biblatex, whereas with \opt{captions} only language switches that also switch other parts of the document language affect \biblatex.
 
 \optitem[none]{block}{\opt{none}, \opt{space}, \opt{par}, \opt{nbpar}, \opt{ragged}}
 

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -542,8 +542,13 @@
   \iftoggle{blx@autolangcite}
     {\let\blx@beglangcite\blx@beglang}
     {}%
+  % babel/polyglossia has loaded the (main document) language already,
+  % so we need to explicitly enable our captions (abx@strings@)
+  % and extras (abx@extras@) now
+  \toggletrue{blx@lang@captions@\blx@languagename}%
   \csuse{abx@extras@\blx@languagename}%
   \csuse{abx@strings@\blx@languagename}%
+  % avoid accidental re-initialization
   \undef\blx@mkautolangbabel
   \undef\blx@mkautolangpoly
   \undef\blx@mknoautolang
@@ -3770,7 +3775,7 @@
 
 \def\blx@declaredelimalias@mom{%
   \blx@declaredelimalias@omom[]}
-    
+
 \def\blx@declaredelimalias@om[#1]#2{%
   \@ifnextchar[%]
     {\blx@declaredelimalias@omom[{#1}]{#2}}
@@ -6288,13 +6293,33 @@
 % User macro for retrieving currrent language
 \def\currentlang{\blx@languagename}
 
+% We need to be able to prefix \providetoggle with \global,
+% plus we don't need the testing from \providetoggle anway.
+% This uses internal implementation details of etoolbox's
+% toggles, so is a bit meh, but it's better than rolling our own
+% version of toggles just for that.
+\newcommand*{\blx@etb@inittoggle}[1]{\cslet{etb@tgl@#1}\@secondoftwo}
+
+% There is no \nocaptions..., so if we send everything to \captions...
+% we need to find a way to call our noextras only in situations where
+% \noextras... is called to clean up \extras... AND \captions...
+% and not just \extras...
+% We detect this by setting a toggle in the \captions...
+
 % {<language>}{<strings>}
 \def\blx@maplang@babel#1#2{%
+  \global\blx@etb@inittoggle{blx@lang@captions@#2}%
   \ifdefstring{\blx@langhook}{captions}
     {\csgappto{captions#1}{%
+       \toggletrue{blx@lang@captions@#2}%
        \blx@resetpunct
        \csuse{abx@extras@#2}%
-       \csuse{abx@strings@#2}}}
+       \csuse{abx@strings@#2}}%
+     \csgappto{noextras#1}{%
+       \iftoggle{blx@lang@captions@#2}
+         {\blx@resetpunct
+          \csuse{abx@noextras@#2}}
+         {}}}
     {\csgappto{extras#1}{%
        \blx@resetpunct
        \csuse{abx@extras@#2}%
@@ -6304,11 +6329,18 @@
        \csuse{abx@noextras@#2}}}}
 
 \def\blx@maplang@polyglossia#1#2{%
+  \global\blx@etb@inittoggle{blx@lang@captions@#2}%
   \ifdefstring{\blx@langhook}{captions}
     {\csgappto{captions@bbl@#1}{%
+       \toggletrue{blx@lang@captions@#2}%
        \blx@resetpunct
        \csuse{abx@extras@#2}%
-       \csuse{abx@strings@#2}}}
+       \csuse{abx@strings@#2}}
+     \csgappto{noextras@bbl@#1}{%
+       \iftoggle{blx@lang@captions@#2}
+         {\blx@resetpunct
+          \csuse{abx@noextras@#2}}
+         {}}}
     {\csgappto{blockextras@bbl@#1}{%
        \blx@resetpunct
        \csuse{abx@extras@#2}%
@@ -6351,7 +6383,12 @@
       {No default 'babel' language defined}
       {You must define a default language for 'babel'}}
     {\let\blx@main@language\bbl@main@language}%
-  \AddBabelHook{biblatex@langsetup}{beforeextras}{%
+  % use afterreset to get in a bit earlier
+  % we want to be there before \captions... is issued
+  % beforeextras is before extras, but captions come before extras
+  % afterreset was added in 3.9i (~2014-03-16)
+  % way before 3.9r (2016-04-23), which we require
+  \AddBabelHook{biblatex@langsetup}{afterreset}{%
     \expandafter\blx@langsetup\expandafter{\languagename}}%
   \ifdef\blx@thelangenv
     {\def\blx@beglang{%

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6335,7 +6335,7 @@
        \toggletrue{blx@lang@captions@#2}%
        \blx@resetpunct
        \csuse{abx@extras@#2}%
-       \csuse{abx@strings@#2}}
+       \csuse{abx@strings@#2}}%
      \csgappto{noextras@bbl@#1}{%
        \iftoggle{blx@lang@captions@#2}
          {\blx@resetpunct

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -6290,26 +6290,36 @@
 
 % {<language>}{<strings>}
 \def\blx@maplang@babel#1#2{%
-  \csgappto{extras#1}{%
-    \blx@resetpunct
-    \csuse{abx@extras@#2}%
-    \csuse{abx@strings@#2}}%
-  \csgappto{noextras#1}{%
-    \blx@resetpunct
-    \csuse{abx@noextras@#2}}}
+  \ifdefstring{\blx@langhook}{captions}
+    {\csgappto{captions#1}{%
+       \blx@resetpunct
+       \csuse{abx@extras@#2}%
+       \csuse{abx@strings@#2}}}
+    {\csgappto{extras#1}{%
+       \blx@resetpunct
+       \csuse{abx@extras@#2}%
+       \csuse{abx@strings@#2}}%
+     \csgappto{noextras#1}{%
+       \blx@resetpunct
+       \csuse{abx@noextras@#2}}}}
 
 \def\blx@maplang@polyglossia#1#2{%
-  \csgappto{blockextras@bbl@#1}{%
-    \blx@resetpunct
-    \csuse{abx@extras@#2}%
-    \csuse{abx@strings@#2}}%
-  \csgappto{inlineextras@bbl@#1}{%
-    \blx@resetpunct
-    \csuse{abx@extras@#2}%
-    \csuse{abx@strings@#2}}%
-  \csgappto{noextras@bbl@#1}{%
-    \blx@resetpunct
-    \csuse{abx@noextras@#2}}}
+  \ifdefstring{\blx@langhook}{captions}
+    {\csgappto{captions@bbl@#1}{%
+       \blx@resetpunct
+       \csuse{abx@extras@#2}%
+       \csuse{abx@strings@#2}}}
+    {\csgappto{blockextras@bbl@#1}{%
+       \blx@resetpunct
+       \csuse{abx@extras@#2}%
+       \csuse{abx@strings@#2}}%
+     \csgappto{inlineextras@bbl@#1}{%
+       \blx@resetpunct
+       \csuse{abx@extras@#2}%
+       \csuse{abx@strings@#2}}%
+     \csgappto{noextras@bbl@#1}{%
+       \blx@resetpunct
+       \csuse{abx@noextras@#2}}}}
 
 %% babel/polyglossia interface
 \def\blx@beglang{\blx@clearlang\begingroup}
@@ -14351,6 +14361,14 @@
   \def\blx@hook@initlang{\@quotereset\@ne}%
   \def\blx@hook@endlang{\blx@postpunct}}
 
+\DeclareBibliographyOption[string]{langhook}{%
+  \ifstrequal{#1}{captions}
+    {\@firstoftwo}
+    {\ifstrequal{#1}{extras}}
+    {\def\blx@langhook{#1}}
+    {\blx@err@invopt{langhook=#1}{}}}
+
+
 \DeclareBiblatexOption{global,type,entry}[string]{indexing}[true]{%
   \blx@opt@index{#1}}
 \def\blx@opt@index#1{%
@@ -15215,13 +15233,16 @@
 \blx@kv@setkeys{blx@opt@pre}{%
   sorting=nty,sortlocale=auto,sortcase,sortupper,sortcites=false,
   maxnames=3,minnames=1,maxalphanames=3,minalphanames=1,
-  maxitems=3,minitems=1,mincrossrefs=2,minxrefs=2,useauthor=true,useeditor=true,
-  usetranslator=false,indexing=false,abbreviate=true,dateabbrev=true,dateera=astronomical,
+  maxitems=3,minitems=1,mincrossrefs=2,minxrefs=2,
+  useauthor=true,useeditor=true,usetranslator=false,
+  indexing=false,abbreviate=true,dateabbrev=true,dateera=astronomical,
   backref=false,backrefsetstyle=setonly,backreffloats=true,
   pagetracker=false,
   ibidtracker=false,idemtracker=false,opcittracker=false,loccittracker=false,
   citetracker=false,trackfloats=false,
-  citecounter=false,block=none,language=autobib,clearlang=true,autolang=none,
+  citecounter=false,
+  block=none,
+  language=autobib,clearlang=true,autolang=none,langhook=captions,
   date=comp,labeldate=year,origdate=comp,eventdate=comp,urldate=short,
   autopunct=true,punctfont=false,defernumbers=false,timezeros=true,
   refsection=none,refsegment=none,citereset=none,hyperref=auto,


### PR DESCRIPTION
Write bibliography strings and extras to `\captions<language>` instead of `\extras<language>`. See #1011.


This can be changed with the `langhook` option.

With `captions`, the new default, `\UndeclareBibliographyExtras` and `\UndefineBibliographyExtras{<language>}` don't do anything any more. This should be no issue for all standard uses of bibliography extras, since everything is local and kept local by grouping. But it could be problematic if people do weird stuff. In case an issue comes up we can advise people to go back to `langhook=extras,` (or change their setup to local changes if possible) - or we can think of something more sophisticated. 