### PR TITLE
Implement arithmetic for ASCII-equivalent numerals

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -1,3 +1,21 @@
+# RELEASE NOTES FOR VERSION 3.17
+- Added helper macros to enable calculations with non-ASCII numerals.
+  This is necessary to properly support languages like Marathi.
+  At the moment the 'translation' is very basic and uses a one-to-one
+  correspondence of US-ASCII (Arabic) digits and non-ASCII digits.
+  The translation also needs additional post-processing steps.
+  Use `\blx@defcomputableequivalent{<numeral digit>}{<ASCII digit>}` to
+  make `<numeral digit>` an equivalent of `<ASCII digit>`
+  (presumably this command will be used in `.lbx` files if the language
+  requires it).
+  `\hascomputableequivalent{<string>}` can be used to check if `<string>`
+  is a number that can be converted to a number with ASCII digits.
+  `\getcomputableequivalent{<string>}{<macro>}` does the conversion
+  and saves the number in `<macro>`.
+  There is `\ifiscomputable{<string>}` to check if a `<string>`
+  is an ASCII number OR has a computable equivalent.
+  There are analogous macros for fields instead of strings.
+
 # RELEASE NOTES FOR VERSION 3.16
 - Fixed an infinite loop caused by excessive aliasing of the `volcitepages`
   format.

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -1887,7 +1887,7 @@ In addition to the \bibfield{crossref} field, \biblatex supports a simplified cr
 \subsubsection{Sorting and Encoding Issues}
 \label{bib:cav:enc}
 
-\biber handles Ascii, 8-bit encodings such as Latin\,1, and \utf. It features true Unicode support and is capable of reencoding the \file{bib} data on the fly in a robust way. For sorting, \biber uses a Perl implementation of the Unicode Collation Algorithm (\acr{UCA}), as outlined in Unicode Technical Standard \#10.\fnurl{https://unicode.org/reports/tr10/} Collation tailoring based on the Unicode Common Locale Data Repository (\acr{CLDR}) is also supported.\fnurl{http://cldr.unicode.org/}
+\biber handles \acr{US-ASCII}, 8-bit encodings such as Latin\,1, and \utf. It features true Unicode support and is capable of reencoding the \file{bib} data on the fly in a robust way. For sorting, \biber uses a Perl implementation of the Unicode Collation Algorithm (\acr{UCA}), as outlined in Unicode Technical Standard \#10.\fnurl{https://unicode.org/reports/tr10/} Collation tailoring based on the Unicode Common Locale Data Repository (\acr{CLDR}) is also supported.\fnurl{http://cldr.unicode.org/}
 
 Supporting Unicode implies much more than handling \utf input. Unicode is a complex standard covering more than its most well-known parts, the Unicode character encoding and transport encodings such as \utf. It also standardizes aspects such as string collation, which is required for language-sensitive sorting. For example, by using the Unicode Collation Algorithm, \biber can handle the character <ß> without any manual intervention. All you need to do to get localised sorting is specify the locale:
 
@@ -1914,18 +1914,18 @@ encodings properly.
 
 \paragraph{Specifying Encodings}
 \label{bib:cav:enc:enc}
-When using a non-Ascii encoding in the \file{bib} file, it is important to understand what \biblatex can do for you and what may require manual intervention. The package takes care of the \latex side, \ie it ensures that the data imported from the \file{bbl} file is interpreted correctly, provided that the \opt{bibencoding} package option (or the datasource specific override for this, see \secref{use:bib:res}) is set properly. All of this is handled automatically and no further steps, apart from setting the \opt{bibencoding} option in certain cases, are required. Here are a few typical usage scenarios along with the relevant lines from the document preamble:
+When using a non-\acr{US-ASCII} encoding in the \file{bib} file, it is important to understand what \biblatex can do for you and what may require manual intervention. The package takes care of the \latex side, \ie it ensures that the data imported from the \file{bbl} file is interpreted correctly, provided that the \opt{bibencoding} package option (or the datasource specific override for this, see \secref{use:bib:res}) is set properly. All of this is handled automatically and no further steps, apart from setting the \opt{bibencoding} option in certain cases, are required. Here are a few typical usage scenarios along with the relevant lines from the document preamble:
 
 \begin{itemize}
 \setlength{\itemsep}{0pt}
 
