### PR TITLE
Fix `\DeclareHyphenationExceptions` with polyglossia and language variants (#1381)

### DIFF
--- a/doc/latex/biblatex/CHANGES.md
+++ b/doc/latex/biblatex/CHANGES.md
@@ -6,6 +6,7 @@
   `\mkcomprange` or `\mkseqrange` (or their starred counterpart, respectively)
   depending on the `citepagerange` value.
 - Use `\mkautorange` in standard styles.
+- Fix `\DeclareHyphenationExceptions` with polyglossia and language variants.
 
 # RELEASE NOTES FOR VERSION 3.20
 - Added new option settings `minyearinit` and `minyearfull` for

--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -15081,6 +15081,7 @@ This revision history is a list of changes relevant to users of this package. Ch
 \item Added option \opt{citepagerange} to customize the format of page ranges\see{use:opt:pre:gen}
 \item Added \cmd{mkautorange} and \cmd{mkautorange*} which forwards to \cmd{mknormrange}, \cmd{mkcomprange} or \cmd{mkseqrange} (or their starred counterpart, respectively) depending on the \opt{citepagerange} value\see{aut:aux:msc}
 \item Use \cmd{mkautorange} in standard styles.
+\item Fix \cmd{DeclareHyphenationExceptions} with \sty{polyglossia} and language variants.
 \end{release}
 \begin{release}{3.20}{2024-03-22}
 \item Added new \opt{uniquename} options \see{use:opt:pre:int}

--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -562,6 +562,9 @@
     {\ifundef\xpg@ifdefined
        {}
        {\def\blx@ifhyphenationundef#1#2#3{\xpg@ifdefined{#1}{#3}{#2}}}%
+     \ifundef\pghyphenation
+       {}
+       {\def\blx@hyphexcept#1#2{\pghyphenation{#1}{#2}}}%
      % This is required for languages which are never explicitly selected
      % \xpg@bloaded is not defined in polyglossia < v1.45
      \ifundef\xpg@bloaded

--- a/tex/latex/biblatex/lbx/austrian.lbx
+++ b/tex/latex/biblatex/lbx/austrian.lbx
@@ -8,9 +8,4 @@
   january          = {{J\"anner}{J\"an\adddot}},
 }
 
-\DeclareHyphenationExceptions{%
-  Pa-tent-an-mel-dung
-  Pa-tent-an-meld
-}
-
 \endinput

--- a/tex/latex/biblatex/lbx/naustrian.lbx
+++ b/tex/latex/biblatex/lbx/naustrian.lbx
@@ -14,9 +14,4 @@
 % sectiontotals    = {{Paragrafen}{\S\S}},
 }
 
-\DeclareHyphenationExceptions{%
-  Pa-tent-an-mel-dung
-  Pa-tent-an-meld
-}
-
 \endinput

--- a/tex/latex/biblatex/lbx/ngerman.lbx
+++ b/tex/latex/biblatex/lbx/ngerman.lbx
@@ -13,9 +13,4 @@
 % sectiontotals    = {{Paragrafen}{\S\S}},
 }
 
-\DeclareHyphenationExceptions{%
-  Pa-tent-an-mel-dung
-  Pa-tent-an-meld
-}
-
 \endinput

--- a/tex/latex/biblatex/lbx/nswissgerman.lbx
+++ b/tex/latex/biblatex/lbx/nswissgerman.lbx
@@ -22,9 +22,4 @@
 % sectiontotals    = {{Paragrafen}{\S\S}},
 }
 
-\DeclareHyphenationExceptions{%
-  Pa-tent-an-mel-dung
-  Pa-tent-an-meld
-}
-
 \endinput

--- a/tex/latex/biblatex/lbx/swissgerman.lbx
+++ b/tex/latex/biblatex/lbx/swissgerman.lbx
@@ -16,9 +16,4 @@
   countryuk        = {{Grossbritannien}{GB}},
 }
 
-\DeclareHyphenationExceptions{%
-  Pa-tent-an-mel-dung
-  Pa-tent-an-meld
-}
-
 \endinput


### PR DESCRIPTION
As elaborated in #1381 this used `polyglossia`'s own `\pghyphenation` which is aware of babel name aliases.

The PR also removes redundant uses of the same `\DeclareHyphenationExceptions` in the different varieties of German. All of them inherit the exceptions as defined in `german.ldf` and apply them to the right pattern.