### PR TITLE
Add \Fvolcite, \Ftvolcite and \ftvolcites to the documentation

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -4774,14 +4774,17 @@ Similar to \cmd{volcite} but based on \cmd{parencite}.
 The multicite version of \cmd{pvolcite} and \cmd{Pvolcite}, respectively.
 
 \cmditem{fvolcite}[prenote]{volume}[pages]{key}
+\cmditem{Fvolcite}[prenote]{volume}[pages]{key}
 \cmditem{ftvolcite}[prenote]{volume}[pages]{key}
+\cmditem{Ftvolcite}[prenote]{volume}[pages]{key}
 
 Similar to \cmd{volcite} but based on \cmd{footcite} and \cmd{footcitetext}, respectively.
 
 \cmditem{fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 \cmditem{Fvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
+\cmditem{ftvolcites}(multiprenote)(multipostnote)[prenote]{volume}[pages]{key}|\\...|[prenote]{volume}[pages]{key}
 
-The multicite version of \cmd{fvolcite} and \cmd{Fvolcite}, respectively.
+The multicite version of \cmd{fvolcite} and \cmd{ftvolcite}, respectively.
 
 \cmditem{svolcite}[prenote]{volume}[pages]{key}
 \cmditem{Svolcite}[prenote]{volume}[pages]{key}


### PR DESCRIPTION
@frankbits noticed that `\Fvolcite`, `\Ftvolcite` and `\ftvolcites` are missing from the documentation. I checked and they appear to be working fine, so I added them.
The exception is `\Ftvolcites` which doesn't work for me, but I can't think of any situation where it would be applicable so not sure if this is an issue.