### PR TITLE
Fixes #1470 and disables the footnote-patch-failed warning in this case

### DIFF
--- a/tex/latex/biblatex/biblatex.sty
+++ b/tex/latex/biblatex/biblatex.sty
@@ -419,6 +419,13 @@
        {}
        {}}
     {}%
+  \IfDocumentMetadataT{% will only work for classes which use the hook
+    \AddToHook{begindocument}{%
+      \AddToHook{fntext/begin}{\toggletrue{blx@footnote}}%
+      \AddToHook{fntext/end}{\togglefalse{blx@footnote}}%
+    }%
+    \togglefalse{blx@tempa}%
+  }%
   \iftoggle{blx@tempa}
     {\blx@warning@noline{%
        Patching footnotes failed.\MessageBreak


### PR DESCRIPTION
Fixes footnote detection if `\DocumentMetadata` is used and disables the footnote-patch-failed warning in this case.

Fixes https://github.com/plk/biblatex/issues/1470

The reason no warning is issued except by chance is that Biblatex's patch succeeds, but is then silently clobbered by `latex-lab` in a later hook. To avoid this, the code needs to be delayed.

This does not use any LaTeX internals, since sufficient public hooks are now available to inject footnote detection.

This is **extremely** minimally tested. 