### PR TITLE
Fix delim aliasing with contexts ...

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -32,6 +32,12 @@
   designation.
   Helper macros have been renamed accordingly. Limited backwards
   compatibility is in place.
+- **BREAKING CHANGE**
+  `\DeclareDelimFormat` no longer accepts a list of names as argument.
+  It only accepts a single delimiter name.
+  A list of contexts is still supported.
+  Note that previously the optional argument would not work correctly
+  with a list of names.
 
 # RELEASE NOTES FOR VERSION 3.16
 - Fixed an infinite loop caused by excessive aliasing of the `volcitepages`

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -5322,10 +5322,10 @@ The delimiters described in \secref{use:fmt:fmt} are globally defined. That is, 
 
 \begin{ltxsyntax}
 
-\cmditem{DeclareDelimFormat}[context, \dots]{name, \dots}{code}
-\cmditem*{DeclareDelimFormat}*[context, \dots]{name, \dots}{code}
+\cmditem{DeclareDelimFormat}[context, \dots]{name}{code}
+\cmditem*{DeclareDelimFormat}*[context, \dots]{name}{code}
 
-Declares the delimiter macros in the comma"=separated list \prm{names} with the replacement text \prm{code}. If the optional comma"=separated list of \prm{contexts} is given, declare the \prm{names} only for those contexts. \prm{names} defined without any \prm{contexts} behave just like the global delimiter definitions which \cmd{newcommand} gives---just a plain macro with a replacement which can be used as \cmd{name}. However, you can also call delimiter macros defined in this way by using \cmd{printdelim}, which is context-aware. The starred version clears all \prm{context} specific declarations for all \prm{names} first.
+Declares the delimiter macro \prm{name} with the replacement text \prm{code}. If the optional comma"=separated list of \prm{contexts} is given, declare \prm{name} only for those contexts. \prm{name} defined without any \prm{contexts} behaves just like the global delimiter definitions which \cmd{newcommand} gives---just a plain macro with a replacement which can be used as \cmd{name}. However, you can also call delimiter macros defined in this way by using \cmd{printdelim}, which is context-aware. The starred version clears all \prm{context} specific declarations for all \prm{names} first.
 
 \cmditem{DeclareDelimAlias}[alias context, \dots]{alias}[delim context]{delim}
 
@@ -14723,6 +14723,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added Marathi localisation (\devanagarifont{निरंजन})
 \item Added Romanian localisation (Patrick Danilevici)
 \item Added some support for calculating with non-\acr{US-ASCII} numerals\see{aut:aux:tst}
+\item Removed list support for \prm{name} argument of \cmd{DeclareDelimFormat}\see{use:fmt:csd}
 \end{release}
 \begin{release}{3.16}{2020-12-31}
 \item Added named refcontext support to \cmd{assignrefcontext*}\see{use:bib:context}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -3824,7 +3824,7 @@
 
 % Delimiter interface
 
-% [<contextname, ...>]{<name, ...>}{<code>}
+% [<contextname, ...>]{<name>}{<code>}
 \newrobustcmd*{\DeclareDelimFormat}{%
   \@ifstar
     {\blx@declaredelimclear}
@@ -3852,12 +3852,10 @@
      \docsvlist{#1}}}%
 
 \def\blx@declaredelim@i#1#2#3#4{%
-  \def\do@i##1{%
-    \ifcsdef{#1##1}
-      {\blx@inf@delimdeclare{##1}{#2}}
-      {}%
-    \csdef{#1##1}{#4}}%
-  \forcsvlist{\do@i}{#3}}
+  \ifcsdef{#1#3}
+    {\blx@inf@delimdeclare{#3}{#2}}
+    {}%
+  \csdef{#1#3}{#4}}
 
 % [<alias context, ...>]{<alias>}[<delim context>]{<delim>}
 % deprecated: *[<alias context, ...>]{<alias>}[<delim context>]{<delim>}
@@ -3925,34 +3923,40 @@
 % {<alias>}{<source>}
 \def\blx@declaredelimalias@auto#1#2{%
   \blx@cleardelim{#1}%
-  \blx@declaredelimalias@def{}{#1}{}{#2}%
+  \blx@declaredelimalias@manual{}{#1}{}{#2}%
   \ifcsvoid{blx@declaredelimcontexts@#2}
     {}
     {\def\do##1{%
-       \blx@declaredelimalias@def
-         {blx@printdelim@##1@}{#1}{blx@printdelim@##1@}{#2}}%
+       \blx@declaredelimalias@manual{##1}{#1}{##1}{#2}}%
      \dolistcsloop{blx@declaredelimcontexts@#2}}}
 
 % {<alias context>}{<alias>}{<source context>}{<source>}
 \def\blx@declaredelimalias@manual#1#2#3#4{%
+  \begingroup
   \ifblank{#1}
-    {\ifblank{#3}
-       {\blx@declaredelimalias@def{}{#2}{}{#4}}
-       {\blx@declaredelimalias@def{}{#2}{blx@printdelim@#3@}{#4}}}
-    {\ifblank{#3}
-       {\blx@declaredelimalias@def{blx@printdelim@#1@}{#2}{}{#4}}}
-       {\blx@declaredelimalias@def{blx@printdelim@#1@}{#2}{blx@printdelim@#3@}{#4}}}
+    {\def\blx@tempa{{}{}}}
+    {\def\blx@tempa{{blx@printdelim@#1@}{#1}}}%
+  \ifblank{#3}
+    {\def\blx@tempb{{}{}}}
+    {\def\blx@tempb{{blx@printdelim@#3@}{#3}}}%
+  \edef\blx@tempc{\endgroup
+    \noexpand\blx@declaredelimalias@def%
+    \expandonce\blx@tempa {\unexpanded{#2}}%
+    \expandonce\blx@tempb {\unexpanded{#4}}}%
+  \blx@tempc}
 
-\def\blx@declaredelimalias@def#1#2#3#4{%
-  \ifcsdef{#1#2}
-    {\blx@inf@delimdeclare{#2}{#1}}
+% {<alias context internal id>}{<alias context name>}{<alias>}
+% {<source context internal id>}{<source context name>}{<source>}
+\def\blx@declaredelimalias@def#1#2#3#4#5#6{%
+  \ifcsdef{#1#3}
+    {\blx@inf@delimdeclare{#3}{#2}}
     {}%
-  \ifblank{#1}
+  \ifblank{#2}
     {}
-    {\ifinlistcs{#1}{blx@declaredelimcontexts@#2}
+    {\ifinlistcs{#2}{blx@declaredelimcontexts@#3}
        {}
-       {\listcsadd{blx@declaredelimcontexts@#2}{#1}}}%
-  \csdef{#1#2}{\ifcsundef{#3#4}{\csuse{#4}}{\csuse{#3#4}}}}
+       {\listcsadd{blx@declaredelimcontexts@#3}{#2}}}%
+  \csdef{#1#3}{\ifcsundef{#4#6}{\csuse{#6}}{\csuse{#4#6}}}}
 
 \def\blx@delimcontext{none}
 \newcommand*{\printdelim}[2][]{%


### PR DESCRIPTION
... remove support for a list of names in `\DeclareDelimFormat`.

The handling of lists in the first mandatory argument of `\DeclareDelimFormat` was broken anyway and a search on CTAN and the rest of the web suggests only `biblatex-archaeology` would be affected.

Plus, other standard commands like `\DeclareFieldFormat` do not support a list as first mandatory argument, either.