### PR TITLE
Rephrase "urlseen" text in "italian.lbx" (#1141)

### DIFF
--- a/tex/latex/biblatex/lbx/italian.lbx
+++ b/tex/latex/biblatex/lbx/italian.lbx
@@ -338,7 +338,7 @@
   version          = {{versione}{ver\adddot}},
   url              = {{indirizzo}{indirizzo}},
 % urlfrom          = {{}{}},% FIXME: missing
-  urlseen          = {{visitato il}{visitato il}},
+  urlseen          = {{visitato il giorno}{visitato il giorno}},
 % inpreparation    = {{}{}},% FIXME: missing
 % submitted        = {{}{}},% FIXME: missing
 % forthcoming      = {{}{}},% FIXME: missing


### PR DESCRIPTION
This change was made to avoid the possibility of producing mistakes such as "visitato il 11" or "visitato il 8".

Edit: to be clearer, if you want to keep the "visitato il" expression, then it should change the article from "il" to " l' " to produce the correct sentence when you have a date whose day contains the number 11 ("undici") or 8 ("otto").
Changing the expression to "visitato il giorno" sidesteps this problem, since it will produce the correct sentence no matter which date is appended to the former ("visitato il giorno 11" and "visitato il giorno 8" are both correct).