### PR TITLE
\notecite causes duplicate runs of Biber in automated contexts

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4746,7 +4746,7 @@ The multicite version of \cmd{avolcite} and \cmd{Avolcite}, respectively.
 \cmditem{notecite}[prenote][postnote]{key}
 \cmditem{Notecite}[prenote][postnote]{key}
 
-These commands print the \prm{prenote} and \prm{postnote} arguments but no citation. Instead, a \cmd{nocite} command is issued for every \prm{key}. This may be useful for authors who incorporate implicit citations in their writing, only giving information not mentioned before in the running text, but who still want to take advantage of the automatic \prm{postnote} formatting and the implicit \cmd{nocite} function. This is a generic, style"=independent citation command. Special citation styles may provide smarter facilities for the same purpose. The capitalized version forces capitalization (note that this is only applicable if the note starts with a command which is sensitive to \biblatex's punctuation tracker).
+These commands print the \prm{prenote} and \prm{postnote} arguments but no citation. This may be useful for authors who incorporate implicit citations in their writing, only giving information not mentioned before in the running text, but who still want to take advantage of the automatic \prm{postnote} formatting and citation tracking. This is a generic, style"=independent citation command. Special citation styles may provide smarter facilities for the same purpose. The capitalized version forces capitalization (note that this is only applicable if the note starts with a command which is sensitive to \biblatex's punctuation tracker).
 
 \cmditem{pnotecite}[prenote][postnote]{key}
 \cmditem{Pnotecite}[prenote][postnote]{key}

--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -2256,21 +2256,21 @@
 \DeclareCiteCommand{\notecite}
   {\printfield{prenote}%
    \setunit*{\printdelim{prenotedelim}}}
-  {\nocite{\thefield{entrykey}}}
+  {}
   {}
   {\printfield{postnote}}
 
 \DeclareCiteCommand{\pnotecite}[\mkbibparens]
   {\printfield{prenote}%
    \setunit*{\printdelim{prenotedelim}}}
-  {\nocite{\thefield{entrykey}}}
+  {}
   {}
   {\printfield{postnote}}
 
 \DeclareCiteCommand{\fnotecite}[\mkbibfootnote]
   {\printfield{prenote}%
    \setunit*{\printdelim{prenotedelim}}}
-  {\nocite{\thefield{entrykey}}}
+  {}
   {}
   {\printfield{postnote}}
 


### PR DESCRIPTION
**TL/DR;** The definition of `\notecite` in `biblatex.def` should not contain `\nocite` in the `loopcode` as it causes duplicate runs of Biber with tools such as `latexmk`

I've been pursuing the ever elusive goal of optimizing LaTeX compile times and found an odd bug with `\notecite`.

Here's a MWEB:
```latex
\documentclass{article}
\usepackage{biblatex}

\addbibresource{\jobname.bib}

\begin{filecontents}{\jobname.bib}
@book{key,
  author = {Author, A.},
  year = {2001},
  title = {Title},
  publisher = {Publisher}
}
\end{filecontents}

\begin{document}

This is a test of using notecite \notecite[foo][bar]{key}.

\printbibliography

\end{document}
```

If you run `latexmk` on this file, the following commands are run:
```
latex main
biber main
latex main
biber main
latex main
latex main
```
Biber is run twice because the `.bcf` file generated after the second run of `latex` adds a duplicate `bcf:citekey`, causing `latexmk`'s dependency analysis to believe that Biber has to be run again:

```xml
  <!-- CITATION DATA -->
  <!-- SECTION 0 -->
  <bcf:bibdata section="0">
    <bcf:datasource type="file" datatype="bibtex" glob="false">main.bib</bcf:datasource>
  </bcf:bibdata>
  <bcf:section number="0">
    <bcf:citekey order="1">key</bcf:citekey>
    <bcf:citekey order="2">key</bcf:citekey> <!-- This was added after the second run -->
  </bcf:section>
```
After testing and digging around, I found that the following lines are problematic:

https://github.com/plk/biblatex/blob/9163c931822ffef222d8c533610edabea651c921/tex/latex/biblatex/biblatex.def#L2256-L2261

Since the loopcode is not executed when keys are undefined (i.e., on the first run of `latex`), `\nocite` is not "seen" until the second `latex` run, where `biblatex` then adds a duplicate `bcf:citekey`.

Removing the whole `\nocite` command from the macro fixes this issue and does not seem to change the output in the slightest. TBH, I don't know what use `\nocite` has here, since the initialization of `\notecite` itself already adds the entry to the bibliography.

Running Biber twice (and Latex) can be time-consuming and is redundant here. Moreover, most Latex IDEs probably use dependency analysis anyways (Overleaf is based on `latexmk`). Hence, fixing this might shave off a few seconds (or minutes considering the subsequent runs of Latex).