### PR TITLE
Remove \abx@aux@refcontextdefaultsdone (#1176)

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -877,8 +877,6 @@
 \newlength{\bibparsep}
 \newlength{\bibhang}
 
-\newbool{refcontextdefaults}
-\booltrue{refcontextdefaults}%
 \newbool{sourcemap}
 \newbool{citetracker}
 \newbool{pagetracker}
@@ -9844,16 +9842,18 @@
 % bibliography list in standard cases where entries are not listed in
 % multiple bibliographies
 \def\blx@setdefaultrefcontext#1{%
-  \ifbool{refcontextdefaults}
-    {\blx@rerun@latex}%
-    {}%
   \ifinlistcs{#1}{blx@defaultrefcontexts@\the\c@refsection}
     {}
     {\listcsgadd{blx@defaultrefcontexts@\the\c@refsection}{#1}}%
-  \csxdef{blx@assignedrefcontextbib@\the\c@refsection @#1}{\blx@refcontext@context}}
+  \ifcsequal
+    {blx@assignedrefcontextbib@\the\c@refsection @#1}
+    {blx@refcontext@context}
+    {}
+    {\blx@rerun@latex
+     \global\cslet{blx@assignedrefcontextbib@\the\c@refsection @#1}%
+       \blx@refcontext@context}}
 % <refsection><key><refcontext>
 \def\abx@aux@defaultrefcontext#1#2#3{%
-  \global\boolfalse{refcontextdefaults}%
   \csxdef{blx@assignedrefcontextbib@#1@#2}{\detokenize{#3}}}
 % \abx@aux@defaultlabelprefix is a dummy only used by BibTeX to implement a
 % simple labelprefix not based on full refcontexts, which BibTeX does not

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -9855,18 +9855,12 @@
 \def\abx@aux@defaultrefcontext#1#2#3{%
   \global\boolfalse{refcontextdefaults}%
   \csxdef{blx@assignedrefcontextbib@#1@#2}{\detokenize{#3}}}
-\def\abx@aux@refcontextdefaultsdone{%
-  \global\boolfalse{refcontextdefaults}}
 % \abx@aux@defaultlabelprefix is a dummy only used by BibTeX to implement a
 % simple labelprefix not based on full refcontexts, which BibTeX does not
 % support.
 \let\abx@aux@defaultlabelprefix\@gobblethree
 
 \AtEndDocument{%
-  % write the .aux to say we don't need to re-run to consume refcontext defaults
-  \ifbool{refcontextdefaults}
-    {}
-    {\blx@auxwrite\@mainaux{}{\string\abx@aux@refcontextdefaultsdone}}%
   % always add default refcontext declarations to .aux after biber run
   \iftoggle{blx@bbldone}
     {\def\do#1{%


### PR DESCRIPTION
163849de21be859ffc3aed17c843ace7a0f18bd4 basically removes the need for `\abx@aux@refcontextdefaultsdone` (73e58fcadba58b93759d6b36af9c4c27421d970d).