### PR TITLE
Update danish.lbx - missing squirly bracket causing compile error

### DIFF
--- a/tex/latex/biblatex/lbx/danish.lbx
+++ b/tex/latex/biblatex/lbx/danish.lbx
@@ -386,7 +386,7 @@
   inseries         = {{i r{\ae}kken}{i rk\adddot}},
   ofseries         = {{fra r{\ae}kken}{fra rk\adddot}},
   number           = {{nummer}{nr\adddot}},
-  numbers          = {{numre}{nr\adddot}},
+ % numbers          = {{numre}{nr\adddot}},%It is unclear where it comes from and what it is for. undefined variable and thus gives an xkeyval error.
   chapter          = {{kapitel}{kap\adddot}},
   bathesis         = {{Bachelorafhandling}{Bachelorafh\adddot}},
   mathesis         = {{Masterafhandling}{Masterafh\adddot}},

--- a/tex/latex/biblatex/lbx/danish.lbx
+++ b/tex/latex/biblatex/lbx/danish.lbx
@@ -215,29 +215,29 @@
   translatorsaf    = {{overs{\ae}ttelse og epilog}%
                       {overs\adddotspace og epilog}},
   translatorcoin   = {{overs{\ae}ttelse, kommentarer og indledning}%
-                      {overs., komment\adddotspace og indl\adddot}},
+                      {overs\adddot, komment\adddotspace og indl\adddot}},
   translatorscoin  = {{overs{\ae}ttelse, kommentarer og indledning}%
-                      {overs., komment\adddotspace og indl\adddot}},
+                      {overs\adddot, komment\adddotspace og indl\adddot}},
   translatorcofo   = {{overs{\ae}ttelse, kommentarer og forord}%
-                      {overs., komment\adddotspace og forord}},
+                      {overs\adddot, komment\adddotspace og forord}},
   translatorscofo  = {{overs{\ae}ttelse, kommentarer og forord}%
-                      {overs., komment\adddotspace og forord}},
+                      {overs\adddot, komment\adddotspace og forord}},
   translatorcoaf   = {{overs{\ae}ttelse, kommentarer og epilog}%
-                      {overs., komment\adddotspace og epilog}},
+                      {overs\adddot, komment\adddotspace og epilog}},
   translatorscoaf  = {{overs{\ae}ttelse, kommentarer og epilog}%
-                      {overs., komment\adddotspace og epilog}},
+                      {overs\adddot, komment\adddotspace og epilog}},
   translatoranin   = {{overs{\ae}ttelse, annotering og indledning}%
-                      {overs., annot\adddotspace og indl\adddot}},
+                      {overs\adddot, annot\adddotspace og indl\adddot}},
   translatorsanin  = {{overs{\ae}ttelse, annotering og indledning}%
-                      {overs., annot\adddotspace og indl\adddot}},
+                      {overs\adddot, annot\adddotspace og indl\adddot}},
   translatoranfo   = {{overs{\ae}ttelse, annotering og forord}%
-                      {overs., annot\adddotspace og forord}},
+                      {overs\adddot, annot\adddotspace og forord}},
   translatorsanfo  = {{overs{\ae}ttelse, annotering og forord}%
-                      {overs., annot\adddotspace og forord}},
+                      {overs\adddot, annot\adddotspace og forord}},
   translatoranaf   = {{overs{\ae}ttelse, annotering og epilog}%
-                      {overs., annot\adddotspace og epilog}},
+                      {overs\adddot, annot\adddotspace og epilog}},
   translatorsanaf  = {{overs{\ae}ttelse, annotering og epilog}%
-                      {overs., annot\adddotspace og epilog}},
+                      {overs\adddot, annot\adddotspace og epilog}},
   organizer        = {{organisator}{org\adddot}},
   organizers       = {{organisatorer}{org\adddot}},
   byorganizer      = {{organiseret af}{org\adddotspace av}},
