### PR TITLE
Update biblatex.tex

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -322,7 +322,7 @@ The \sty{showkeys} package prints the internal keys of, among other things, cita
 When using the \sty{memoir} class, the default bibliography headings are adapted such that they blend well with the default layout of this class. See \secref{use:cav:mem} for further usage hints.
 
 \item[\acr{KOMA}-Script]
-When using any of the \sty{scrartcl}, \sty{scrbook}, or \sty{scrreprt} classes, the default bibliography headings are adapted such that they blend with the default layout of these classes. See \secref{use:cav:scr} for further usage hints.
+When using any of the \sty{scrartcl}, \sty{scrbook}, or \sty{scrreprt} classes, the default bibliography headings are adapted such that they blend well with the default layout of these classes. See \secref{use:cav:scr} for further usage hints.
 
 If available \biblatex makes use of some of the more recent of \acr{KOMA}-Script's \emph{do-hooks}. The relevant hooks are present from version~3.27 (2019/10/12) onwards, which is therefore the minimum version recommendation.
 


### PR DESCRIPTION
Add the apparently missing word *well*, the sentence being almost identical to the one for *memoir* class except for the word *well*.