-\item Ascii notation in both the \file{tex} and the \file{bib} file with \pdftex or traditional \tex:
+\item \acr{US-ASCII} notation in both the \file{tex} and the \file{bib} file with \pdftex or traditional \tex:
 
 \begin{ltxexample}
 \usepackage{biblatex}
 \end{ltxexample}
 
-\item Latin\,1 encoding (\acr{ISO}-8859-1) in the \file{tex} file, Ascii notation in the \file{bib} file with \pdftex or traditional \tex :
+\item Latin\,1 encoding (\acr{ISO}-8859-1) in the \file{tex} file, \acr{US-ASCII} notation in the \file{bib} file with \pdftex or traditional \tex :
 
 \begin{ltxexample}
 \usepackage[latin1]{inputenc}
@@ -1961,7 +1961,7 @@ The same scenario with \latex release 2018-04-01 or above, \xetex or \luatex in 
 
 \end{itemize}
 
-\biber can handle Ascii notation, 8-bit encodings such as Latin\,1, and \utf. It is also capable of reencoding the \file{bib} data on the fly (replacing the limited macro-level reencoding feature of \biblatex). This will happen automatically if required, provided that you specify the encoding of the \file{bib} files properly. In addition to the scenarios discussed above, \biber can also handle the following cases:
+\biber can handle \acr{US-ASCII} notation, 8-bit encodings such as Latin\,1, and \utf. It is also capable of reencoding the \file{bib} data on the fly (replacing the limited macro-level reencoding feature of \biblatex). This will happen automatically if required, provided that you specify the encoding of the \file{bib} files properly. In addition to the scenarios discussed above, \biber can also handle the following cases:
 
 \begin{itemize}
 
@@ -2005,11 +2005,11 @@ Some workarounds may be required when using traditional \tex or \pdftex with \ut
 \usepackage[safeinputenc]{biblatex}
 \end{ltxexample}
 %
-If this option is enabled, \biblatex will ignore \sty{inputenc}'s \opt{utf8} option and use Ascii. \biber will then try to convert the \file{bib} data to Ascii notation. For example, it will convert \k{S} to |\k{S}|. This option is similar to setting \kvopt{texencoding}{ascii} but will only take effect in this specific scenario (\sty{inputenc}\slash \sty{inputenx} with \utf). This workaround takes advantage of the fact that both Unicode and the \utf transport encoding are backwards compatible with Ascii.
+If this option is enabled, \biblatex will ignore \sty{inputenc}'s \opt{utf8} option and use \acr{US-ASCII}. \biber will then try to convert the \file{bib} data to \acr{US-ASCII} notation. For example, it will convert \k{S} to |\k{S}|. This option is similar to setting \kvopt{texencoding}{ascii} but will only take effect in this specific scenario (\sty{inputenc}\slash \sty{inputenx} with \utf). This workaround takes advantage of the fact that both Unicode and the \utf transport encoding are backwards compatible with \acr{US-ASCII}.
 
 \end{itemize}
 
-This solution may be acceptable as a workaround if the data in the \file{bib} file is mostly Ascii anyway, with only a few strings, such as some authors' names, causing problems. However, keep in mind that it will not magically make traditional \tex or \pdftex support Unicode. It may help if the occasional odd character is not supported by \sty{inputenc}, but may still be processed by \tex when using an accent command (\eg |\d{S}| instead of \d{S}). If you need full Unicode support, however, switch to \xetex or \luatex.
+This solution may be acceptable as a workaround if the data in the \file{bib} file is mostly \acr{US-ASCII} anyway, with only a few strings, such as some authors' names, causing problems. However, keep in mind that it will not magically make traditional \tex or \pdftex support Unicode. It may help if the occasional odd character is not supported by \sty{inputenc}, but may still be processed by \tex when using an accent command (\eg |\d{S}| instead of \d{S}). If you need full Unicode support, however, switch to \xetex or \luatex.
 
 Typical errors when \sty{inputenc} cannot handle a certain UTF-8 character are:
 
@@ -2047,11 +2047,11 @@ Specifies the database backend. The following backends are supported:
 
 \begin{valuelist}
 
