### PR TITLE
Minor fixes for multiple .lbx files

### DIFF
--- a/tex/latex/biblatex/lbx/basque.lbx
+++ b/tex/latex/biblatex/lbx/basque.lbx
@@ -241,17 +241,17 @@
                       {ed.,\addabbrvspace ohk\adddotspace eta hitzaur\adddot}},%
   byeditoranaf     = {{edizioa, oharrak eta hitzatzea}%
                       {ed.,\addabbrvspace ohk\adddotspace eta hitzatz\adddot}},%
-  byeditortrcoin   = {{edizioa, \lbx@lfromlang itzulpena, iruzkinak eta sarrera}%
+  byeditortrcoin   = {{edizioa, \lbx@lfromlang\ itzulpena, iruzkinak eta sarrera}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, irzk\adddotspace eta sar\adddot}},%
-  byeditortrcofo   = {{edizioa, \lbx@lfromlang itzulpena, iruzkinak eta hitzaurrea}%
+  byeditortrcofo   = {{edizioa, \lbx@lfromlang\ itzulpena, iruzkinak eta hitzaurrea}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, irzk\adddotspace eta hitzaur\adddot}},%
-  byeditortrcoaf   = {{edizioa, \lbx@lfromlang itzulpena, iruzkinak eta hitzatzea}%
+  byeditortrcoaf   = {{edizioa, \lbx@lfromlang\ itzulpena, iruzkinak eta hitzatzea}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, irzk\adddotspace eta hitzatz\adddot}},%
-  byeditortranin   = {{edizioa, \lbx@lfromlang itzulpena, oharrak eta sarrera}%
+  byeditortranin   = {{edizioa, \lbx@lfromlang\ itzulpena, oharrak eta sarrera}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, ohk\adddotspace eta sar\adddot}},%
-  byeditortranfo   = {{edizioa, \lbx@lfromlang itzulpena, oharrak eta hitzaurrea}%
+  byeditortranfo   = {{edizioa, \lbx@lfromlang\ itzulpena, oharrak eta hitzaurrea}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, ohk\adddotspace eta hitzaur\adddot}},%
-  byeditortranaf   = {{edizioa, \lbx@lfromlang itzulpena, oharrak eta hitzatzea}%
+  byeditortranaf   = {{edizioa, \lbx@lfromlang\ itzulpena, oharrak eta hitzatzea}%
                       {ed.,\addabbrvspace \lbx@sfromlang\ itz\adddot, ohk\adddotspace eta hitzatz\adddot}},%
   bytranslatorco   = {{\lbx@lfromlang\ itzulpena eta iruzkinak}%
                       {\lbx@sfromlang\ itz\adddot\ eta irzk\adddot}},%
@@ -263,18 +263,18 @@
                       {\lbx@sfromlang\ itz\adddot\ eta hitzaur\adddot}},%
   bytranslatoraf   = {{\lbx@lfromlang\ itzulpena eta hitzatzea}%
                       {\lbx@sfromlang\ itz\adddot\ eta hitzatz\adddot}},%
