### PR TITLE
Implement bibliography string (formatting) classes (#555, #1027)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -129,6 +129,10 @@
   of the `\ifnumerals` and `\ifpages` checks.
 - Deprecate the starred `\DeclareDelimAlias*` in favour of
   `\DeclareDelimAlias` with optional arguments.
+- Added `\DeclareBibstringClass`, `\DeclareBibstringClassFormat` etc.
+  to allow injecting additional formatting for a class of bibstrings.
+  Classes can be defined arbitrarily. These commands are primarily
+  intended for use in localisation modules.
 - **INCOMPATIBLE CHANGE**
   `biblatex` no longer falls back to English for unknown languages.
   Warnings will be triggered if undefined language strings or extras

--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -129,9 +129,9 @@
   of the `\ifnumerals` and `\ifpages` checks.
 - Deprecate the starred `\DeclareDelimAlias*` in favour of
   `\DeclareDelimAlias` with optional arguments.
-- Added `\DeclareBibstringClass`, `\DeclareBibstringClassFormat` etc.
-  to allow injecting additional formatting for a class of bibstrings.
-  Classes can be defined arbitrarily. These commands are primarily
+- Added `\DeclareBibstringSet`, `\DeclareBibstringSetFormat` etc.
+  to allow injecting additional formatting for a set of bibstrings.
+  Sets can be defined arbitrarily. These commands are primarily
   intended for use in localisation modules.
 - **INCOMPATIBLE CHANGE**
   `biblatex` no longer falls back to English for unknown languages.

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -11366,41 +11366,41 @@ It is possible to add bibliography strings to a bibliography string class to app
 
 \begin{ltxsyntax}
 
-\cmditem{DeclareBibstringClass}{class}{key, \dots}
+\cmditem{DeclareBibstringSet}{setname}{key, \dots}
 
-This commands assigns all \prm{key}s to the bibliography string class \prm{class}.
+This commands assigns all \prm{key}s to the bibliography string class \prm{setname}.
 
-\cmditem{UndeclareBibstringClass}{class}
+\cmditem{UndeclareBibstringSet}{setname}
 
-Remove the bibliography string class \prm{class}. Any formatting definitions will also be cleared.
+Remove the bibliography string set \prm{setname}. Any formatting definitions will also be cleared.
 
-\cmditem{UndeclareBibstringClasses}
+\cmditem{UndeclareBibstringSets}
 
-Remove all existing bibliography string classes with \cmd{UndeclareBibstringClass}.
+Remove all existing bibliography string sets with \cmd{UndeclareBibstringSet}.
 
-\cmditem{DeclareBibstringClassFormat}{class}{code}
+\cmditem{DeclareBibstringSetFormat}{setname}{code}
 
-Defines the bibliography string format for \prm{class}. The format works exactly like an additional \prm{wrapper} format for \cmd{bibstring}. \prm{code} is executed whenever a bibliography string of \prm{class} is printed. The text of the bibliography string is passed to \prm{code} as first and only argument.
+Defines the bibliography string format for \prm{setname}. The format works exactly like an additional \prm{wrapper} format for \cmd{bibstring}. \prm{code} is executed whenever a bibliography string of \prm{setname} is printed. The text of the bibliography string is passed to \prm{code} as first and only argument.
 
-\cmditem{UneclareBibstringClassFormat}{class}
+\cmditem{UneclareBibstringSetFormat}{setname}
 
-Remove any bibliography string class format defined for \prm{class}.
+Remove any bibliography string set format defined for \prm{setname}.
 
 \end{ltxsyntax}
 
-Bibliography string classes can be useful to apply additional formatting to a number of bibliography strings at the same time. These commands are intended for use in language modules. For example in French typography it is customary to italicise Latin terms. The French language module can define a new bibliography string class called \texttt{latin} for all lating strings and apply additional formatting only to these strings. It is not recommended to apply the formatting dierctly in the bibliography string definitions, since that can interfere with the capitalisation function. Assuming that the French language \texttt{.lbx} file only defines two Latin strings, \texttt{andothers} and \texttt{andothers}, the \texttt{.lbx} file would contain.
+Bibliography string sets can be useful to apply additional formatting to a number of bibliography strings at the same time. These commands are intended for use in language modules. For example in French typography it is customary to italicise Latin terms. The French language module can define a new bibliography string set called \texttt{latin} for all Latin strings and apply additional formatting only to these strings. It is not recommended to apply the formatting dierctly in the bibliography string definitions, since that can interfere with the capitalisation function. Assuming that the French language \texttt{.lbx} file only defines two Latin strings, \texttt{andothers} and \texttt{andothers}, the \texttt{.lbx} file would contain.
 
 \begin{ltxexample}[escapeinside={(*@}{@*)}]
 \DeclareBibliographyExtras{%
   (*@\dots@*)
-  \DeclareBibstringClass{latin}{andothers,ibidem}%
-  \DeclareBibstringClassFormat{latin}{\mkbibemph{#1}}%
+  \DeclareBibstringSet{latin}{andothers,ibidem}%
+  \DeclareBibstringSetFormat{latin}{\mkbibemph{#1}}%
   (*@\dots@*)
 }
 
 \UndeclareBibliographyExtras{%
   (*@\dots@*)
-  \UndeclareBibstringClass{latin}%
+  \UndeclareBibstringSet{latin}%
   (*@\dots@*)
 }
 \end{ltxexample}

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -11362,13 +11362,13 @@ Switches from the current language to the main document language. This can be us
 
 \end{ltxsyntax}
 
-It is possible to add bibliography strings to a bibliography string class to apply additional formatting.
+It is possible to add bibliography strings to a bibliography string set to apply additional formatting.
 
 \begin{ltxsyntax}
 
 \cmditem{DeclareBibstringSet}{setname}{key, \dots}
 
-This commands assigns all \prm{key}s to the bibliography string class \prm{setname}.
+This commands assigns all \prm{key}s to the bibliography string set \prm{setname}.
 
 \cmditem{UndeclareBibstringSet}{setname}
 
@@ -11404,7 +11404,7 @@ Bibliography string sets can be useful to apply additional formatting to a numbe
   (*@\dots@*)
 }
 \end{ltxexample}
-Note that the defined classes should be undeclared after use to avoid side effects for other languages.
+Note that the defined sets should be undeclared after use to avoid side effects for other languages.
 
 
 \subsection{Localization Modules}
@@ -14489,7 +14489,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \cmd{AtEveryEntrykey}\see{aut:fmt:hok}
 \item Added \cmd{ifdatesequal} and \cmd{ifdaterangesequal}\see{aut:aux:tst}
 \item Clarified \cmd{ifuniqueprimaryauthor} semantics\see{aut:aux:tst}
-\item Added \cmd{DeclareBibstringClass}, \cmd{DeclareBibstringClassFormat} etc.\see{aut:str}
+\item Added \cmd{DeclareBibstringSet}, \cmd{DeclareBibstringSetFormat} etc.\see{aut:str}
 \item Added \cmd{bibncpstring}, \cmd{bibncplstring} and \cmd{bibncpsstring}\see{aut:str}
 \item Added Lithuanian localisation (Valdemaras Klumbys)
 \item Added Serbian localisation (Andrej Radović)

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -10698,10 +10698,10 @@ title = {The {\TeX book}},
 The behaviour of \cmd{MakeSentenceCase} differs slightly between the \opt{latex2e} and \opt{expl3} implementation. Generally speaking, the \opt{expl3} code is closer to the \bibtex behaviour of \texttt{change.case\$}. It is also better equipped to deal with non-ASCII input and macros than the \opt{latex2e} implementation. \cmd{MakeSentenceCase} behaves as follows.
 \begin{itemize}\setlength{\labelsep}{1em}
   \item The first letter of its argument is capitalised with \cmd{MakeUppercase}. This is different from \bibtex's \texttt{change.case\$}, which does not touch the first letter of its argument.
-  
+
   Note that with the \opt{latex2e} code a pair of braces that starts with a control sequence will be treated as a single character for capitalisation purposes. This means that the entire argument of a command protected with a single pair of braces is capitalised.
   \item With the \opt{latex2e} code expandable commands are expanded before the case change, which means that the case change applies to the replacement text. Unexpandable commands are not touched.
-  
+
   \bibtex does not interpret macros and therefore passes commands through unchanged (this does not necessarily apply to the \emph{arguments} of those commands). The \opt{expl3} implementation also does not expand commands and only applies case change to the arguments.
   \item Text wrapped in one or more pairs of braces is protected from case change \emph{unless} it starts with a control sequence. This is the same behaviour as with \bibtex. Note that the braces could either be explicit groups or argument delimiters.
   \item Text in a single pair of braces that starts with a control sequence is not protected and will be subject to case changes. Note that this need not apply to braces that are argument delimiters, in fact the \opt{latex2e} implementation of \cmd{MakeSentenceCase} may in some cases produce an error or otherwise undesirable output if the argument of a command starts with a control sequence. \bibtex's case change function does not differentiate between argument delimiters and brace groups and always subjects text at brace level~1 to case change if it starts with a control sequence.
@@ -11361,6 +11361,51 @@ Similar to \cmd{bibxstring} but always uses the short string, ignoring the \opt{
 Switches from the current language to the main document language. This can be used the \prm{wrapper} argument in the localisation string commands above.
 
 \end{ltxsyntax}
+
+It is possible to add bibliography strings to a bibliography string class to apply additional formatting.
+
+\begin{ltxsyntax}
+
+\cmditem{DeclareBibstringClass}{class}{key, \dots}
+
+This commands assigns all \prm{key}s to the bibliography string class \prm{class}.
+
+\cmditem{UndeclareBibstringClass}{class}
+
+Remove the bibliography string class \prm{class}. Any formatting definitions will also be cleared.
+
+\cmditem{UndeclareBibstringClasses}
+
+Remove all existing bibliography string classes with \cmd{UndeclareBibstringClass}.
+
+\cmditem{DeclareBibstringClassFormat}{class}{code}
+
+Defines the bibliography string format for \prm{class}. The format works exactly like an additional \prm{wrapper} format for \cmd{bibstring}. \prm{code} is executed whenever a bibliography string of \prm{class} is printed. The text of the bibliography string is passed to \prm{code} as first and only argument.
+
+\cmditem{UneclareBibstringClassFormat}{class}
+
+Remove any bibliography string class format defined for \prm{class}.
+
+\end{ltxsyntax}
+
+Bibliography string classes can be useful to apply additional formatting to a number of bibliography strings at the same time. These commands are intended for use in language modules. For example in French typography it is customary to italicise Latin terms. The French language module can define a new bibliography string class called \texttt{latin} for all lating strings and apply additional formatting only to these strings. It is not recommended to apply the formatting dierctly in the bibliography string definitions, since that can interfere with the capitalisation function. Assuming that the French language \texttt{.lbx} file only defines two Latin strings, \texttt{andothers} and \texttt{andothers}, the \texttt{.lbx} file would contain.
+
+\begin{ltxexample}[escapeinside={(*@}{@*)}]
+\DeclareBibliographyExtras{%
+  (*@\dots@*)
+  \DeclareBibstringClass{latin}{andothers,ibidem}%
+  \DeclareBibstringClassFormat{latin}{\mkbibemph{#1}}%
+  (*@\dots@*)
+}
+
+\UndeclareBibliographyExtras{%
+  (*@\dots@*)
+  \UndeclareBibstringClass{latin}%
+  (*@\dots@*)
+}
+\end{ltxexample}
+Note that the defined classes should be undeclared after use to avoid side effects for other languages.
+
 
 \subsection{Localization Modules}
 \label{aut:lng}
@@ -14444,6 +14489,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added \cmd{AtEveryEntrykey}\see{aut:fmt:hok}
 \item Added \cmd{ifdatesequal} and \cmd{ifdaterangesequal}\see{aut:aux:tst}
 \item Clarified \cmd{ifuniqueprimaryauthor} semantics\see{aut:aux:tst}
+\item Added \cmd{DeclareBibstringClass}, \cmd{DeclareBibstringClassFormat} etc.\see{aut:str}
 \item Added \cmd{bibncpstring}, \cmd{bibncplstring} and \cmd{bibncpsstring}\see{aut:str}
 \item Added Lithuanian localisation (Valdemaras Klumbys)
 \item Added Serbian localisation (Andrej Radović)

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -4707,42 +4707,42 @@
   \printtext \printfield \printlist \printnames \printfile
   \indexfield \indexlist \indexnames \entrydata \entryset}
 
-\let\blx@bibstringclasses\@empty
+\let\blx@bibstringsets\@empty
 
-% {<class>}{<bibstring_1>,...,<bibstring_n>}
-\newrobustcmd*{\DeclareBibstringClass}[1]{%
-  \listadd\blx@bibstringclasses{#1}
+% {<set>}{<bibstring_1>,...,<bibstring_n>}
+\newrobustcmd*{\DeclareBibstringSet}[1]{%
+  \listadd\blx@bibstringsets{#1}
   \def\do##1{%
-    \csdef{blx@bibstringclass@string@##1}{#1}%
-    \listcsadd{blx@bibstringclass@class@#1}{##1}}%
+    \csdef{blx@bibstringset@string@##1}{#1}%
+    \listcsadd{blx@bibstringset@set@#1}{##1}}%
   \docsvlist}
 
-% {<class>}
-\newrobustcmd*{\UndeclareBibstringClass}[1]{%
-  \def\do##1{\csundef{blx@bibstringclass@string@##1}}
-  \dolistcsloop{blx@bibstringclass@class@#1}%
-  \csundef{blx@bibstringclass@class@#1}%
-  \UndeclareBibstringClassFormat{#1}}
+% {<set>}
+\newrobustcmd*{\UndeclareBibstringSet}[1]{%
+  \def\do##1{\csundef{blx@bibstringset@string@##1}}
+  \dolistcsloop{blx@bibstringset@set@#1}%
+  \csundef{blx@bibstringset@set@#1}%
+  \UndeclareBibstringSetFormat{#1}}
 
-\newrobustcmd*{\UndeclareBibstringClasses}{%
-  \forlistloop{\UndeclareBibstringClass}{\blx@bibstringclasses}%
-  \let\blx@bibstringclasses\@empty}
+\newrobustcmd*{\UndeclareBibstringSets}{%
+  \forlistloop{\UndeclareBibstringSet}{\blx@bibstringsets}%
+  \let\blx@bibstringsets\@empty}
 
-% {<class>}{<code>}
-\newrobustcmd*{\DeclareBibstringClassFormat}[1]{%
-  \csdef{blx@bibstringclassformat@#1}##1}
+% {<set>}{<code>}
+\newrobustcmd*{\DeclareBibstringSetFormat}[1]{%
+  \csdef{blx@bibstringsetformat@#1}##1}
 
-% {<class>}
-\newrobustcmd*{\UndeclareBibstringClassFormat}[1]{%
-  \csundef{blx@bibstringclassformat@#1}}
+% {<set>}
+\newrobustcmd*{\UndeclareBibstringSetFormat}[1]{%
+  \csundef{blx@bibstringsetformat@#1}}
 
 % {<wrapper>}{<string (name)>}{<text (derived from string)>}
 \def\blx@wrapbibstring#1#2#3{%
-  \ifcsundef{blx@bibstringclass@string@#2}
+  \ifcsundef{blx@bibstringset@string@#2}
     {#1{#3}}
-    {\ifcsundef{blx@bibstringclassformat@\csuse{blx@bibstringclass@string@#2}}
+    {\ifcsundef{blx@bibstringsetformat@\csuse{blx@bibstringset@string@#2}}
        {#1{#3}}
-       {#1{\csuse{blx@bibstringclassformat@\csuse{blx@bibstringclass@string@#2}}
+       {#1{\csuse{blx@bibstringsetformat@\csuse{blx@bibstringset@string@#2}}
              {#3}}}}}
 
 %% Localization

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -4707,6 +4707,44 @@
   \printtext \printfield \printlist \printnames \printfile
   \indexfield \indexlist \indexnames \entrydata \entryset}
 
+\let\blx@bibstringclasses\@empty
+
+% {<class>}{<bibstring_1>,...,<bibstring_n>}
+\newrobustcmd*{\DeclareBibstringClass}[1]{%
+  \listadd\blx@bibstringclasses{#1}
+  \def\do##1{%
+    \csdef{blx@bibstringclass@string@##1}{#1}%
+    \listcsadd{blx@bibstringclass@class@#1}{##1}}%
+  \docsvlist}
+
+% {<class>}
+\newrobustcmd*{\UndeclareBibstringClass}[1]{%
+  \def\do##1{\csundef{blx@bibstringclass@string@##1}}
+  \dolistcsloop{blx@bibstringclass@class@#1}%
+  \csundef{blx@bibstringclass@class@#1}%
+  \UndeclareBibstringClassFormat{#1}}
+
+\newrobustcmd*{\UndeclareBibstringClasses}{%
+  \forlistloop{\UndeclareBibstringClass}{\blx@bibstringclasses}%
+  \let\blx@bibstringclasses\@empty}
+
+% {<class>}{<code>}
+\newrobustcmd*{\DeclareBibstringClassFormat}[1]{%
+  \csdef{blx@bibstringclassformat@#1}##1}
+
+% {<class>}
+\newrobustcmd*{\UndeclareBibstringClassFormat}[1]{%
+  \csundef{blx@bibstringclassformat@#1}}
+
+% {<wrapper>}{<string (name)>}{<text (derived from string)>}
+\def\blx@wrapbibstring#1#2#3{%
+  \ifcsundef{blx@bibstringclass@string@#2}
+    {#1{#3}}
+    {\ifcsundef{blx@bibstringclassformat@\csuse{blx@bibstringclass@string@#2}}
+       {#1{#3}}
+       {#1{\csuse{blx@bibstringclassformat@\csuse{blx@bibstringclass@string@#2}}
+             {#3}}}}}
+
 %% Localization
 
 % {<wrapper>}{<long/short>}{<string>}{<print code>}
@@ -4746,8 +4784,8 @@
 \protected\def\blx@bibstring#1#2#3{%
   \blx@met@bibstring{#1}{#2}{#3}
     {\blx@imc@ifcapital
-       {#1{\MakeCapital{\csuse{#2@\blx@tempa}}}}
-       {#1{\csuse{#2@\blx@tempa}}}%
+       {\blx@wrapbibstring{#1}{\blx@tempa}{\MakeCapital{\csuse{#2@\blx@tempa}}}}
+       {\blx@wrapbibstring{#1}{\blx@tempa}{\csuse{#2@\blx@tempa}}}%
      \blx@endunit}}
 
 % [<wrapper>]{<string>}
@@ -4762,7 +4800,7 @@
 
 \protected\def\blx@bibncpstring#1#2#3{%
   \blx@met@bibstring{#1}{#2}{#3}
-    {#1{\csuse{#2@\blx@tempa}}%
+    {\blx@wrapbibstring{#1}{\blx@tempa}{\csuse{#2@\blx@tempa}}%
      \blx@endunit}}
 
 % [<wrapper>]{<string>}
@@ -4777,7 +4815,7 @@
 
 \protected\def\blx@bibcpstring#1#2#3{%
   \blx@met@bibstring{#1}{#2}{#3}
-    {#1{\MakeCapital{\csuse{#2@\blx@tempa}}}%
+    {\blx@wrapbibstring{#1}{\blx@tempa}{\MakeCapital{\csuse{#2@\blx@tempa}}}%
      \blx@endunit}}
 
 % [<wrapper>]{<string>}
@@ -4792,7 +4830,7 @@
 
 \protected\def\blx@biblcstring#1#2#3{%
   \blx@met@bibstring{#1}{#2}{#3}
-    {#1{\blx@maketext@lowercase{\csuse{#2@\blx@tempa}}}%
+    {\blx@wrapbibstring{#1}{\blx@tempa}{\blx@maketext@lowercase{\csuse{#2@\blx@tempa}}}%
      \blx@endunit}}
 
 % [<wrapper>]{<string>}
@@ -4807,7 +4845,7 @@
 
 \protected\def\blx@bibucstring#1#2#3{%
   \blx@met@bibstring{#1}{#2}{#3}
-    {#1{\blx@maketext@uppercase{\csuse{#2@\blx@tempa}}}%
+    {\blx@wrapbibstring{#1}{\blx@tempa}{\blx@maketext@uppercase{\csuse{#2@\blx@tempa}}}%
      \blx@endunit}}
 
 % {<string>}


### PR DESCRIPTION
Inspired by #555, #1027, etc. This should make it easier to apply formatting to bibstrings. While it is tempting to just include formatting commands like `\mkbibemph` directly in the strings, it doesn't always yield best results as demonstrated in
```latex
\documentclass[french]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=authortitle-ibid, backend=biber]{biblatex}

\DefineBibliographyStrings{french}{
  andothers = {\mkbibemph{et\addabbrvspace al\adddot}},
  ibidem    = {\mkbibemph{ibid\adddot}},
}

\addbibresource{biblatex-examples.bib}

\begin{document}
Lorem \autocite{sigfridsson}
ipsum \autocite{sigfridsson}
dolor \autocite{aksin}
\printbibliography
\end{document}
```
The "ibid." in the second footnotes fails to be capitalised properly
![screenshot of the footnotes from the MWE: in particular footnote 2 shows "ibid." in lowercase.](https://user-images.githubusercontent.com/6755835/87847761-cca4ce80-c8da-11ea-920d-0bb62279320e.png)
> 2. *ibid.*

---

With this commit we can define a new class for Latin terms and apply additional formatting  (in the right place) only to those strings.
```latex
\documentclass[british,french]{article}
\usepackage[T1]{fontenc}
\usepackage[utf8]{inputenc}
\usepackage{babel}
\usepackage{csquotes}

\usepackage[style=authortitle-ibid, backend=biber]{biblatex}

\DefineBibliographyStrings{french}{
  andothers = {et\addabbrvspace al\adddot},
  ibidem    = {ibid\adddot},
}

\DefineBibliographyExtras{french}{%
  \DeclareBibstringClass{latin}{andothers,ibidem}%
  \DeclareBibstringClassFormat{latin}{\mkbibemph{#1}}}

\UndefineBibliographyExtras{french}{%
  \UndeclareBibstringClass{latin}}

\addbibresource{biblatex-examples.bib}

\begin{document}
Lorem \autocite{sigfridsson}
ipsum \autocite{sigfridsson}
dolor \autocite{aksin}
\printbibliography

\selectlanguage{british}
Lorem \autocite{sigfridsson}
ipsum \autocite{sigfridsson}
dolor \autocite{aksin}
\printbibliography
\end{document}
```
![screenshot of the footnotes from the MWE: Footnote 2 now is correctly capitalised to "Ibid.". The English footnotes do not show any of the italic formatting for the French text.](https://user-images.githubusercontent.com/6755835/87847832-4046db80-c8db-11ea-926f-e98371ffcb76.png)

---

This also helps with https://github.com/plk/biblatex/issues/899.

---


@plk (and anyone else who wants to have a go) As always I don't feel particularly confident about the name. Suggestions are welcome. Other comments are of course also appreciated.