### PR TITLE
Fix typo in the docs

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -6482,7 +6482,7 @@ All \latex environments enclosed in \cmd{begin} and \cmd{end} form a group. This
 <<\endrefsection>>
 \end{ltxexample}
 %
-This will not from a group, but otherwise works as usual. As far as \biblatex is concerned, it does not matter which syntax you use. The alternative syntax is also supported by the \env{refsegment} environment. Note that the commands \cmd{newrefsection} and \cmd{newrefsegment} do not form a group. See \secref{use:bib:sec, use:bib:seg} for details.
+This will not form a group, but otherwise works as usual. As far as \biblatex is concerned, it does not matter which syntax you use. The alternative syntax is also supported by the \env{refsegment} environment. Note that the commands \cmd{newrefsection} and \cmd{newrefsegment} do not form a group. See \secref{use:bib:sec, use:bib:seg} for details.
 
 \subsection{Using the fallback \bibtex\ backend}
 \label{use:bibtex}


### PR DESCRIPTION
Another small English typo spotted in the documentation. Changed 'from' to 'form'.