-\item[biber] \biber, the default backend of \biblatex, supports Ascii, 8-bit encodings, \utf, on-the-fly reencoding, locale"=specific sorting, and many other features. Locale"=specific sorting, case"=sensitive sorting, and upper\slash lowercase precedence are controlled by the options \opt{sortlocale}, \opt{sortcase}, and \opt{sortupper}, respectively.
+\item[biber] \biber, the default backend of \biblatex, supports \acr{US-ASCII}, 8-bit encodings, \utf, on-the-fly reencoding, locale"=specific sorting, and many other features. Locale"=specific sorting, case"=sensitive sorting, and upper\slash lowercase precedence are controlled by the options \opt{sortlocale}, \opt{sortcase}, and \opt{sortupper}, respectively.
 
-\item[bibtex] Legacy \bibtex. Traditional \bibtex supports Ascii encoding only. Sorting is always case"=insensitive.
+\item[bibtex] Legacy \bibtex. Traditional \bibtex supports \acr{US-ASCII} encoding only. Sorting is always case"=insensitive.
 
-\item[bibtex8] \bin{bibtex8}, the 8-bit implementation of \bibtex, supports Ascii and 8-bit encodings such as Latin~1.
+\item[bibtex8] \bin{bibtex8}, the 8-bit implementation of \bibtex, supports \acr{US-ASCII} and 8-bit encodings such as Latin~1.
 
 
 \end{valuelist}
@@ -2080,7 +2080,7 @@ Loads a citation module which provides \sty{mcite}\slash\sty{mciteplus}-like cit
 
 \optitem[auto]{casechanger}{\opt{auto}, \opt{latex2e}, \opt{expl3}}
 
-This option selects the implementation of \biblatex's case changing functions, most prominently \cmd{MakeSentenceCase*}. \opt{expl3} selects the new implementation based on the \latex3 module \sty{l3text}. Note that the \sty{l3text} module assumes \utf input and that your \sty{expl3} version should be new enough (at least version 2020-04-06). \opt{latex2e} selects the original implementation, which has tricky brace protection behaviour and some shortcomings when dealing with non-ASCII characters. The default \opt{auto} selects the case changing code based on the available \sty{expl3} version and detected document encoding (\opt{expl3} is selected if \sty{expl3} is at least version 2020-04-06 and the document encoding is detected as \utf).
+This option selects the implementation of \biblatex's case changing functions, most prominently \cmd{MakeSentenceCase*}. \opt{expl3} selects the new implementation based on the \latex3 module \sty{l3text}. Note that the \sty{l3text} module assumes \utf input and that your \sty{expl3} version should be new enough (at least version 2020-04-06). \opt{latex2e} selects the original implementation, which has tricky brace protection behaviour and some shortcomings when dealing with non-\acr{US-ASCII} characters. The default \opt{auto} selects the case changing code based on the available \sty{expl3} version and detected document encoding (\opt{expl3} is selected if \sty{expl3} is at least version 2020-04-06 and the document encoding is detected as \utf).
 
 \end{optionlist}
 
@@ -2535,7 +2535,7 @@ Specifies the encoding of the \file{tex} file. This option affects the data tran
 
 \begin{valuelist}
 
-\item[auto] Try to auto-detect the input encoding. If the \sty{inputenc}\slash \sty{inputenx}\slash \sty{luainputenc} package is available, \biblatex will get the main encoding from that package. If not, it assumes \utf encoding if a \latex format using at least the April 2018 version of the kernel, \xetex or \luatex has been detected, and Ascii otherwise.
+\item[auto] Try to auto-detect the input encoding. If the \sty{inputenc}\slash \sty{inputenx}\slash \sty{luainputenc} package is available, \biblatex will get the main encoding from that package. If not, it assumes \utf encoding if a \latex format using at least the April 2018 version of the kernel, \xetex or \luatex has been detected, and \acr{US-ASCII} otherwise.
 
 \item[\prm{encoding}] Specifies the \prm{encoding} explicitly. This is for odd cases in which auto-detection fails or you want to force a certain encoding for some reason.
 
@@ -2559,7 +2559,7 @@ By default, \biblatex assumes that the \file{tex} file and the \file{bib} file u
 
 \boolitem[false]{safeinputenc}
 
