### PR TITLE
Added "eprint:iacreprint" field format for IACR Cryptology ePrint Archive

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -554,6 +554,11 @@
     {\href{http://books.google.com/books?id=#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}
 \DeclareFieldAlias{eprint:Google Books}{eprint:googlebooks}
+\DeclareFieldFormat{eprint:iacreprint}{%
+  Cryptology ePrint Archive, Paper\space
+  \ifhyperref
+    {\href{https://eprint.iacr.org/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}}
 \DeclareFieldFormat{file}{\url{#1}}
 \DeclareFieldFormat{isbn}{\mkbibacro{ISBN}\addcolon\space #1}
 \DeclareFieldFormat{isrn}{\mkbibacro{ISRN}\addcolon\space #1}


### PR DESCRIPTION
Added "eprint:iacreprint" field format for IACR Cryptology ePrint Archive, with recommended citation style according to https://eprint.iacr.org/citation.html