### PR TITLE
(Hyper)Link field and entry names to their description in biblatex's documentation

### DIFF
--- a/doc/latex/biblatex/.gitignore
+++ b/doc/latex/biblatex/.gitignore
@@ -1,0 +1,6 @@
+/*.aux
+/*.fdb_latexmk
+/*.fls
+/*.log
+/*.lot
+/*.toc

--- a/doc/latex/biblatex/Makefile
+++ b/doc/latex/biblatex/Makefile
@@ -1,0 +1,4 @@
+all: biblatex.pdf biblatex-quickstart.pdf
+
+%.pdf: %.tex
+	latexmk -lualatex $<

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4,7 +4,7 @@
 \usepackage{hyperref}
 \usepackage{zref-xr}
 
-\setmonofont{Courier New}
+\setmonofont{Liberation Mono}
 \setmainfont[Ligatures=TeX]{Linux Libertine O}
 \setsansfont[Ligatures=TeX]{Linux Biolinum O}
 \newfontfamily\devanagarifont{Shobhika}[%

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -61,6 +61,12 @@
 \newcommand*{\biblatexhome}{https://sourceforge.net/projects/biblatex/}
 \newcommand*{\biblatexctan}{https://ctan.org/pkg/biblatex/}
 
+\newcounter{hrefcounter}
+
+\usepackage{xparse}
+\NewDocumentCommand{\hreflabel}{m}{\refstepcounter{hrefcounter}\label{#1}}
+\NewDocumentCommand{\journaltitle}{}{\hyperref[journaltitle]{journaltitle}}
+
 \titlepage{%
   title={The \biblatex Package},
   subtitle={Programmable Bibliographies and Citations},
@@ -475,9 +481,9 @@ The <alias> relation referred to in this subsection is the <soft alias> defined 
 
 \typeitem{article}
 
-An article in a journal, magazine, newspaper, or other periodical which forms a self"=contained unit with its own title. The title of the periodical is given in the \bibfield{journaltitle} field. If the issue has its own title in addition to the main title of the periodical, it goes in the \bibfield{issuetitle} field. Note that \bibfield{editor} and related fields refer to the journal while \bibfield{translator} and related fields refer to the article.
+An article in a journal, magazine, newspaper, or other periodical which forms a self"=contained unit with its own title. The title of the periodical is given in the \journaltitle{} field. If the issue has its own title in addition to the main title of the periodical, it goes in the \bibfield{issuetitle} field. Note that \bibfield{editor} and related fields refer to the journal while \bibfield{translator} and related fields refer to the article.
 
-\reqitem{author, title, journaltitle, year/date}
+\reqitem{author, title, \journaltitle{}, year/date}
 \optitem{translator, annotator, commentator, subtitle, titleaddon, editor, editora, editorb, editorc, journalsubtitle, journaltitleaddon, issuetitle, issuesubtitle, issuetitleaddon, language, origlanguage, series, volume, number, eid, issue, month, pages, version, note, issn, addendum, pubstate, doi, eprint, eprintclass, eprinttype, url, urldate}
 
 \typeitem{book}
@@ -1031,13 +1037,13 @@ The International Standard Work Code of a musical work. Not used by the standard
 
 The subtitle of a journal, a newspaper, or some other periodical.
 
-\fielditem{journaltitle}{literal}
+\fielditem{journaltitle}{literal}\hreflabel{journaltitle}
 
 The name of a journal, a newspaper, or some other periodical.
 
 \fielditem{journaltitleaddon}{literal}
 
-An annex to the \bibfield{journaltitle}, to be printed in a different font.
+An annex to the \journaltitle{}, to be printed in a different font.
 
 
 \fielditem{label}{literal}
@@ -1162,7 +1168,7 @@ The verbose citation styles which comes with this package use a phrase like «he
 
 \fielditem{shortjournal}{literal\LFMark}
 
-A short version or an acronym of the \bibfield{journaltitle}. Not used by the standard bibliography styles.
+A short version or an acronym of the \journaltitle{}. Not used by the standard bibliography styles.
 
 \fielditem{shortseries}{literal\LFMark}
 
@@ -1453,7 +1459,7 @@ An alias for \bibfield{eprinttype}, provided for arXiv compatibility. See \secre
 
 \fielditem{journal}{literal}
 
-An alias for \bibfield{journaltitle}, provided for \bibtex compatibility. See \secref{bib:fld:dat}.
+An alias for \journaltitle{}, provided for \bibtex compatibility. See \secref{bib:fld:dat}.
 
 \fielditem{key}{literal}
 


### PR DESCRIPTION
I always found that this is missing and that hyperlinks to the field/entry description would make biblatex's documentation far more accessible (see also #1163). The current state of this PR is just a showcase, where only journaltitle is linked. I first like to hear from you like the idea before I put more work into it. And of course I am happy about any feedback on how to improve this. If you think the idea is sensible, which I would hope, then I am happy to link all the things.

Note that the first two commits are, strictly speaking, unrelated to this change. But I needed those to work on the tex file. You may find them sensible and pick them up, or may drop them.