### PR TITLE
Added "eprint:ark"

### DIFF
--- a/tex/latex/biblatex/biblatex.def
+++ b/tex/latex/biblatex/biblatex.def
@@ -523,6 +523,12 @@
     {\href{http://hdl.handle.net/#1}{\nolinkurl{#1}}}
     {\nolinkurl{#1}}}
 \DeclareFieldAlias{eprint:HDL}{eprint:hdl}
+\DeclareFieldFormat{eprint:ark}{%
+  ARK\addcolon\space
+  \ifhyperref
+    {\href{https://n2t.net/ark:/#1}{\nolinkurl{#1}}}
+    {\nolinkurl{#1}}}
+\DeclareFieldAlias{eprint:ARK}{eprint:ark}
 \DeclareFieldFormat{eprint:arxiv}{%
   arXiv\addcolon\space
   \ifhyperref


### PR DESCRIPTION
[ARK](https://en.wikipedia.org/wiki/Archival_Resource_Key) identifiers are used by many organisations. This change adds ARK identifiers in the format, ARK: [53355/cl010066723](https://n2t.net/ark:/53355/cl010066723), and uses [n2t.net](https://n2t.net) for resolving the identifier.