### PR TITLE
Fix typo 's/an warning/a warning' in the docs

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -6141,8 +6141,8 @@ There are \opt{--output-*} variants of the above options for \biber tool mode ou
 Things to note with granular \bibtype{xdata} references:
 
 \begin{itemize}
-  \item References must be made only to \bibtype{xdata} fields. An warning will be generated otherwise and the reference will not be resolved
-  \item References must be made only to \bibtype{xdata} fields of the same type (list/name and datatype) as the referencing field. An warning will be generated otherwise and the reference will not be resolved
+  \item References must be made only to \bibtype{xdata} fields. A warning will be generated otherwise and the reference will not be resolved
+  \item References must be made only to \bibtype{xdata} fields of the same type (list/name and datatype) as the referencing field. A warning will be generated otherwise and the reference will not be resolved
   \item References to fields of datatype 'date' are not possible. References to legacy \bibfield{year} and \bibfield{month} fields are possible
   \item References to missing entries, fields or list/name indices will generate a warning and the reference will not be resolved
   \item If an index is missing for a reference to a list/name field, the


### PR DESCRIPTION
A small English typo spotted in the documentation.