### PR TITLE
Missing comma in romanian.lbx.

### DIFF
--- a/tex/latex/biblatex/lbx/romanian.lbx
+++ b/tex/latex/biblatex/lbx/romanian.lbx
@@ -508,7 +508,7 @@
   langpolish       = {{Polonă}{Polonă}},
   langportuguese   = {{Portugheză}{Portugheză}},
   langamerican     = {{Engleză}{Engleză}},
-  langromanian     = {{Română}{Română}}
+  langromanian     = {{Română}{Română}},
   langrussian      = {{Rusă}{Rusă}},
   langserbian      = {{Sârbă}{Sârbă}},
   langslovak       = {{Slovacă}{Slovacă}},


### PR DESCRIPTION
The missing comma is creating spurious text in the output of any .tex file loading `romanian.lbx`.