### PR TITLE
add new inclusive flag `superstitious`

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -8789,6 +8789,14 @@
           {}}
         {\csnumgdef{blx@labelnumber@\the\c@refsection}{%
             \csuse{blx@labelnumber@\the\c@refsection}+1}%
+          % some people are truly afraid of number 13
+          % for sake of inclusivity, we never use 13 as a reference number
+          \iftoggle{blx@superstitious}{
+          \ifnumcomp{\csuse{blx@labelnumber@\the\c@refsection}}{=}{13}{
+            \csnumgdef{blx@labelnumber@\the\c@refsection}{%
+                \csuse{blx@labelnumber@\the\c@refsection}+1}
+            }{}
+          }{}
           \edef\abx@field@localnumber{%
             \csuse{blx@labelnumber@\the\c@refsection}}%
           \blx@bbl@fieldedef{labelnumber}{\abx@field@localnumber}%
@@ -15915,6 +15923,12 @@
   \ifstrequal{#1}{true}
     {\toggletrue{blx@seconds}}
     {\togglefalse{blx@seconds}}}
+
+\newtoggle{blx@superstitious}
+\DeclareBibliographyOption[boolean]{superstitious}[true]{%
+  \ifstrequal{#1}{true}
+    {\toggletrue{blx@superstitious}}
+    {\togglefalse{blx@superstitious}}}
 
 \DeclareBibliographyOption[string]{autocite}{%
   \ifcsundef{blx@acite@#1}


### PR DESCRIPTION
It has been widely documented that number 13 causes potentially deep anxiety for some people, this is called [Triskaidekaphobia](https://en.wikipedia.org/wiki/Triskaidekaphobia).
For this reason, architects don't put floor 13 in buildings, airways don't have row 13 and important events are never held on Friday 13.

For those reasons, we need to accommodate scholars suffering from Triskaidekaphobia. 

This pull-request adds a flag `superstititious` in biblatex. Usage is direct:

```latex
\usepackage[superstitious=true]{biblatex}
```

As a result, the bibliography omits reference 13 both in citation style and bibliographic style. 

> [12] Smith, John. The Enchanted Forest. Imaginary Press, 2020. 
> [14] Doe, Jane. Mysteries of the Unknown. Phantom Publications, 2018.
> [15] Adams, Robert. Journey to Nowhere. Fictional House, 2022. 





