### PR TITLE
Fix "abbreviation" for refererences

### DIFF
--- a/tex/latex/biblatex/lbx/german.lbx
+++ b/tex/latex/biblatex/lbx/german.lbx
@@ -95,7 +95,7 @@
 
 \DeclareBibliographyStrings{%
   bibliography     = {{Literaturverzeichnis}{Literatur}},
-  references       = {{Literaturverzeichnis}{Literatur}},
+  references       = {{Literaturverzeichnis}{Literaturverzeichnis}},
   shorthands       = {{Sigelverzeichnis}{Sigel}},
   editor           = {{Herausgeber}{Hrsg\adddot}},
   editors          = {{Herausgeber}{Hrsg\adddot}},


### PR DESCRIPTION
In German, the word "Literatur" denotes a **full** bibliography, not the ones being cited (the references). (This was somehow brought up at https://github.com/gi-ev/LNI/issues/94#issuecomment-1537180873).

As far as I understand the intention of the abbreviations, the main use is to shorten the text itself - and not some shorter headings (in general).

Therefore, I propose to use the "right" word "Literaturverzeichnis" also for the abbreviation. (The alternative "Literaturverz." is really, really strange).

For "bibliography", the short form "Literatur" is IMHO OK.

Note that also in Italian, the longer form is also used as "abbreviation". https://github.com/plk/biblatex/blob/a581e08747804b4984fe136fea2ffbd5013754b3/tex/latex/biblatex/lbx/italian.lbx#L91