### PR TITLE
More minor fixes for multiple .lbx files

### DIFF
--- a/tex/latex/biblatex/lbx/danish.lbx
+++ b/tex/latex/biblatex/lbx/danish.lbx
@@ -251,7 +251,7 @@
   bycontinuator    = {{videref\o rt af}{videref\adddotspace af}},
   bycollaborator   = {{i samarbejde med}{i samarb\adddotspace m\adddot}},
   bytranslator     = {{oversat \lbx@lfromlang\ af}%
-  		      {overs\adddot \lbx@sfromlang\ af}},
+  		      {overs\adddot\ \lbx@sfromlang\ af}},
   bycommentator    = {{kommenteret af}{komm\adddot\ af}},
   byannotator      = {{annoteret af}{ann\adddot\ af}},
   withcommentator  = {{med kommentarer af}{m\adddotspace komm\adddot\ af}},
@@ -260,7 +260,7 @@
   withforeword     = {{med forord af}{m\adddotspace forord af}},
   withafterword    = {{med efterord af}{m\adddotspace efterord af}},
   byeditortr       = {{redigeret og oversat \lbx@lfromlang\ af}%
-                      {red\adddotspace og overs\adddot \lbx@sfromlang\ af}},
+                      {red\adddotspace og overs\adddot\ \lbx@sfromlang\ af}},
   byeditorco       = {{redigeret og kommenteret af}%
                       {red\adddotspace og komm\adddot\ af}},
   byeditoran       = {{redigeret med annoteringer af}%

--- a/tex/latex/biblatex/lbx/marathi.lbx
+++ b/tex/latex/biblatex/lbx/marathi.lbx
@@ -256,15 +256,15 @@
         {संपा\adddotspace व अनु\adddot}},
     editorstr        = {{संपादक आणि अनुवादक}%
         {संपा\adddotspace व अनु\adddot}},
-    editorco         = {{संपादक आणि }%
-        {संपा\adddotspace व \adddot}},
+    editorco         = {{संपादक आणि भाष्यकार}%
+        {संपा\adddotspace व भाष्य}},
     editorsco        = {{संपादक आणि भाष्यकार}%
         {संपा\adddotspace व भाष्य}},
     editoran         = {{संपादक आणि टीपालेखक}%
         {संपा\adddotspace व टीपा\adddot}},
     editorsan        = {{संपादक आणि टीपालेखक}%
         {संपा\adddotspace व टीपा\adddot}},
-    editorin         = {{संपादन आणि प्रस्तावना}%
+    editorin         = {{संपादक आणि प्रस्तावना}%
         {संपा\adddotspace व प्रस्ता\adddot}},
     editorsin        = {{संपादक व प्रस्तावना}%
         {संपा\adddotspace व प्रस्ता\adddot}},

--- a/tex/latex/biblatex/lbx/spanish.lbx
+++ b/tex/latex/biblatex/lbx/spanish.lbx
@@ -207,7 +207,7 @@
   byfounder        = {{fundado por}{fund\adddotspace por}},
   bycontinuator    = {{continuado por}{cont\adddotspace por}},
   bycollaborator   = {{colaboraci\'{o}n de}{col\adddotspace de}},% FIXME: unsure
-  bytranslator     = {{traducido \lbx@lfromlang\ por}{trad\adddot \lbx@sfromlang\ por}},
+  bytranslator     = {{traducido \lbx@lfromlang\ por}{trad\adddotspace \lbx@sfromlang\ por}},
   bycommentator    = {{comentado por}{com\adddotspace por}},
   byannotator      = {{anotado por}{anot\adddotspace por}},
   withcommentator  = {{con comentario de}{con com\adddotspace de}},
@@ -216,7 +216,7 @@
   withforeword     = {{con pr\'ologo de}{con pr\'ol\adddotspace de}},
   withafterword    = {{con ep\'{i}logo de}{con ep\'{\i}l\adddotspace de}},
   byeditortr       = {{editado y traducido \lbx@lfromlang\ por}%
-                      {ed\adddotspace y trad\adddot \lbx@sfromlang\ por}},
+                      {ed\adddotspace y trad\adddotspace \lbx@sfromlang\ por}},
   byeditorco       = {{editado y comentado por}%
                       {ed\adddotspace y com\adddotspace por}},
   byeditoran       = {{editado y anotado por}%
@@ -272,17 +272,17 @@
   bytranslatoraf   = {{traducido \lbx@lfromlang\ y epilogado por}%
                       {trad\adddotspace \lbx@sfromlang\ y ep\'{\i}l\adddotspace por}},
   bytranslatorcoin = {{traducido \lbx@lfromlang, comentado e introducido por}%
-                      {trad\adddot \lbx@sfromlang, com\adddotspace e intr\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, com\adddotspace e intr\adddotspace por}},
   bytranslatorcofo = {{traducido \lbx@lfromlang, comentado y prologado por}%
-                      {trad\adddot \lbx@sfromlang, com\adddotspace y pr\'ol\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, com\adddotspace y pr\'ol\adddotspace por}},
   bytranslatorcoaf = {{traducido \lbx@lfromlang, comentado y epilogado por}%
-                      {trad\adddot \lbx@sfromlang, com\adddotspace y ep\'{\i}l\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, com\adddotspace y ep\'{\i}l\adddotspace por}},
   bytranslatoranin = {{traducido \lbx@lfromlang, anotado e introducido por}%
-                      {trad\adddot \lbx@sfromlang, anot\adddotspace e intr\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, anot\adddotspace e intr\adddotspace por}},
   bytranslatoranfo = {{traducido \lbx@lfromlang, anotado y prologado por}%
-                      {trad\adddot \lbx@sfromlang, anot\adddotspace y pr\'ol\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, anot\adddotspace y pr\'ol\adddotspace por}},
   bytranslatoranaf = {{traducido \lbx@lfromlang, anotado y epilogado por}%
-                      {trad\adddot \lbx@sfromlang, anot\adddotspace y ep\'{\i}l\adddotspace por}},
+                      {trad\adddotspace \lbx@sfromlang, anot\adddotspace y ep\'{\i}l\adddotspace por}},
   and              = {{y}{y}},
   andothers        = {{y~col\adddot}{y~col\adddot}},
   andmore          = {{et\adddotspace al\adddot}{et\adddotspace al\adddot}},


### PR DESCRIPTION
danish, spanish: use \adddot\ or \adddotspace instead of plain \adddot
before \lbx@fromlang
marathi: fix 2 fragmentary strings and one typo

The first fixes ensure there's a space before any `origlanguage` field printed by `\lbx@fromlang`. In the Marathi file two of the strings appeared fragmentary, so I restored them using surrounding context. In the other the "editor" string appeared as something like "edit", unlike any other example in the file. I assume this is a typo, but perhaps the provider of the localization might be able to confirm or deny this.