### PR TITLE
Fix typo

### DIFF
--- a/doc/latex/biblatex/biblatex.tex
+++ b/doc/latex/biblatex/biblatex.tex
@@ -5571,7 +5571,7 @@ Similar to \cmd{mkbibdatelong} but using the language specific short date format
 
 \csitem{mkbibtimezone}
 
-Modifies a timezone string passed in as the only argument. By default this changes <Z> to the value of \cmd{bibtimezone}.
+Modifies a timezone string passed in as the only argument. By default this changes <Z> to the value of \cmd{bibutctimezone}.
 
 \csitem{bibdateuncertain}
 
@@ -12941,7 +12941,7 @@ Similar to \cmd{mkbibdatelong} but using the language specific short date format
 
 \csitem{mkbibtimezone}
 
-Modifies a timezone string passed in as the only argument. By default this changes <Z> to the value of \cmd{bibtimezone}.
+Modifies a timezone string passed in as the only argument. By default this changes <Z> to the value of \cmd{bibutctimezone}.
 
 \csitem{bibdateuncertain}
 


### PR DESCRIPTION
Documentation of `mkbibtimezone` was referring to nonexistent command `￼bibutctimezone￼￼￼`, this commit accords with the definition of `mkbibtimezone` in https://github.com/pcdi/biblatex/blob/a29995037732e15e44dd893767631692fe59a4f6/tex/latex/biblatex/biblatex.sty#L6542 to refer to `bibutctimezone`