-  bytranslatorcoin = {{\lbx@lfromlang itzulpena, iruzkinak eta sarrera}%
-                      {\lbx@sfromlang itz\adddot, irzk\adddotspace eta sar\adddot}},%
-  bytranslatorcofo = {{\lbx@lfromlang itzulpena, iruzkinak eta hitzaurrea}%
-                      {\lbx@sfromlang itz\adddot, irzk\adddotspace eta pr\'ol\adddot}},%
-  bytranslatorcoaf = {{\lbx@lfromlang itzulpena, iruzkinak eta hitzatzea}%
-                      {\lbx@sfromlang itz\adddot, irzk\adddotspace eta hitzatz\adddot}},%
-  bytranslatoranin = {{\lbx@lfromlang itzulpena, oharrak eta sarrera}%
-                      {\lbx@sfromlang itz\adddot, ohk\adddotspace eta sar\adddot}},%
-  bytranslatoranfo = {{\lbx@lfromlang itzulpena, oharrak eta hitzaurrea}%
-                      {\lbx@sfromlang itz\adddot, ohk\adddotspace eta pr\'ol\adddot}},%
-  bytranslatoranaf = {{\lbx@lfromlang itzulpena, oharrak eta hitzatzea}%
-                      {\lbx@sfromlang itz\adddot, ohk\adddotspace eta hitzatz\adddot}},%
+  bytranslatorcoin = {{\lbx@lfromlang\ itzulpena, iruzkinak eta sarrera}%
+                      {\lbx@sfromlang\ itz\adddot, irzk\adddotspace eta sar\adddot}},%
+  bytranslatorcofo = {{\lbx@lfromlang\ itzulpena, iruzkinak eta hitzaurrea}%
+                      {\lbx@sfromlang\ itz\adddot, irzk\adddotspace eta pr\'ol\adddot}},%
+  bytranslatorcoaf = {{\lbx@lfromlang\ itzulpena, iruzkinak eta hitzatzea}%
+                      {\lbx@sfromlang\ itz\adddot, irzk\adddotspace eta hitzatz\adddot}},%
+  bytranslatoranin = {{\lbx@lfromlang\ itzulpena, oharrak eta sarrera}%
+                      {\lbx@sfromlang\ itz\adddot, ohk\adddotspace eta sar\adddot}},%
+  bytranslatoranfo = {{\lbx@lfromlang\ itzulpena, oharrak eta hitzaurrea}%
+                      {\lbx@sfromlang\ itz\adddot, ohk\adddotspace eta pr\'ol\adddot}},%
+  bytranslatoranaf = {{\lbx@lfromlang\ itzulpena, oharrak eta hitzatzea}%
+                      {\lbx@sfromlang\ itz\adddot, ohk\adddotspace eta hitzatz\adddot}},%
   and              = {{eta}{eta}},%
   andothers        = {{et\adddotspace al\adddot}{et\adddotspace al\adddot}},%
   andmore          = {{et\adddotspace al\adddot}{et\adddotspace al\adddot}},%

--- a/tex/latex/biblatex/lbx/brazilian.lbx
+++ b/tex/latex/biblatex/lbx/brazilian.lbx
@@ -287,11 +287,11 @@
   byeditortran     = {{editado, traduzido \lbx@lfromlang\ e anotado por}%
                       {ed.,\addabbrvspace trad\adddot\ \lbx@sfromlang\ e anot\adddot\ por}},
   byeditortrin     = {{editado, traduzido \lbx@lfromlang\ e introduzido por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e introd\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e introd\adddot\ por}},
   byeditortrfo     = {{editado, traduzido \lbx@lfromlang\ e prefaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e pref\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e pref\adddot\ por}},
   byeditortraf     = {{editado, traduzido \lbx@lfromlang\ e posfaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e posf\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e posf\adddot\ por}},
   byeditorcoin     = {{editado, comentado e introduzido por}%
                       {ed.,\addabbrvspace coment\adddot\ e introd\adddot\ por}},
   byeditorcofo     = {{editado, comentado e prefaciado por}%

--- a/tex/latex/biblatex/lbx/dutch.lbx
+++ b/tex/latex/biblatex/lbx/dutch.lbx
@@ -286,11 +286,11 @@
   byeditortran     = {{geredigeerd, vertaald \lbx@lfromlang\ en geannoteerd door}%
                       {red., vert\adddotspace \lbx@sfromlang\ en annot\adddotspace door}},
   byeditortrin     = {{geredigeerd en vertaald \lbx@lfromlang, met een inleiding, door}%
-                      {red\adddotspace en vert. \lbx@sfromlang, met een inl., door}},
+                      {red\adddotspace en vert\adddotspace \lbx@sfromlang, met een inl., door}},
   byeditortrfo     = {{geredigeerd en vertaald \lbx@lfromlang, met een voorwoord, door}%
-                      {red\adddotspace en vert. \lbx@sfromlang, met een voorw., door}},
+                      {red\adddotspace en vert\adddotspace \lbx@sfromlang, met een voorw., door}},
   byeditortraf     = {{geredigeerd en vertaald \lbx@lfromlang, met een nawoord, door}%
-                      {red\adddotspace en vert. \lbx@sfromlang, met een naw., door}},
+                      {red\adddotspace en vert\adddotspace \lbx@sfromlang, met een naw., door}},
   byeditorcoin     = {{geredigeerd en becommentarieerd, met een inleiding, door}%
                       {red\adddotspace en comm., met een inl., door}},
   byeditorcofo     = {{geredigeerd en becommentarieerd, met een voorwoord, door}%
@@ -320,11 +320,11 @@
   bytranslatoran   = {{vertaald \lbx@lfromlang\ en geannoteerd door}%
                       {vert\adddotspace \lbx@sfromlang\ en annot.\adddotspace door}},
   bytranslatorin   = {{vertaald \lbx@lfromlang, met een inleiding, door}%
-                      {vert. \lbx@sfromlang, met een inl., door}},
+                      {vert\adddotspace \lbx@sfromlang, met een inl., door}},
   bytranslatorfo   = {{vertaald \lbx@lfromlang, met een voorwoord, door}%
-                      {vert. \lbx@sfromlang, met een voorw., door}},
+                      {vert\adddotspace \lbx@sfromlang, met een voorw., door}},
   bytranslatoraf   = {{vertaald \lbx@lfromlang, met een nawoord, door}%
-                      {vert. \lbx@sfromlang, met een naw., door}},
+                      {vert\adddotspace \lbx@sfromlang, met een naw., door}},
   bytranslatorcoin = {{vertaald \lbx@lfromlang\ en becommentarieerd, met een inleiding, door}%
                       {vert\adddotspace \lbx@sfromlang\ en comm., met een inl., door}},
   bytranslatorcofo = {{vertaald \lbx@lfromlang\ en becommentarieerd, met een voorwoord, door}%

--- a/tex/latex/biblatex/lbx/galician.lbx
+++ b/tex/latex/biblatex/lbx/galician.lbx
@@ -287,11 +287,11 @@
   byeditortran     = {{editado, traducido \lbx@lfromlang\ e anotado por}%
                       {ed.,\addabbrvspace trad\adddot\ \lbx@sfromlang\ e anot\adddot\ por}},
   byeditortrin     = {{editado, traducido \lbx@lfromlang\ e introducido por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e introd\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e introd\adddot\ por}},
   byeditortrfo     = {{editado, traducido \lbx@lfromlang\ e prefaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e pref\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e pref\adddot\ por}},
   byeditortraf     = {{editado, traducido \lbx@lfromlang\ e posfaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e posf\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e posf\adddot\ por}},
   byeditorcoin     = {{editado, comentado e introducido por}%
                       {ed.,\addabbrvspace com\adddot\ e introd\adddot\ por}},
   byeditorcofo     = {{editado, comentado e prefaciado por}%

--- a/tex/latex/biblatex/lbx/marathi.lbx
+++ b/tex/latex/biblatex/lbx/marathi.lbx
@@ -363,7 +363,7 @@
     byreviewer       = {{परीक्षण}{परी\adddot}},
     byfounder        = {{संस्थापना}{संस्था\adddot}},
     bycontinuator    = {{क्रमशः}{क्रम\adddot}},
-    bytranslator     = {{\lbx@lfromlang तून अनुवादित}{\lbx@sfromlang\ अनु\adddot}},
+    bytranslator     = {{\lbx@lfromlang\ तून अनुवादित}{\lbx@sfromlang\ अनु\adddot}},
     bycommentator    = {{भाष्य}{भाष्य}},
     byannotator      = {{टीपांसहित}{टीपा\adddot}},
     withcommentator  = {{समालोचन}{समा\adddot}},

--- a/tex/latex/biblatex/lbx/polish.lbx
+++ b/tex/latex/biblatex/lbx/polish.lbx
@@ -289,10 +289,10 @@
   byeditorin       = {{zredagowany, z wst\c{e}pem}{zred., z wst\adddot}},
   byeditorfo       = {{zredagowany, z przedmow\c{a}}{zred., z przedm\adddot}},
   byeditoraf       = {{zredagowany, z pos\l owiem}{zred., z pos\l \adddot}},
-  byeditortrco     = {{zredagowany, t\l umaczenie \lbx@lfromlang i komentarze}%
-                      {zred., t\l um\adddotspace \lbx@sfromlang i kom\adddot}},
-  byeditortran     = {{zredagowany, t\l umaczenie \lbx@lfromlang i uwagi}%
-                      {zred., t\l um\adddotspace \lbx@sfromlang i uw\adddot}},
+  byeditortrco     = {{zredagowany, t\l umaczenie \lbx@lfromlang\ i komentarze}%
+                      {zred., t\l um\adddotspace \lbx@sfromlang\ i kom\adddot}},
+  byeditortran     = {{zredagowany, t\l umaczenie \lbx@lfromlang\ i uwagi}%
+                      {zred., t\l um\adddotspace \lbx@sfromlang\ i uw\adddot}},
   byeditortrin     = {{zredagowany, t\l umaczenie \lbx@lfromlang, wst\c{e}p}%
                       {zred., t\l um\adddotspace \lbx@sfromlang, wst\adddot}},
   byeditortrfo     = {{zredagowany, t\l umaczenie \lbx@lfromlang, przedmowa}%
@@ -317,16 +317,16 @@
                       {zred., t\l um\adddotspace \lbx@sfromlang, uw\adddotspace i przedm\adddot}},
   byeditortranaf   = {{zredagowany, t\l umaczenie \lbx@lfromlang, uwagi i pos\l owie}%
                       {zred., t\l um\adddotspace \lbx@sfromlang, uw\adddotspace i pos\l \adddot}},
-  bytranslatorco   = {{t\l umaczenie \lbx@lfromlang i komentarze}%
-                      {t\l um\adddotspace \lbx@sfromlang i kom\adddot}},
-  bytranslatoran   = {{t\l umaczenie \lbx@lfromlang i uwagi}%
-                      {t\l um\adddotspace \lbx@sfromlang i uw\adddot}},
-  bytranslatorin   = {{t\l umaczenie \lbx@lfromlang i wst\c{e}p}%
-                      {t\l um\adddotspace \lbx@sfromlang i wst\adddot}},
-  bytranslatorfo   = {{t\l umaczenie \lbx@lfromlang i przedmowa}%
-                      {t\l um\adddotspace \lbx@sfromlang i przedm\adddot}},
-  bytranslatoraf   = {{t\l umaczenie \lbx@lfromlang i pos\l owie}%
-                      {t\l um\adddotspace \lbx@sfromlang i pos\l \adddot}},
+  bytranslatorco   = {{t\l umaczenie \lbx@lfromlang\ i komentarze}%
+                      {t\l um\adddotspace \lbx@sfromlang\ i kom\adddot}},
+  bytranslatoran   = {{t\l umaczenie \lbx@lfromlang\ i uwagi}%
+                      {t\l um\adddotspace \lbx@sfromlang\ i uw\adddot}},
+  bytranslatorin   = {{t\l umaczenie \lbx@lfromlang\ i wst\c{e}p}%
+                      {t\l um\adddotspace \lbx@sfromlang\ i wst\adddot}},
+  bytranslatorfo   = {{t\l umaczenie \lbx@lfromlang\ i przedmowa}%
+                      {t\l um\adddotspace \lbx@sfromlang\ i przedm\adddot}},
+  bytranslatoraf   = {{t\l umaczenie \lbx@lfromlang\ i pos\l owie}%
+                      {t\l um\adddotspace \lbx@sfromlang\ i pos\l \adddot}},
   bytranslatorcoin = {{t\l umaczenie \lbx@lfromlang, komentarze i wst\c{e}p}%
                       {t\l um\adddotspace \lbx@sfromlang, kom\adddotspace i wst\adddot}},
   bytranslatorcofo = {{t\l umaczenie \lbx@lfromlang, komentarze i przedmowa}%

--- a/tex/latex/biblatex/lbx/portuguese.lbx
+++ b/tex/latex/biblatex/lbx/portuguese.lbx
@@ -287,11 +287,11 @@
   byeditortran     = {{editado, traduzido \lbx@lfromlang\ e anotado por}%
                       {ed.,\addabbrvspace trad\adddot\ \lbx@sfromlang\ e anot\adddot\ por}},
   byeditortrin     = {{editado, traduzido \lbx@lfromlang\ e introduzido por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e introd\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e introd\adddot\ por}},
   byeditortrfo     = {{editado, traduzido \lbx@lfromlang\ e prefaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e pref\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e pref\adddot\ por}},
   byeditortraf     = {{editado, traduzido \lbx@lfromlang\ e posfaciado por}%
-                      {ed.,\addabbrvspace trad. \lbx@sfromlang\ e posf\adddot\ por}},
+                      {ed.,\addabbrvspace trad\adddotspace \lbx@sfromlang\ e posf\adddot\ por}},
   byeditorcoin     = {{editado, comentado e introduzido por}%
                       {ed.,\addabbrvspace coment\adddot\ e introd\adddot\ por}},
   byeditorcofo     = {{editado, comentado e prefaciado por}%


### PR DESCRIPTION
basque, marathi, polish: add explicit space after `\lbx@fromlang`
brazilian, dutch, galician, portuguese: use `\adddot` instead of period "."
before `\lbx@fromlang`

In languages that don't add an explicit `\space` in the definition of `\lbx@fromlang`, space after the macro will disappear in the output, so I've added \ in these cases. In the four other languages, the period after the abbreviation meant that when a language field is present, the bibstring printed by `\lbx@fromlang` will be capitalized, so I replace the . with `\adddotspace`.

(I caught multiple examples of these errors in Chicago's .lbx files, so I thought I'd look at biblatex's files, too.)