-If this option is enabled, \biblatex will automatically force \kvopt{texencoding}{ascii} if the \sty{inputenc}\slash \sty{inputenx} package has been loaded and the input encoding is \utf, \ie it will ignore any macro-based \utf support and use Ascii only. \biber will then try to convert any non-Ascii data in the \file{bib} file to Ascii. For example, it will convert \texttt{\d{S}} to |\d{S}|. See \secref{bib:cav:enc:enc} for an explanation of why you may want to enable this option.
+If this option is enabled, \biblatex will automatically force \kvopt{texencoding}{ascii} if the \sty{inputenc}\slash \sty{inputenx} package has been loaded and the input encoding is \utf, \ie it will ignore any macro-based \utf support and use \acr{US-ASCII} only. \biber will then try to convert any non-\acr{US-ASCII} data in the \file{bib} file to \acr{US-ASCII}. For example, it will convert \texttt{\d{S}} to |\d{S}|. See \secref{bib:cav:enc:enc} for an explanation of why you may want to enable this option.
 
 \boolitem[true]{bibwarn}
 
@@ -5658,7 +5658,7 @@ Automatically converts the \prm{character} to its uppercase form if \biblatex's 
 \autocap{s}pecial issue
 \end{ltxexample}
 %
-will yield <Special issue> or <special issue>, as appropriate. If the string to be capitalized starts with an inflected character given in Ascii notation, include the accent command in the \prm{character} argument as follows:
+will yield <Special issue> or <special issue>, as appropriate. If the string to be capitalized starts with an inflected character given in \acr{US-ASCII} notation, include the accent command in the \prm{character} argument as follows:
 
 \begin{ltxexample}
 \autocap{\'e}dition sp\'eciale
@@ -6440,7 +6440,7 @@ There are pathological cases where neither \texttt{defernumbers=true} nor \textt
 \subsubsection{Active Characters in Bibliography Headings}
 \label{use:cav:act}
 
-Packages using active characters, such as \sty{babel}, \sty{polyglossia}, \sty{csquotes}, or \sty{underscore}, usually do not make them active until the beginning of the document body to avoid interference with other packages. A typical example of such an active character is the Ascii quote |"|, which is used by various language modules of the \sty{babel}/\sty{polyglossia} packages. If shorthands such as |"<| and |"a| are used in the argument to \cmd{defbibheading} and the headings are defined in the document preamble, the non-active form of the characters is saved in the heading definition. When the heading is typeset, they do not function as a command but are simply printed literally. The most straightforward solution consists in moving \cmd{defbibheading} after |\begin{document}|. Alternatively, you may use \sty{babel}'s \cmd{shorthandon} and \cmd{shorthandoff} commands to temporarily make the shorthands active in the preamble. The above also applies to bibliography notes and the \cmd{defbibnote} command.
+Packages using active characters, such as \sty{babel}, \sty{polyglossia}, \sty{csquotes}, or \sty{underscore}, usually do not make them active until the beginning of the document body to avoid interference with other packages. A typical example of such an active character is the \acr{US-ASCII} quote |"|, which is used by various language modules of the \sty{babel}/\sty{polyglossia} packages. If shorthands such as |"<| and |"a| are used in the argument to \cmd{defbibheading} and the headings are defined in the document preamble, the non-active form of the characters is saved in the heading definition. When the heading is typeset, they do not function as a command but are simply printed literally. The most straightforward solution consists in moving \cmd{defbibheading} after |\begin{document}|. Alternatively, you may use \sty{babel}'s \cmd{shorthandon} and \cmd{shorthandoff} commands to temporarily make the shorthands active in the preamble. The above also applies to bibliography notes and the \cmd{defbibnote} command.
 
 \subsubsection{Grouping in Reference Sections and Segments}
 \label{use:cav:grp}
@@ -6475,7 +6475,7 @@ and a special data file (automatically included in those to be read by
 
 Key limitations of the \bibtex backend are:
 \begin{itemize}
-\item Sorting is global and is limited to Ascii ordering
+\item Sorting is global and is limited to \acr{US-ASCII} ordering
 \item No re-encoding is possible and thus database entries must be in
   LICR form to work reliably
 \item The data model is fixed
@@ -6904,10 +6904,10 @@ but would additionally have the field \bibfield{dateunspecified} set to <yearinc
 The entry key of an item in the \file{bib} file. This is the string used by \biblatex and the backend to identify an entry in the \file{bib} file.
 
 Note that the set of characters allowed and usable in the string for \bibfield{entrykey} depends on the backend (\biber, \bibtex) as well as the \latex engine (\pdflatex, \lualatex, \xelatex).
-Generally, ASCII-letters (\texttt{a-z}, \texttt{A-Z}) and numbers (\texttt{0-9}) are safe, so are the punctuation characters full stop (\texttt{.}) and solidus (\texttt{/}). The punctuation characters \texttt{-\_:;!?} are also safe even if they are made active by \sty{babel}/\sty{polyglossia}. If a Unicode engine is used, non-ASCII characters are also acceptable.
+Generally, \acr{US-ASCII}-letters (\texttt{a-z}, \texttt{A-Z}) and numbers (\texttt{0-9}) are safe, so are the punctuation characters full stop (\texttt{.}) and solidus (\texttt{/}). The punctuation characters \texttt{-\_:;!?} are also safe even if they are made active by \sty{babel}/\sty{polyglossia}. If a Unicode engine is used, non-\acr{US-ASCII} characters are also acceptable.
 Curly braces (\texttt{\{\}}), commas, spaces, backslashes (\texttt{\textbackslash}), hashes (\texttt{\#}), percent characters (\texttt{\%}) and tildes (\texttt{\textasciitilde}) are always forbidden. \biber additionally forbids round brackets (\texttt{()}), quotation marks (\texttt{\textquotedbl}, \texttt{\textquotesingle}), and the equals sign (\texttt{=}).
 The \bibfield{entrykey} is case sensitive, but it is not recommended to exploit that fact too much by introducing two different entries whose key differs only in capitalisation (\eg\ \texttt{sigfridsson} and \texttt{Sigfridsson}).
-For full portability it is advisable to stick to a scheme of lowercase (and if so desired uppercase) ASCII-letters, numbers and a small set of acceptable punctuation characters, say \texttt{.:-}.
+For full portability it is advisable to stick to a scheme of lowercase (and if so desired uppercase) \acr{US-ASCII}-letters, numbers and a small set of acceptable punctuation characters, say \texttt{.:-}.
 
 \fielditem{childentrykey}{string}
 
@@ -10503,6 +10503,19 @@ Note that \cmd{value} is not prefixed by \cmd{the} and that the subtraction is i
 
 Executes \prm{true} if the \prm{string} is a positive integer, and \prm{false} otherwise. This command is robust.
 
+\cmditem{hascomputableequivalent}{string}{true}{false}
+
+Executes \prm{true} if the \prm{string} can be transformed into a \latex-computable integer consisting only of \acr{US-ASCII} characters via \cmd{getcomputableequivalent} and \prm{false} otherwise.
+The mapping from non-\acr{US-ASCII} to \acr{US-ASCII} numerals will usually be given in the \file{lbx} file.
+
+\cmditem{ifiscomputable}{string}{true}{false}
+
+Returns \prm{true} if \cmd{ifinteger} or \cmd{hascomputableequivalent} retrurns \prm{true} on \prm{string} and \prm{false} otherwise.
+
+\cmditem{getcomputableequivalent}{string}{macro}
+
+Saves the \acr{US-ASCII} representation of the number given as \prm{string} in \prm{macro}.
+
 \cmditem{ifnumeral}{string}{true}{false}
 
 Executes \prm{true} if the \prm{string} is an Arabic or Roman numeral, and \prm{false} otherwise. This command is robust. See also \cmd{DeclareNumChars} and \cmd{NumCheckSetup} in \secref{aut:aux:msc}.
@@ -10518,6 +10531,14 @@ Similar to \cmd{ifnumerals}, but also considers \cmd{DeclarePageCommands} and \c
 \cmditem{iffieldint}{field}{true}{false}
 
 Similar to \cmd{ifinteger}, but uses the value of a \prm{field} rather than a literal string in the test. If the \prm{field} is undefined, it executes \prm{false}.
+
+\cmditem{fieldhascomputableequivalent}{field}{true}{false}
+
+Similar to \cmd{hascomputableequivalent}, but uses the value of a \prm{field} rather than a literal string in the test. If the \prm{field} is undefined, it executes \prm{false}.
+
+\cmditem{iffieldiscomputable}{field}{true}{false}
+
+Similar to \cmd{ifiscomputable}, but uses the value of a \prm{field} rather than a literal string in the test. If the \prm{field} is undefined, it executes \prm{false}.
 
 \cmditem{iffieldnum}{field}{true}{false}
 
@@ -10759,7 +10780,7 @@ Similar to the \cmd{forcsvlist} command from the \sty{etoolbox} package, except 
 
 \cmditem{MakeCapital}{text}
 
-Similar to \cmd{MakeUppercase} but only converts the first printable character in \prm{text} to uppercase. Note that the restrictions that apply to \cmd{MakeUppercase} also apply to this command. Namely, all commands in \prm{text} must either be robust or prefixed with \cmd{protect} since the \prm{text} is expanded during capitalization. Apart from Ascii characters and the standard accent commands, this command also handles the active characters of the \sty{inputenc} package as well as the shorthands of the \sty{babel} package. If the \prm{text} starts with a control sequence, nothing is capitalized. This command is robust.
+Similar to \cmd{MakeUppercase} but only converts the first printable character in \prm{text} to uppercase. Note that the restrictions that apply to \cmd{MakeUppercase} also apply to this command. Namely, all commands in \prm{text} must either be robust or prefixed with \cmd{protect} since the \prm{text} is expanded during capitalization. Apart from \acr{US-ASCII} characters and the standard accent commands, this command also handles the active characters of the \sty{inputenc} package as well as the shorthands of the \sty{babel} package. If the \prm{text} starts with a control sequence, nothing is capitalized. This command is robust.
 
 \cmditem{MakeSentenceCase}{text}
 \cmditem*{MakeSentenceCase*}{text}
@@ -10795,7 +10816,7 @@ title = {The {\TeX book}},
 \end{lstlisting}
 
 %
-The behaviour of \cmd{MakeSentenceCase} differs slightly between the \opt{latex2e} and \opt{expl3} implementation. Generally speaking, the \opt{expl3} code is closer to the \bibtex behaviour of \texttt{change.case\$}. It is also better equipped to deal with non-ASCII input and macros than the \opt{latex2e} implementation. \cmd{MakeSentenceCase} behaves as follows.
+The behaviour of \cmd{MakeSentenceCase} differs slightly between the \opt{latex2e} and \opt{expl3} implementation. Generally speaking, the \opt{expl3} code is closer to the \bibtex behaviour of \texttt{change.case\$}. It is also better equipped to deal with non-\acr{US-ASCII} input and macros than the \opt{latex2e} implementation. \cmd{MakeSentenceCase} behaves as follows.
 \begin{itemize}\setlength{\labelsep}{1em}
   \item The first letter of its argument is capitalised with \cmd{MakeUppercase}. This is different from \bibtex's \texttt{change.case\$}, which does not touch the first letter of its argument.
 
@@ -10957,7 +10978,7 @@ Takes the name of a bibfield declared as a range field in the data model and ret
 \begin{itemize}
 \item Calculate the total of multiple ranges in the same field such as <1-10, 20-30>
 \item Handle implicit ranges such as <22-4> and <130-33>
-\item Handle roman numeral ranges in upper and lower case and consisting of both ASCII and Unicode roman numeral representations.
+\item Handle roman numeral ranges in upper and lower case and consisting of both \acr{US-ASCII} and Unicode roman numeral representations.
 \end{itemize}
 %
 Here are some examples:
@@ -14533,6 +14554,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \begin{changelog}
 \begin{release}{3.17}{2021-??-??}
 \item Added Romanian localisation (Patrick Danilevici)
+\item Added some support for calculating with non-\acr{US-ASCII} numerals\see{aut:aux:tst}
 \end{release}
 \begin{release}{3.16}{2020-12-31}
 \item Added named refcontext support to \cmd{assignrefcontext*}\see{use:bib:context}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3145,12 +3145,68 @@
   \fi
   \endgroup}
 
+% {\<non-ASCII numeral>}{\<ASCII number>}
+\protected\def\blx@defcomputableequivalent#1#2{%
+  \appto\blx@dononasciicomputablenumerals{\do#1}%
+  \appto\blx@initcomputableequivs{\uccode`#1=`#2}}
+
+% {<string>}{<true>}{<false>}
+\protected\long\def\blx@imc@hascomputableequivalent#1{%
+  \begingroup
+  \def\do##1{\uccode`##1=`\%}%
+  \blx@dononasciicomputablenumerals
+  \catcode`\@=11
+  \catcode`\%=9
+  \endlinechar\m@ne
+  \uppercase{\scantokens{\def\blx@tempa{#1}}}%
+  \ifx\blx@tempa\@empty
+    \aftergroup\@firstoftwo
+  \else
+    \aftergroup\@secondoftwo
+  \fi
+  \endgroup}
+
+% {<string>}{<true>}{<false>}
+\protected\long\def\blx@imc@ifiscomputable#1{%
+  \blx@imc@ifinteger{#1}
+    {\@firstofone}
+    {\blx@imc@hascomputableequivalent{#1}}}
+
+% {<string>}{<macro>}
+\protected\long\def\blx@imc@getcomputableequivalent#1#2{%
+  \blx@imc@hascomputableequivalent{#1}
+    {\begingroup
+     \blx@initcomputableequivs
+     \uppercase{\def\blx@tempa{#1}}%
+     \edef\blx@tempb{\endgroup
+       \noexpand\def\noexpand#2{\expandonce{\blx@tempa}}}%
+      \blx@tempb}
+    {\def#2{#1}}}
+
 % {<field>}{<true>}{<false>}
 \protected\def\blx@imc@iffieldint#1{%
   \blx@imc@iffieldundef{#1}
     {\@secondoftwo}
     {\expandafter\expandafter
      \expandafter\blx@imc@ifinteger
+     \expandafter\expandafter
+     \expandafter{\csname abx@field@#1\endcsname}}}
+
+% {<field>}{<true>}{<false>}
+\protected\def\blx@imc@fieldhascomputableequivalent#1{%
+  \blx@imc@iffieldundef{#1}
+    {\@secondoftwo}
+    {\expandafter\expandafter
+     \expandafter\blx@imc@hascomputableequivalent
+     \expandafter\expandafter
+     \expandafter{\csname abx@field@#1\endcsname}}}
+
+% {<field>}{<true>}{<false>}
+\protected\def\blx@imc@iffieldiscomputable#1{%
+  \blx@imc@iffieldundef{#1}
+    {\@secondoftwo}
+    {\expandafter\expandafter
+     \expandafter\blx@imc@hascomputableequivalent
      \expandafter\expandafter
      \expandafter{\csname abx@field@#1\endcsname}}}
 
@@ -3184,11 +3240,14 @@
   \fi
   \endgroup}
 
+\let\lbx@dononasciinumerals\relax
+
 \def\blx@hook@ifnum{%
   \def\do##1{\uccode`##1=`\%}%
   \do\ \do\0\do\1\do\2\do\3\do\4\do\5\do\6\do\7\do\8\do\9%
   \do\i\do\v\do\x\do\l\do\c\do\d\do\m
   \do\I\do\V\do\X\do\L\do\C\do\D\do\M
+  \lbx@dononasciinumerals
   \blx@donumchars
   \let\RN\@firstofone
   \let\Rn\@firstofone}
@@ -4121,8 +4180,10 @@
   \ifnameequalcs \ifnameequals \ifnamesequal \ifnameundef \ifnamexref
   \iffirstonpage \ifsamepage \savefield \savefieldcs \savelist
   \savelistcs \savename \savenamecs \usedriver
-  \ifinteger \ifnumeral \ifnumerals \ifpages
-  \iffieldint \iffieldnum \iffieldnums \iffieldpages
+  \ifinteger \hascomputableequivalent \ifiscomputable \getcomputableequivalent
+  \ifnumeral \ifnumerals \ifpages
+  \iffieldint \fieldhascomputableequivalent \iffieldiscomputable
+  \iffieldnum \iffieldnums \iffieldpages
   \iflabeldateisdate \ifdatehasyearonlyprecision \ifdatehastime
   \ifdateshavedifferentprecision
   \ifdateyearsequal \ifdatesequal \ifdaterangesequal


### PR DESCRIPTION
Helpful for languages such as Marathi (https://github.com/plk/biblatex/pull/1060), that use the Hindu–Arabic numeral system with non-ASCII digits.