@@ -501,25 +501,25 @@
   fromukrainian    = {{fra ukrainsk}{fra ukrainsk}},
   countryde        = {{Tyskland}{DE}},
   countryeu        = {{Europ{\ae}iske Union}{EU}},
-  countryep        = {{Europ{\ae}iske Union}{EP}},
+  countryep        = {{Europ{\ae}iske Union}{EP}},%must be wrong. Does this refer to European Parliament or European Patent?
   countryfr        = {{Frankrig}{FR}},
   countryuk        = {{Storbritannien}{GB}},
   countryus        = {{USA}{US}},
   patent           = {{patent}{pat\adddot}},
-  patentde         = {{tysk patent}{tysk pat\adddot}},
-  patenteu         = {{europ{\ae}isk patent}{eur\adddot\ pat\adddot}},
-  patentfr         = {{fransk patent}{fransk pat\adddot}},
-  patentuk         = {{britisk patent}{brit\adddot\ pat\adddot}},
-  patentus         = {{amerikansk patent}{am\adddot\ pat\adddot}},
-  patreq           = {{patentans\o gning}{pat\adddot\ ans\o gn\adddot}},
-  patreqde         = {{tysk patentans\o gning}{tysk pat\adddot\ ans\o gn\adddot}},
-  patreqeu         = {{europ{\ae}isk patentans\o gning}{eur\adddot\ pat\adddot\ ans\o gn\adddot}},
-  patreqfr         = {{fransk patentans\o gning}{fransk pat\adddot\ ans\o gn\adddot}},
-  patrequk         = {{britisk patentans\o gning}{brit\adddot\ pat\adddot\ ans\o gn\adddot}},
-  patrequs         = {{amerikansk patentans\o gning}{am\adddot\ pat\adddot\ ans\o gn\adddot}},
+  patentde         = {{DE-patent}{DE-pat\adddot}},
+  patenteu         = {{EU-patent}{EU-pat\adddot}},
+  patentfr         = {{FR-patent}{FR-pat\adddot}},
+  patentuk         = {{UK-patent}{UK-pat\adddot}},
+  patentus         = {{US-patent}{US-pat\adddot}},
+  patreq           = {{patentans{\o}gning}{pat\adddot\ ans{\o}gn\adddot}},
+  patreqde         = {{tysk patentans{\o}gning}{tysk pat\adddot\ ans{\o}gn\adddot}},
+  patreqeu         = {{europ{\ae}isk patentans{\o}gning}{EU-pat\adddot\ ans{\o}gn\adddot}},
+  patreqfr         = {{fransk patentans{\o}gning}{fransk pat\adddot\ ans{\o}gn\adddot}},
+  patrequk         = {{britisk patentans{\o}gning}{brit\adddot\ pat\adddot\ ans{\o}gn\adddot}},
+  patrequs         = {{amerikansk patentans{\o}gning}{am\adddot\ pat\adddot\ ans{\o}gn\adddot}},
   file             = {{fil}{fil}},
   library          = {{bibliotek}{bibl\adddot}},
-  abstract         = {{Abstract}{Abstract},%akademically it is an abstract and not a "resumé". They are not the same thing.
+  abstract         = {{Abstract}{Abstract}},%akademically it is an abstract and not a "resumé". They are not the same thing.
   annotation       = {{kommentarer}{komment\adddot}},
   commonera        = {{efter vor tidsregning}{e\adddot v\adddot t\adddot}},
   beforecommonera  = {{f{\o}r vor tidsregning}{f\adddot v\adddot t\adddot}},


### PR DESCRIPTION
- Added a missing squirly bracket that caused a compile error.
- Additionally, it now gives errors for some of the newly added items that were commented out before (Package xkeyval Error: `Q1' undefined in families `blx@lbx'.), etc. 
- I presume that these errors stem from an incompatibility between my version of biblatex v. 3.16 and this dev branch of biblatex-apa and will be fixed once the final version rolls out.